### PR TITLE
feat: implement database schema and seed data (Feature 2)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ This document breaks down the project requirements into discrete, implementable 
 | # | Feature | Priority | Dependencies | Status |
 |---|---------|----------|--------------|--------|
 | 1 | Project Foundation & Setup | P0 | None | ✅ Complete |
-| 2 | Database Schema & Seed Data | P0 | Feature 1 | |
+| 2 | Database Schema & Seed Data | P0 | Feature 1 | ✅ Complete |
 | 3 | ACP Core Endpoints (CRUD) | P0 | Feature 2 | |
 | 4 | API Security & Validation | P0 | Feature 3 | |
 | 5 | PSP - Delegated Payments | P1 | Feature 2 | |
@@ -87,23 +87,23 @@ This document breaks down the project requirements into discrete, implementable 
 
 ### Tasks
 
-- [ ] Define SQLModel models:
+- [x] Define SQLModel models:
   - `Product`: `id`, `sku`, `name`, `base_price`, `stock_count`, `min_margin`, `image_url`
   - `CompetitorPrice`: `id`, `product_id` (FK), `retailer_name`, `price`, `updated_at`
   - `CheckoutSession`: Full ACP state including status, line_items, totals, etc.
-- [ ] Create database initialization script
-- [ ] Seed 4 products (t-shirts as per PRD):
+- [x] Create database initialization script
+- [x] Seed 4 products (t-shirts as per PRD):
   ```python
   # Example seed data
   products = [
-      Product(id="prod_1", sku="TS-001", name="Classic Tee", base_price=2500, stock_count=100, min_margin=0.15),
-      Product(id="prod_2", sku="TS-002", name="V-Neck Tee", base_price=2800, stock_count=50, min_margin=0.12),
-      Product(id="prod_3", sku="TS-003", name="Graphic Tee", base_price=3200, stock_count=200, min_margin=0.18),
-      Product(id="prod_4", sku="TS-004", name="Premium Tee", base_price=4500, stock_count=25, min_margin=0.20),
+      Product(id="prod_1", sku="TS-001", name="Classic Tee", base_price=2500, stock_count=100, min_margin=0.15, image_url="https://placehold.co/400x400/png?text=Classic+Tee"),
+      Product(id="prod_2", sku="TS-002", name="V-Neck Tee", base_price=2800, stock_count=50, min_margin=0.12, image_url="https://placehold.co/400x400/png?text=V-Neck+Tee"),
+      Product(id="prod_3", sku="TS-003", name="Graphic Tee", base_price=3200, stock_count=200, min_margin=0.18, image_url="https://placehold.co/400x400/png?text=Graphic+Tee"),
+      Product(id="prod_4", sku="TS-004", name="Premium Tee", base_price=4500, stock_count=25, min_margin=0.20, image_url="https://placehold.co/400x400/png?text=Premium+Tee"),
   ]
   ```
-- [ ] Seed competitor prices for dynamic pricing logic
-- [ ] Create database utility functions (get_db session)
+- [x] Seed competitor prices for dynamic pricing logic
+- [x] Create database utility functions (get_db session)
 
 ### Acceptance Criteria
 

--- a/src/merchant/config.py
+++ b/src/merchant/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     app_version: str = "0.1.0"
     debug: bool = False
 
+    # Database
+    database_url: str = "sqlite:///./agentic_commerce.db"
+
     # NIM Configuration
     nim_endpoint: str = "https://integrate.api.nvidia.com/v1"
     nim_api_key: str = ""

--- a/src/merchant/db/__init__.py
+++ b/src/merchant/db/__init__.py
@@ -1,1 +1,29 @@
-# Database models and utilities
+"""Database models and utilities for the Agentic Commerce middleware."""
+
+from src.merchant.db.database import (
+    get_engine,
+    get_session,
+    init_and_seed_db,
+    init_db,
+    reset_engine,
+    seed_data,
+)
+from src.merchant.db.models import (
+    CheckoutSession,
+    CheckoutStatus,
+    CompetitorPrice,
+    Product,
+)
+
+__all__ = [
+    "CheckoutSession",
+    "CheckoutStatus",
+    "CompetitorPrice",
+    "Product",
+    "get_engine",
+    "get_session",
+    "init_and_seed_db",
+    "init_db",
+    "reset_engine",
+    "seed_data",
+]

--- a/src/merchant/db/database.py
+++ b/src/merchant/db/database.py
@@ -1,2 +1,176 @@
-# Database connection and session management
-# Will be implemented in Feature 2
+"""Database connection and session management for the Agentic Commerce middleware."""
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from src.merchant.config import get_settings
+from src.merchant.db.models import CompetitorPrice, Product
+
+# Create engine lazily to allow settings to be loaded
+_engine = None
+
+
+def get_engine():
+    """Get or create the database engine.
+
+    Returns:
+        Engine: SQLAlchemy engine instance.
+    """
+    global _engine
+    if _engine is None:
+        settings = get_settings()
+        _engine = create_engine(
+            settings.database_url,
+            echo=settings.debug,
+            connect_args={"check_same_thread": False},
+        )
+    return _engine
+
+
+def get_session() -> Generator[Session, None, None]:
+    """Get a database session.
+
+    Yields:
+        Session: A SQLModel session for database operations.
+    """
+    with Session(get_engine()) as session:
+        yield session
+
+
+def init_db() -> None:
+    """Initialize the database by creating all tables."""
+    SQLModel.metadata.create_all(get_engine())
+
+
+def seed_data(session: Session) -> None:
+    """Seed the database with initial product and competitor price data.
+
+    Args:
+        session: Database session for operations.
+    """
+    existing_product = session.exec(select(Product).limit(1)).first()
+    if existing_product is not None:
+        return
+
+    products = [
+        Product(
+            id="prod_1",
+            sku="TS-001",
+            name="Classic Tee",
+            base_price=2500,
+            stock_count=100,
+            min_margin=0.15,
+            image_url="https://placehold.co/400x400/png?text=Classic+Tee",
+        ),
+        Product(
+            id="prod_2",
+            sku="TS-002",
+            name="V-Neck Tee",
+            base_price=2800,
+            stock_count=50,
+            min_margin=0.12,
+            image_url="https://placehold.co/400x400/png?text=V-Neck+Tee",
+        ),
+        Product(
+            id="prod_3",
+            sku="TS-003",
+            name="Graphic Tee",
+            base_price=3200,
+            stock_count=200,
+            min_margin=0.18,
+            image_url="https://placehold.co/400x400/png?text=Graphic+Tee",
+        ),
+        Product(
+            id="prod_4",
+            sku="TS-004",
+            name="Premium Tee",
+            base_price=4500,
+            stock_count=25,
+            min_margin=0.20,
+            image_url="https://placehold.co/400x400/png?text=Premium+Tee",
+        ),
+    ]
+
+    for product in products:
+        session.add(product)
+
+    session.commit()
+
+    competitor_prices = [
+        CompetitorPrice(
+            product_id="prod_1",
+            retailer_name="FashionMart",
+            price=2400,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_1",
+            retailer_name="StyleHub",
+            price=2600,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_2",
+            retailer_name="FashionMart",
+            price=2700,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_2",
+            retailer_name="TrendyWear",
+            price=2900,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_3",
+            retailer_name="StyleHub",
+            price=3000,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_3",
+            retailer_name="FashionMart",
+            price=3100,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_3",
+            retailer_name="TrendyWear",
+            price=3300,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_4",
+            retailer_name="StyleHub",
+            price=4300,
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_4",
+            retailer_name="TrendyWear",
+            price=4600,
+            updated_at=datetime.now(UTC),
+        ),
+    ]
+
+    for competitor_price in competitor_prices:
+        session.add(competitor_price)
+
+    session.commit()
+
+
+def init_and_seed_db() -> None:
+    """Initialize the database and seed with initial data."""
+    init_db()
+    with Session(get_engine()) as session:
+        seed_data(session)
+
+
+def reset_engine() -> None:
+    """Reset the database engine. Useful for testing."""
+    global _engine
+    if _engine is not None:
+        _engine.dispose()
+        _engine = None

--- a/src/merchant/db/models.py
+++ b/src/merchant/db/models.py
@@ -1,2 +1,116 @@
-# SQLModel database models
-# Will be implemented in Feature 2
+"""SQLModel database models for the Agentic Commerce middleware."""
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import ClassVar
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+def _utc_now() -> datetime:
+    """Return current UTC datetime."""
+    return datetime.now(UTC)
+
+
+class CheckoutStatus(str, Enum):
+    """Checkout session status as per ACP specification."""
+
+    NOT_READY_FOR_PAYMENT = "not_ready_for_payment"
+    READY_FOR_PAYMENT = "ready_for_payment"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+
+
+class Product(SQLModel, table=True):
+    """Product model representing items available for purchase.
+
+    Attributes:
+        id: Unique product identifier (e.g., "prod_1")
+        sku: Stock keeping unit code
+        name: Product display name
+        base_price: Base price in cents (e.g., 2500 = $25.00)
+        stock_count: Current inventory quantity
+        min_margin: Minimum profit margin (e.g., 0.15 = 15%)
+        image_url: URL to product image
+    """
+
+    id: str = Field(primary_key=True)
+    sku: str = Field(unique=True, index=True)
+    name: str
+    base_price: int
+    stock_count: int
+    min_margin: float
+    image_url: str
+
+    competitor_prices: list["CompetitorPrice"] = Relationship(
+        back_populates="product",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+
+
+class CompetitorPrice(SQLModel, table=True):
+    """Competitor pricing data for dynamic pricing logic.
+
+    Attributes:
+        id: Auto-generated primary key
+        product_id: Foreign key to Product
+        retailer_name: Name of the competing retailer
+        price: Competitor's price in cents
+        updated_at: Timestamp of last price update
+    """
+
+    __tablename__: ClassVar[str] = "competitor_price"  # type: ignore[assignment]
+
+    id: int | None = Field(default=None, primary_key=True)
+    product_id: str = Field(foreign_key="product.id", index=True)
+    retailer_name: str
+    price: int
+    updated_at: datetime = Field(default_factory=_utc_now)
+
+    product: Product | None = Relationship(back_populates="competitor_prices")
+
+
+class CheckoutSession(SQLModel, table=True):
+    """Checkout session model representing the ACP checkout state.
+
+    Attributes:
+        id: Unique session identifier (e.g., "checkout_abc123")
+        status: Current checkout status
+        currency: ISO 4217 currency code (default: USD)
+        locale: BCP 47 language tag (default: en-US)
+        line_items_json: JSON string of line items array
+        buyer_json: JSON string of buyer information
+        fulfillment_address_json: JSON string of shipping address
+        fulfillment_options_json: JSON string of available shipping options
+        selected_fulfillment_option_id: ID of selected shipping option
+        totals_json: JSON string of price totals
+        order_json: JSON string of order details (after completion)
+        messages_json: JSON string of messages array
+        links_json: JSON string of HATEOAS links
+        metadata_json: JSON string of additional metadata
+        created_at: Session creation timestamp
+        updated_at: Last modification timestamp
+        expires_at: Session expiration timestamp
+    """
+
+    __tablename__: ClassVar[str] = "checkout_session"  # type: ignore[assignment]
+
+    id: str = Field(primary_key=True)
+    status: CheckoutStatus = Field(default=CheckoutStatus.NOT_READY_FOR_PAYMENT)
+    currency: str = Field(default="USD")
+    locale: str = Field(default="en-US")
+
+    line_items_json: str = Field(default="[]")
+    buyer_json: str | None = Field(default=None)
+    fulfillment_address_json: str | None = Field(default=None)
+    fulfillment_options_json: str = Field(default="[]")
+    selected_fulfillment_option_id: str | None = Field(default=None)
+    totals_json: str = Field(default="{}")
+    order_json: str | None = Field(default=None)
+    messages_json: str = Field(default="[]")
+    links_json: str = Field(default="[]")
+    metadata_json: str = Field(default="{}")
+
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+    expires_at: datetime | None = Field(default=None)

--- a/src/merchant/main.py
+++ b/src/merchant/main.py
@@ -1,17 +1,39 @@
 """FastAPI application entry point for the Agentic Commerce middleware."""
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.merchant.api.routes.health import router as health_router
 from src.merchant.config import get_settings
+from src.merchant.db import init_and_seed_db
 
 settings = get_settings()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
+    """Application lifespan context manager.
+
+    Initializes the database and seeds data on startup.
+
+    Args:
+        _app: FastAPI application instance (unused but required by protocol).
+
+    Yields:
+        None
+    """
+    init_and_seed_db()
+    yield
+
 
 app = FastAPI(
     title=settings.app_name,
     version=settings.app_version,
     description="Agentic Commerce Protocol Reference Architecture",
+    lifespan=lifespan,
 )
 
 # Configure CORS for development

--- a/tests/merchant/db/__init__.py
+++ b/tests/merchant/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database tests package."""

--- a/tests/merchant/db/test_database.py
+++ b/tests/merchant/db/test_database.py
@@ -1,0 +1,246 @@
+"""Tests for database initialization and session management."""
+
+import contextlib
+import os
+import tempfile
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlmodel import Session, select
+
+from src.merchant.db.database import (
+    get_engine,
+    get_session,
+    init_and_seed_db,
+    init_db,
+    reset_engine,
+    seed_data,
+)
+from src.merchant.db.models import CheckoutSession, CompetitorPrice, Product
+
+
+@pytest.fixture
+def temp_db_url() -> Generator[str, None, None]:
+    """Create a temporary database file for testing.
+
+    Yields:
+        str: SQLite connection URL for the temporary database.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        temp_path = f.name
+
+    db_url = f"sqlite:///{temp_path}"
+    yield db_url
+
+    if os.path.exists(temp_path):
+        os.unlink(temp_path)
+
+
+@pytest.fixture
+def reset_db_engine() -> Generator[None, None, None]:
+    """Reset the database engine before and after each test.
+
+    Yields:
+        None
+    """
+    reset_engine()
+    yield
+    reset_engine()
+
+
+@pytest.mark.usefixtures("reset_db_engine")
+class TestDatabaseInitialization:
+    """Test suite for database initialization."""
+
+    def test_init_db_creates_tables(self, temp_db_url: str) -> None:
+        """Happy path: init_db creates all required tables."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                products = session.exec(select(Product)).all()
+                assert products == []
+
+                competitor_prices = session.exec(select(CompetitorPrice)).all()
+                assert competitor_prices == []
+
+                checkout_sessions = session.exec(select(CheckoutSession)).all()
+                assert checkout_sessions == []
+
+    def test_init_db_is_idempotent(self, temp_db_url: str) -> None:
+        """Edge case: Calling init_db multiple times does not raise errors."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+            init_db()
+            init_db()
+
+
+@pytest.mark.usefixtures("reset_db_engine")
+class TestSeedData:
+    """Test suite for database seeding."""
+
+    def test_seed_data_creates_products(self, temp_db_url: str) -> None:
+        """Happy path: seed_data creates 4 products."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                seed_data(session)
+
+                products = session.exec(select(Product)).all()
+                assert len(products) == 4
+
+    def test_seed_data_creates_competitor_prices(self, temp_db_url: str) -> None:
+        """Happy path: seed_data creates competitor prices for products."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                seed_data(session)
+
+                competitor_prices = session.exec(select(CompetitorPrice)).all()
+                assert len(competitor_prices) > 0
+
+    def test_seed_data_is_idempotent(self, temp_db_url: str) -> None:
+        """Edge case: Calling seed_data multiple times does not duplicate data."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                seed_data(session)
+                seed_data(session)
+                seed_data(session)
+
+                products = session.exec(select(Product)).all()
+                assert len(products) == 4
+
+    def test_seed_data_product_fields(self, temp_db_url: str) -> None:
+        """Happy path: Seeded products have correct field values."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                seed_data(session)
+
+                classic_tee = session.exec(
+                    select(Product).where(Product.id == "prod_1")
+                ).first()
+
+                assert classic_tee is not None
+                assert classic_tee.sku == "TS-001"
+                assert classic_tee.name == "Classic Tee"
+                assert classic_tee.base_price == 2500
+                assert classic_tee.stock_count == 100
+                assert classic_tee.min_margin == 0.15
+                assert "placehold.co" in classic_tee.image_url
+
+    def test_seed_data_image_urls_are_placeholders(self, temp_db_url: str) -> None:
+        """Happy path: All products have placeholder image URLs."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                seed_data(session)
+
+                products = session.exec(select(Product)).all()
+
+                for product in products:
+                    assert "https://placehold.co/400x400/png" in product.image_url
+
+
+@pytest.mark.usefixtures("reset_db_engine")
+class TestGetSession:
+    """Test suite for get_session dependency."""
+
+    def test_get_session_yields_session(self, temp_db_url: str) -> None:
+        """Happy path: get_session yields a valid Session object."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_db()
+
+            session_gen = get_session()
+            session = next(session_gen)
+
+            assert isinstance(session, Session)
+
+            with contextlib.suppress(StopIteration):
+                next(session_gen)
+
+
+@pytest.mark.usefixtures("reset_db_engine")
+class TestInitAndSeedDb:
+    """Test suite for init_and_seed_db convenience function."""
+
+    def test_init_and_seed_db_initializes_and_seeds(self, temp_db_url: str) -> None:
+        """Happy path: init_and_seed_db creates tables and seeds data."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_and_seed_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                products = session.exec(select(Product)).all()
+                assert len(products) == 4
+
+                competitor_prices = session.exec(select(CompetitorPrice)).all()
+                assert len(competitor_prices) > 0
+
+
+@pytest.mark.usefixtures("reset_db_engine")
+class TestCompetitorPriceRelationship:
+    """Test suite for Product-CompetitorPrice relationship."""
+
+    def test_competitor_prices_linked_to_products(self, temp_db_url: str) -> None:
+        """Happy path: Competitor prices are correctly linked to products."""
+        with patch("src.merchant.db.database.get_settings") as mock_settings:
+            mock_settings.return_value.database_url = temp_db_url
+            mock_settings.return_value.debug = False
+
+            init_and_seed_db()
+
+            engine = get_engine()
+            with Session(engine) as session:
+                competitor_prices = session.exec(
+                    select(CompetitorPrice).where(
+                        CompetitorPrice.product_id == "prod_1"
+                    )
+                ).all()
+
+                assert len(competitor_prices) >= 2
+
+                for cp in competitor_prices:
+                    assert cp.product_id == "prod_1"
+                    assert cp.price > 0
+                    assert cp.retailer_name != ""

--- a/tests/merchant/db/test_models.py
+++ b/tests/merchant/db/test_models.py
@@ -1,0 +1,169 @@
+"""Tests for SQLModel database models."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.merchant.db.models import (
+    CheckoutSession,
+    CheckoutStatus,
+    CompetitorPrice,
+    Product,
+)
+
+
+class TestProductModel:
+    """Test suite for the Product model."""
+
+    def test_product_creation_with_all_fields(self) -> None:
+        """Happy path: Product can be created with all required fields."""
+        product = Product(
+            id="prod_test",
+            sku="TEST-001",
+            name="Test Product",
+            base_price=1000,
+            stock_count=50,
+            min_margin=0.10,
+            image_url="https://example.com/image.png",
+        )
+
+        assert product.id == "prod_test"
+        assert product.sku == "TEST-001"
+        assert product.name == "Test Product"
+        assert product.base_price == 1000
+        assert product.stock_count == 50
+        assert product.min_margin == 0.10
+        assert product.image_url == "https://example.com/image.png"
+
+    def test_product_price_in_cents(self) -> None:
+        """Edge case: Product price is stored in cents."""
+        product = Product(
+            id="prod_cents",
+            sku="CENTS-001",
+            name="Cents Test",
+            base_price=2500,
+            stock_count=10,
+            min_margin=0.15,
+            image_url="https://example.com/image.png",
+        )
+
+        assert product.base_price == 2500
+        assert product.base_price / 100 == 25.00
+
+    def test_product_min_margin_as_decimal(self) -> None:
+        """Edge case: Minimum margin is stored as decimal (0.15 = 15%)."""
+        product = Product(
+            id="prod_margin",
+            sku="MARGIN-001",
+            name="Margin Test",
+            base_price=1000,
+            stock_count=10,
+            min_margin=0.15,
+            image_url="https://example.com/image.png",
+        )
+
+        assert product.min_margin == 0.15
+        assert product.min_margin * 100 == 15.0
+
+
+class TestCompetitorPriceModel:
+    """Test suite for the CompetitorPrice model."""
+
+    def test_competitor_price_creation(self) -> None:
+        """Happy path: CompetitorPrice can be created with required fields."""
+        now = datetime.now(UTC)
+        competitor_price = CompetitorPrice(
+            product_id="prod_1",
+            retailer_name="TestRetailer",
+            price=2400,
+            updated_at=now,
+        )
+
+        assert competitor_price.id is None
+        assert competitor_price.product_id == "prod_1"
+        assert competitor_price.retailer_name == "TestRetailer"
+        assert competitor_price.price == 2400
+        assert competitor_price.updated_at == now
+
+    def test_competitor_price_default_updated_at(self) -> None:
+        """Edge case: CompetitorPrice gets default updated_at if not provided."""
+        competitor_price = CompetitorPrice(
+            product_id="prod_1",
+            retailer_name="TestRetailer",
+            price=2400,
+        )
+
+        assert competitor_price.updated_at is not None
+        assert isinstance(competitor_price.updated_at, datetime)
+
+
+class TestCheckoutSessionModel:
+    """Test suite for the CheckoutSession model."""
+
+    def test_checkout_session_creation_with_defaults(self) -> None:
+        """Happy path: CheckoutSession has sensible defaults."""
+        session = CheckoutSession(id="checkout_test")
+
+        assert session.id == "checkout_test"
+        assert session.status == CheckoutStatus.NOT_READY_FOR_PAYMENT
+        assert session.currency == "USD"
+        assert session.locale == "en-US"
+        assert session.line_items_json == "[]"
+        assert session.buyer_json is None
+        assert session.fulfillment_address_json is None
+        assert session.fulfillment_options_json == "[]"
+        assert session.selected_fulfillment_option_id is None
+        assert session.totals_json == "{}"
+        assert session.order_json is None
+        assert session.messages_json == "[]"
+        assert session.links_json == "[]"
+        assert session.metadata_json == "{}"
+
+    def test_checkout_session_status_transitions(self) -> None:
+        """Edge case: CheckoutSession status can be set to any valid status."""
+        session = CheckoutSession(id="checkout_status")
+
+        assert session.status == CheckoutStatus.NOT_READY_FOR_PAYMENT
+
+        session.status = CheckoutStatus.READY_FOR_PAYMENT
+        assert session.status == CheckoutStatus.READY_FOR_PAYMENT
+
+        session.status = CheckoutStatus.COMPLETED
+        assert session.status == CheckoutStatus.COMPLETED
+
+        session.status = CheckoutStatus.CANCELED
+        assert session.status == CheckoutStatus.CANCELED
+
+    def test_checkout_session_timestamps(self) -> None:
+        """Edge case: CheckoutSession has created_at and updated_at timestamps."""
+        session = CheckoutSession(id="checkout_timestamps")
+
+        assert session.created_at is not None
+        assert session.updated_at is not None
+        assert isinstance(session.created_at, datetime)
+        assert isinstance(session.updated_at, datetime)
+
+
+class TestCheckoutStatusEnum:
+    """Test suite for the CheckoutStatus enum."""
+
+    def test_checkout_status_values(self) -> None:
+        """Happy path: CheckoutStatus has correct string values."""
+        assert CheckoutStatus.NOT_READY_FOR_PAYMENT.value == "not_ready_for_payment"
+        assert CheckoutStatus.READY_FOR_PAYMENT.value == "ready_for_payment"
+        assert CheckoutStatus.COMPLETED.value == "completed"
+        assert CheckoutStatus.CANCELED.value == "canceled"
+
+    def test_checkout_status_is_string_enum(self) -> None:
+        """Edge case: CheckoutStatus values are strings."""
+        for status in CheckoutStatus:
+            assert isinstance(status.value, str)
+
+    @pytest.mark.parametrize(
+        "status_value",
+        ["not_ready_for_payment", "ready_for_payment", "completed", "canceled"],
+    )
+    def test_checkout_status_from_string(self, status_value: str) -> None:
+        """Edge case: CheckoutStatus can be created from string value."""
+        status = CheckoutStatus(status_value)
+        assert status.value == status_value


### PR DESCRIPTION
## Summary

- Implement SQLModel models for `Product`, `CompetitorPrice`, and `CheckoutSession`
- Add database initialization and seeding with 4 t-shirt products and competitor pricing data
- Configure database URL setting and lifespan context manager for startup initialization
- Include placeholder image URLs for all products using placehold.co

## Changes

### Models (`src/merchant/db/models.py`)
- `Product`: id, sku, name, base_price, stock_count, min_margin, image_url
- `CompetitorPrice`: id, product_id (FK), retailer_name, price, updated_at
- `CheckoutSession`: Full ACP state with status enum and JSON fields
- `CheckoutStatus`: Enum (not_ready_for_payment, ready_for_payment, completed, canceled)

### Database Layer (`src/merchant/db/database.py`)
- `get_engine()`: Lazy-loaded SQLite engine
- `get_session()`: FastAPI dependency for database sessions
- `init_db()`: Creates all tables
- `seed_data()`: Populates 4 products and 9 competitor prices
- `init_and_seed_db()`: Convenience function for startup

### Configuration
- Added `database_url` setting to `config.py`
- Added lifespan context manager to `main.py`

### Tests
- 24 new unit tests for models and database layer
- All 33 tests pass (9 existing + 24 new)

## Test plan

- [x] All unit tests pass (`uv run pytest tests/ -v`)
- [x] Ruff linting passes (`uv run ruff check src/ tests/`)
- [x] Ruff formatting passes (`uv run ruff format --check src/ tests/`)
- [x] Pyright type checking passes (`uv run pyright src/`)
- [x] Database initializes and seeds on application startup