### PR TITLE
feat: implement ACP core checkout endpoints (Feature 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ Once the server is running, visit:
 - **Swagger UI**: http://localhost:8000/docs
 - **ReDoc**: http://localhost:8000/redoc
 
+### ACP Checkout Endpoints
+
+The following ACP-compliant checkout session endpoints are available:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/checkout_sessions` | POST | Create a new checkout session |
+| `/checkout_sessions/{id}` | GET | Get checkout session by ID |
+| `/checkout_sessions/{id}` | POST | Update checkout session |
+| `/checkout_sessions/{id}/complete` | POST | Complete checkout with payment |
+| `/checkout_sessions/{id}/cancel` | POST | Cancel checkout session |
+
+Example: Create a checkout session
+```bash
+curl -X POST http://localhost:8000/checkout_sessions \
+  -H "Content-Type: application/json" \
+  -d '{"items": [{"id": "prod_1", "quantity": 1}]}'
+```
+
 ### Running Tests
 
 ```bash

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,7 @@ This document breaks down the project requirements into discrete, implementable 
 |---|---------|----------|--------------|--------|
 | 1 | Project Foundation & Setup | P0 | None | ✅ Complete |
 | 2 | Database Schema & Seed Data | P0 | Feature 1 | ✅ Complete |
-| 3 | ACP Core Endpoints (CRUD) | P0 | Feature 2 | |
+| 3 | ACP Core Endpoints (CRUD) | P0 | Feature 2 | ✅ Complete |
 | 4 | API Security & Validation | P0 | Feature 3 | |
 | 5 | PSP - Delegated Payments | P1 | Feature 2 | |
 | 6 | Promotion Agent (NAT) | P1 | Features 3, 4 | |
@@ -152,25 +152,25 @@ This document breaks down the project requirements into discrete, implementable 
 
 ### Tasks
 
-- [ ] Create Pydantic schemas for all request/response models
-- [ ] Implement checkout session service layer
-- [ ] Implement all 5 endpoints
-- [ ] Handle session state transitions:
+- [x] Create Pydantic schemas for all request/response models
+- [x] Implement checkout session service layer
+- [x] Implement all 5 endpoints
+- [x] Handle session state transitions:
   ```
   not_ready_for_payment → ready_for_payment → completed
                        ↘                   ↘
                          →    canceled    ←
   ```
-- [ ] Calculate line_items totals (base_amount, discount, tax, total)
-- [ ] Generate fulfillment_options based on address
-- [ ] Include required `messages[]` and `links[]` in responses
+- [x] Calculate line_items totals (base_amount, discount, tax, total)
+- [x] Generate fulfillment_options based on address
+- [x] Include required `messages[]` and `links[]` in responses
 
 ### Acceptance Criteria
 
-- All 5 endpoints return ACP-compliant JSON
-- State transitions work correctly
-- 404 for non-existent sessions
-- 405 for invalid state transitions
+- [x] All 5 endpoints return ACP-compliant JSON
+- [x] State transitions work correctly
+- [x] 404 for non-existent sessions
+- [x] 405 for invalid state transitions
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ select = [
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)
+    "B008",   # function call in default argument (standard FastAPI pattern with Depends)
 ]
 
 [tool.ruff.lint.isort]

--- a/src/merchant/api/routes/checkout.py
+++ b/src/merchant/api/routes/checkout.py
@@ -1,0 +1,260 @@
+"""Checkout session API routes implementing the Agentic Checkout Protocol."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session
+
+from src.merchant.api.schemas import (
+    CheckoutSessionResponse,
+    CompleteCheckoutRequest,
+    CreateCheckoutRequest,
+    ErrorResponse,
+    ErrorResponseCodeEnum,
+    ErrorTypeEnum,
+    UpdateCheckoutRequest,
+)
+from src.merchant.db.database import get_session
+from src.merchant.services.checkout import (
+    InvalidStateTransitionError,
+    ProductNotFoundError,
+    SessionNotFoundError,
+    cancel_checkout_session,
+    complete_checkout_session,
+    create_checkout_session,
+    get_checkout_session,
+    update_checkout_session,
+)
+
+router = APIRouter(prefix="/checkout_sessions", tags=["checkout"])
+
+
+def _handle_service_error(error: Exception) -> HTTPException:
+    """Convert service layer errors to HTTP exceptions.
+
+    Args:
+        error: Service layer exception.
+
+    Returns:
+        HTTPException with appropriate status code and error response.
+    """
+    if isinstance(error, SessionNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ErrorResponse(
+                type=ErrorTypeEnum.NOT_FOUND,
+                code=ErrorResponseCodeEnum.SESSION_NOT_FOUND,
+                message=error.message,
+            ).model_dump(),
+        )
+
+    if isinstance(error, ProductNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorResponse(
+                type=ErrorTypeEnum.INVALID_REQUEST,
+                code=ErrorResponseCodeEnum.PRODUCT_NOT_FOUND,
+                message=error.message,
+            ).model_dump(),
+        )
+
+    if isinstance(error, InvalidStateTransitionError):
+        return HTTPException(
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
+            detail=ErrorResponse(
+                type=ErrorTypeEnum.METHOD_NOT_ALLOWED,
+                code=ErrorResponseCodeEnum.INVALID_STATUS_TRANSITION,
+                message=error.message,
+            ).model_dump(),
+        )
+
+    # Generic internal error
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ErrorResponse(
+            type=ErrorTypeEnum.INTERNAL_ERROR,
+            code=ErrorResponseCodeEnum.VALIDATION_ERROR,
+            message=str(error),
+        ).model_dump(),
+    )
+
+
+@router.post(
+    "",
+    response_model=CheckoutSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create Checkout Session",
+    description="Create a new checkout session with items and optional buyer/address.",
+    responses={
+        201: {"description": "Checkout session created"},
+        400: {"description": "Invalid request (e.g., product not found)"},
+    },
+)
+def create_checkout(
+    request: CreateCheckoutRequest,
+    db: Session = Depends(get_session),
+) -> CheckoutSessionResponse:
+    """Create a new checkout session.
+
+    Args:
+        request: CreateCheckoutRequest with items and optional buyer/address.
+        db: Database session from dependency injection.
+
+    Returns:
+        CheckoutSessionResponse with the new session.
+
+    Raises:
+        HTTPException: 400 if product not found.
+    """
+    try:
+        return create_checkout_session(db, request)
+    except (
+        ProductNotFoundError,
+        SessionNotFoundError,
+        InvalidStateTransitionError,
+    ) as e:
+        raise _handle_service_error(e) from e
+
+
+@router.get(
+    "/{session_id}",
+    response_model=CheckoutSessionResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get Checkout Session",
+    description="Retrieve a checkout session by ID.",
+    responses={
+        200: {"description": "Checkout session found"},
+        404: {"description": "Checkout session not found"},
+    },
+)
+def get_checkout(
+    session_id: str,
+    db: Session = Depends(get_session),
+) -> CheckoutSessionResponse:
+    """Get a checkout session by ID.
+
+    Args:
+        session_id: Checkout session ID.
+        db: Database session from dependency injection.
+
+    Returns:
+        CheckoutSessionResponse with the session.
+
+    Raises:
+        HTTPException: 404 if session not found.
+    """
+    try:
+        return get_checkout_session(db, session_id)
+    except SessionNotFoundError as e:
+        raise _handle_service_error(e) from e
+
+
+@router.post(
+    "/{session_id}",
+    response_model=CheckoutSessionResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update Checkout Session",
+    description="Update a checkout session with new items, buyer info, or address.",
+    responses={
+        200: {"description": "Checkout session updated"},
+        400: {"description": "Invalid request"},
+        404: {"description": "Checkout session not found"},
+        405: {"description": "Cannot update session in current state"},
+    },
+)
+def update_checkout(
+    session_id: str,
+    request: UpdateCheckoutRequest,
+    db: Session = Depends(get_session),
+) -> CheckoutSessionResponse:
+    """Update a checkout session.
+
+    Args:
+        session_id: Checkout session ID.
+        request: UpdateCheckoutRequest with fields to update.
+        db: Database session from dependency injection.
+
+    Returns:
+        CheckoutSessionResponse with the updated session.
+
+    Raises:
+        HTTPException: 404 if session not found, 405 if invalid state.
+    """
+    try:
+        return update_checkout_session(db, session_id, request)
+    except (
+        ProductNotFoundError,
+        SessionNotFoundError,
+        InvalidStateTransitionError,
+    ) as e:
+        raise _handle_service_error(e) from e
+
+
+@router.post(
+    "/{session_id}/complete",
+    response_model=CheckoutSessionResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Complete Checkout",
+    description="Complete a checkout session with payment data.",
+    responses={
+        200: {"description": "Checkout completed, order created"},
+        404: {"description": "Checkout session not found"},
+        405: {"description": "Cannot complete session in current state"},
+    },
+)
+def complete_checkout(
+    session_id: str,
+    request: CompleteCheckoutRequest,
+    db: Session = Depends(get_session),
+) -> CheckoutSessionResponse:
+    """Complete a checkout session with payment.
+
+    Args:
+        session_id: Checkout session ID.
+        request: CompleteCheckoutRequest with payment data.
+        db: Database session from dependency injection.
+
+    Returns:
+        CheckoutSessionResponse with the completed session and order.
+
+    Raises:
+        HTTPException: 404 if session not found, 405 if invalid state.
+    """
+    try:
+        return complete_checkout_session(
+            db, session_id, request.payment_data, request.buyer
+        )
+    except (SessionNotFoundError, InvalidStateTransitionError) as e:
+        raise _handle_service_error(e) from e
+
+
+@router.post(
+    "/{session_id}/cancel",
+    response_model=CheckoutSessionResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Cancel Checkout",
+    description="Cancel a checkout session.",
+    responses={
+        200: {"description": "Checkout session canceled"},
+        404: {"description": "Checkout session not found"},
+        405: {"description": "Cannot cancel session in current state"},
+    },
+)
+def cancel_checkout(
+    session_id: str,
+    db: Session = Depends(get_session),
+) -> CheckoutSessionResponse:
+    """Cancel a checkout session.
+
+    Args:
+        session_id: Checkout session ID.
+        db: Database session from dependency injection.
+
+    Returns:
+        CheckoutSessionResponse with the canceled session.
+
+    Raises:
+        HTTPException: 404 if session not found, 405 if invalid state.
+    """
+    try:
+        return cancel_checkout_session(db, session_id)
+    except (SessionNotFoundError, InvalidStateTransitionError) as e:
+        raise _handle_service_error(e) from e

--- a/src/merchant/api/schemas.py
+++ b/src/merchant/api/schemas.py
@@ -1,0 +1,380 @@
+"""Pydantic schemas for ACP checkout session endpoints.
+
+Based on the Agentic Checkout Protocol specification (docs/acp-spec.md).
+"""
+
+from enum import Enum
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# =============================================================================
+# Enums
+# =============================================================================
+
+
+class CheckoutStatusEnum(str, Enum):
+    """Checkout session status values."""
+
+    NOT_READY_FOR_PAYMENT = "not_ready_for_payment"
+    READY_FOR_PAYMENT = "ready_for_payment"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+
+
+class PaymentProviderEnum(str, Enum):
+    """Supported payment providers."""
+
+    STRIPE = "stripe"
+    ADYEN = "adyen"
+
+
+class PaymentMethodEnum(str, Enum):
+    """Supported payment methods."""
+
+    CARD = "card"
+
+
+class FulfillmentTypeEnum(str, Enum):
+    """Fulfillment option types."""
+
+    SHIPPING = "shipping"
+    DIGITAL = "digital"
+
+
+class TotalTypeEnum(str, Enum):
+    """Total line item types."""
+
+    ITEMS_BASE_AMOUNT = "items_base_amount"
+    ITEMS_DISCOUNT = "items_discount"
+    SUBTOTAL = "subtotal"
+    DISCOUNT = "discount"
+    FULFILLMENT = "fulfillment"
+    TAX = "tax"
+    FEE = "fee"
+    TOTAL = "total"
+
+
+class MessageTypeEnum(str, Enum):
+    """Message types."""
+
+    INFO = "info"
+    ERROR = "error"
+
+
+class ContentTypeEnum(str, Enum):
+    """Content format types."""
+
+    PLAIN = "plain"
+    MARKDOWN = "markdown"
+
+
+class ErrorCodeEnum(str, Enum):
+    """Error codes for error messages."""
+
+    MISSING = "missing"
+    INVALID = "invalid"
+    OUT_OF_STOCK = "out_of_stock"
+    PAYMENT_DECLINED = "payment_declined"
+    REQUIRES_SIGN_IN = "requires_sign_in"
+    REQUIRES_3DS = "requires_3ds"
+
+
+class LinkTypeEnum(str, Enum):
+    """Link types for HATEOAS links."""
+
+    TERMS_OF_USE = "terms_of_use"
+    PRIVACY_POLICY = "privacy_policy"
+    SELLER_SHOP_POLICIES = "seller_shop_policies"
+
+
+# =============================================================================
+# Input Models (Request Schemas)
+# =============================================================================
+
+
+class ItemInput(BaseModel):
+    """Item input for checkout requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., description="Product ID")
+    quantity: Annotated[int, Field(gt=0, description="Quantity to purchase")]
+
+
+class BuyerInput(BaseModel):
+    """Buyer information input."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    first_name: Annotated[str, Field(max_length=256, description="First name")]
+    email: Annotated[str, Field(max_length=256, description="Email address")]
+    phone_number: Annotated[
+        str | None, Field(default=None, description="Phone number in E.164 format")
+    ] = None
+
+
+class AddressInput(BaseModel):
+    """Address input for fulfillment or billing."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str, Field(max_length=256, description="Recipient name")]
+    line_one: Annotated[str, Field(max_length=60, description="Address line 1")]
+    line_two: Annotated[
+        str | None, Field(default=None, max_length=60, description="Address line 2")
+    ] = None
+    city: Annotated[str, Field(max_length=60, description="City/district/suburb")]
+    state: Annotated[str, Field(description="State/province/region (ISO 3166-1)")]
+    country: Annotated[str, Field(description="Country code (ISO 3166-1)")]
+    postal_code: Annotated[str, Field(max_length=20, description="Postal/ZIP code")]
+    phone_number: Annotated[
+        str | None, Field(default=None, description="Phone number in E.164 format")
+    ] = None
+
+
+class PaymentDataInput(BaseModel):
+    """Payment data input for completing checkout."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    token: str = Field(..., description="Payment method token (e.g., spt_123)")
+    provider: PaymentProviderEnum = Field(..., description="Payment processor")
+    billing_address: AddressInput | None = Field(
+        default=None, description="Billing address"
+    )
+
+
+class CreateCheckoutRequest(BaseModel):
+    """Request body for creating a checkout session."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: Annotated[
+        list[ItemInput], Field(min_length=1, description="Items to purchase")
+    ]
+    buyer: BuyerInput | None = Field(default=None, description="Buyer information")
+    fulfillment_address: AddressInput | None = Field(
+        default=None, description="Shipping address"
+    )
+
+
+class UpdateCheckoutRequest(BaseModel):
+    """Request body for updating a checkout session."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ItemInput] | None = Field(default=None, description="Updated items")
+    buyer: BuyerInput | None = Field(default=None, description="Buyer information")
+    fulfillment_address: AddressInput | None = Field(
+        default=None, description="Shipping address"
+    )
+    fulfillment_option_id: str | None = Field(
+        default=None, description="Selected fulfillment option ID"
+    )
+
+
+class CompleteCheckoutRequest(BaseModel):
+    """Request body for completing a checkout session."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    buyer: BuyerInput | None = Field(default=None, description="Buyer information")
+    payment_data: PaymentDataInput = Field(..., description="Payment data")
+
+
+# =============================================================================
+# Output Models (Response Schemas)
+# =============================================================================
+
+
+class Item(BaseModel):
+    """Item reference in line items."""
+
+    id: str = Field(..., description="Product ID")
+    quantity: Annotated[int, Field(gt=0, description="Quantity")]
+
+
+class Buyer(BaseModel):
+    """Buyer information in response."""
+
+    first_name: str = Field(..., description="First name")
+    email: str = Field(..., description="Email address")
+    phone_number: str | None = Field(default=None, description="Phone number")
+
+
+class Address(BaseModel):
+    """Address in response."""
+
+    name: str = Field(..., description="Recipient name")
+    line_one: str = Field(..., description="Address line 1")
+    line_two: str | None = Field(default=None, description="Address line 2")
+    city: str = Field(..., description="City")
+    state: str = Field(..., description="State/province")
+    country: str = Field(..., description="Country code")
+    postal_code: str = Field(..., description="Postal code")
+    phone_number: str | None = Field(default=None, description="Phone number")
+
+
+class PaymentProvider(BaseModel):
+    """Payment provider configuration."""
+
+    provider: PaymentProviderEnum = Field(..., description="Payment processor")
+    supported_payment_methods: list[PaymentMethodEnum] = Field(
+        ..., description="Accepted payment methods"
+    )
+
+
+class LineItem(BaseModel):
+    """Line item in checkout session."""
+
+    id: str = Field(..., description="Line item ID")
+    item: Item = Field(..., description="Item reference")
+    base_amount: Annotated[
+        int, Field(ge=0, description="Base price before adjustments")
+    ]
+    discount: Annotated[int, Field(ge=0, description="Discount amount")]
+    subtotal: Annotated[int, Field(ge=0, description="Amount after adjustments")]
+    tax: Annotated[int, Field(ge=0, description="Tax amount")]
+    total: Annotated[int, Field(ge=0, description="Final amount")]
+
+
+class FulfillmentOptionBase(BaseModel):
+    """Base fulfillment option fields."""
+
+    type: FulfillmentTypeEnum = Field(..., description="Fulfillment type")
+    id: str = Field(..., description="Unique option ID")
+    title: str = Field(..., description="Display title")
+    subtitle: str = Field(..., description="Delivery estimate or description")
+    subtotal: Annotated[int, Field(ge=0, description="Cost before tax")]
+    tax: Annotated[int, Field(ge=0, description="Tax amount")]
+    total: Annotated[int, Field(ge=0, description="Total cost")]
+
+
+class ShippingFulfillmentOption(FulfillmentOptionBase):
+    """Shipping fulfillment option."""
+
+    type: FulfillmentTypeEnum = FulfillmentTypeEnum.SHIPPING
+    carrier_info: str = Field(..., description="Carrier name")
+    earliest_delivery_time: str = Field(..., description="Earliest delivery (RFC 3339)")
+    latest_delivery_time: str = Field(..., description="Latest delivery (RFC 3339)")
+
+
+class DigitalFulfillmentOption(FulfillmentOptionBase):
+    """Digital fulfillment option."""
+
+    type: FulfillmentTypeEnum = FulfillmentTypeEnum.DIGITAL
+
+
+# Union type for fulfillment options
+FulfillmentOption = ShippingFulfillmentOption | DigitalFulfillmentOption
+
+
+class Total(BaseModel):
+    """Total line in checkout summary."""
+
+    type: TotalTypeEnum = Field(..., description="Total category")
+    display_text: str = Field(..., description="Customer-facing label")
+    amount: Annotated[int, Field(ge=0, description="Amount in minor units")]
+
+
+class MessageInfo(BaseModel):
+    """Info message."""
+
+    type: MessageTypeEnum = MessageTypeEnum.INFO
+    param: str = Field(..., description="JSONPath to related component (RFC 9535)")
+    content_type: ContentTypeEnum = Field(..., description="Content format")
+    content: str = Field(..., description="Message content")
+
+
+class MessageError(BaseModel):
+    """Error message."""
+
+    type: MessageTypeEnum = MessageTypeEnum.ERROR
+    code: ErrorCodeEnum = Field(..., description="Error code")
+    param: str | None = Field(default=None, description="JSONPath to related component")
+    content_type: ContentTypeEnum = Field(..., description="Content format")
+    content: str = Field(..., description="Message content")
+
+
+# Union type for messages
+Message = MessageInfo | MessageError
+
+
+class Link(BaseModel):
+    """HATEOAS link."""
+
+    type: LinkTypeEnum = Field(..., description="Link category")
+    url: str = Field(..., description="Link URL")
+
+
+class Order(BaseModel):
+    """Order created after checkout completion."""
+
+    id: str = Field(..., description="Order ID")
+    checkout_session_id: str = Field(..., description="Associated checkout session")
+    permalink_url: str = Field(..., description="Customer-accessible order URL")
+
+
+class CheckoutSessionResponse(BaseModel):
+    """Full checkout session response (ACP-compliant)."""
+
+    id: str = Field(..., description="Checkout session ID")
+    buyer: Buyer | None = Field(default=None, description="Buyer information")
+    payment_provider: PaymentProvider = Field(
+        ..., description="Payment provider config"
+    )
+    status: CheckoutStatusEnum = Field(..., description="Session status")
+    currency: str = Field(..., description="ISO 4217 currency code (lowercase)")
+    line_items: list[LineItem] = Field(..., description="Items in checkout")
+    fulfillment_address: Address | None = Field(
+        default=None, description="Shipping address"
+    )
+    fulfillment_options: list[ShippingFulfillmentOption | DigitalFulfillmentOption] = (
+        Field(..., description="Available fulfillment options")
+    )
+    fulfillment_option_id: str | None = Field(
+        default=None, description="Selected fulfillment option"
+    )
+    totals: list[Total] = Field(..., description="Price totals")
+    messages: list[MessageInfo | MessageError] = Field(
+        ..., description="Info and error messages"
+    )
+    links: list[Link] = Field(..., description="HATEOAS links")
+    order: Order | None = Field(
+        default=None, description="Order (present after completion)"
+    )
+
+
+# =============================================================================
+# Error Response Schema
+# =============================================================================
+
+
+class ErrorTypeEnum(str, Enum):
+    """Error response types."""
+
+    INVALID_REQUEST = "invalid_request"
+    NOT_FOUND = "not_found"
+    METHOD_NOT_ALLOWED = "method_not_allowed"
+    INTERNAL_ERROR = "internal_error"
+
+
+class ErrorResponseCodeEnum(str, Enum):
+    """Error response codes."""
+
+    REQUEST_NOT_IDEMPOTENT = "request_not_idempotent"
+    INVALID_STATUS_TRANSITION = "invalid_status_transition"
+    SESSION_NOT_FOUND = "session_not_found"
+    PRODUCT_NOT_FOUND = "product_not_found"
+    INVALID_PAYMENT = "invalid_payment"
+    VALIDATION_ERROR = "validation_error"
+
+
+class ErrorResponse(BaseModel):
+    """Error response schema."""
+
+    type: ErrorTypeEnum = Field(..., description="Error type")
+    code: ErrorResponseCodeEnum = Field(..., description="Error code")
+    message: str = Field(..., description="Human-readable message")
+    param: str | None = Field(default=None, description="JSONPath to offending field")

--- a/src/merchant/main.py
+++ b/src/merchant/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from src.merchant.api.routes.checkout import router as checkout_router
 from src.merchant.api.routes.health import router as health_router
 from src.merchant.config import get_settings
 from src.merchant.db import init_and_seed_db
@@ -47,3 +48,4 @@ app.add_middleware(
 
 # Include routers
 app.include_router(health_router)
+app.include_router(checkout_router)

--- a/src/merchant/services/checkout.py
+++ b/src/merchant/services/checkout.py
@@ -1,0 +1,813 @@
+"""Checkout session service layer for ACP endpoints.
+
+Handles business logic for creating, updating, completing, and canceling
+checkout sessions according to the Agentic Checkout Protocol specification.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlmodel import Session, select
+
+from src.merchant.api.schemas import (
+    Address,
+    AddressInput,
+    Buyer,
+    BuyerInput,
+    CheckoutSessionResponse,
+    CheckoutStatusEnum,
+    ContentTypeEnum,
+    CreateCheckoutRequest,
+    Item,
+    LineItem,
+    Link,
+    LinkTypeEnum,
+    MessageInfo,
+    Order,
+    PaymentDataInput,
+    PaymentMethodEnum,
+    PaymentProvider,
+    PaymentProviderEnum,
+    ShippingFulfillmentOption,
+    Total,
+    TotalTypeEnum,
+    UpdateCheckoutRequest,
+)
+from src.merchant.db.models import CheckoutSession, CheckoutStatus, Product
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+TAX_RATE = 0.10  # 10% tax rate
+DEFAULT_CURRENCY = "usd"
+DEFAULT_SHOP_URL = "https://shop.example.com"
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def _generate_session_id() -> str:
+    """Generate a unique checkout session ID."""
+    return f"checkout_{uuid.uuid4().hex[:12]}"
+
+
+def _generate_line_item_id() -> str:
+    """Generate a unique line item ID."""
+    return f"li_{uuid.uuid4().hex[:8]}"
+
+
+def _generate_order_id() -> str:
+    """Generate a unique order ID."""
+    return f"order_{uuid.uuid4().hex[:12]}"
+
+
+def _buyer_input_to_dict(buyer: BuyerInput) -> dict[str, Any]:
+    """Convert BuyerInput to dictionary for JSON storage."""
+    return {
+        "first_name": buyer.first_name,
+        "email": buyer.email,
+        "phone_number": buyer.phone_number,
+    }
+
+
+def _dict_to_buyer(data: dict[str, Any]) -> Buyer:
+    """Convert dictionary to Buyer response model."""
+    return Buyer(
+        first_name=data["first_name"],
+        email=data["email"],
+        phone_number=data.get("phone_number"),
+    )
+
+
+def _address_input_to_dict(address: AddressInput) -> dict[str, Any]:
+    """Convert AddressInput to dictionary for JSON storage."""
+    return {
+        "name": address.name,
+        "line_one": address.line_one,
+        "line_two": address.line_two,
+        "city": address.city,
+        "state": address.state,
+        "country": address.country,
+        "postal_code": address.postal_code,
+        "phone_number": address.phone_number,
+    }
+
+
+def _dict_to_address(data: dict[str, Any]) -> Address:
+    """Convert dictionary to Address response model."""
+    return Address(
+        name=data["name"],
+        line_one=data["line_one"],
+        line_two=data.get("line_two"),
+        city=data["city"],
+        state=data["state"],
+        country=data["country"],
+        postal_code=data["postal_code"],
+        phone_number=data.get("phone_number"),
+    )
+
+
+def _calculate_line_item(
+    product: Product, quantity: int, discount: int = 0
+) -> dict[str, Any]:
+    """Calculate line item totals for a product.
+
+    Args:
+        product: Product database model.
+        quantity: Quantity ordered.
+        discount: Discount amount in cents (default 0).
+
+    Returns:
+        Dictionary with line item data for JSON storage.
+    """
+    base_amount = product.base_price * quantity
+    subtotal = base_amount - discount
+    tax = int(subtotal * TAX_RATE)
+    total = subtotal + tax
+
+    return {
+        "id": _generate_line_item_id(),
+        "item": {
+            "id": product.id,
+            "quantity": quantity,
+        },
+        "base_amount": base_amount,
+        "discount": discount,
+        "subtotal": subtotal,
+        "tax": tax,
+        "total": total,
+    }
+
+
+def _dict_to_line_item(data: dict[str, Any]) -> LineItem:
+    """Convert dictionary to LineItem response model."""
+    return LineItem(
+        id=data["id"],
+        item=Item(id=data["item"]["id"], quantity=data["item"]["quantity"]),
+        base_amount=data["base_amount"],
+        discount=data["discount"],
+        subtotal=data["subtotal"],
+        tax=data["tax"],
+        total=data["total"],
+    )
+
+
+def _generate_fulfillment_options(has_address: bool) -> list[dict[str, Any]]:
+    """Generate available fulfillment options.
+
+    Args:
+        has_address: Whether a fulfillment address has been provided.
+
+    Returns:
+        List of fulfillment option dictionaries.
+    """
+    if not has_address:
+        return []
+
+    now = datetime.now(UTC)
+    standard_earliest = now + timedelta(days=5)
+    standard_latest = now + timedelta(days=7)
+    express_earliest = now + timedelta(days=2)
+    express_latest = now + timedelta(days=3)
+
+    return [
+        {
+            "type": "shipping",
+            "id": "shipping_standard",
+            "title": "Standard Shipping",
+            "subtitle": "5-7 business days",
+            "carrier_info": "USPS",
+            "earliest_delivery_time": standard_earliest.isoformat(),
+            "latest_delivery_time": standard_latest.isoformat(),
+            "subtotal": 599,
+            "tax": 0,
+            "total": 599,
+        },
+        {
+            "type": "shipping",
+            "id": "shipping_express",
+            "title": "Express Shipping",
+            "subtitle": "2-3 business days",
+            "carrier_info": "UPS",
+            "earliest_delivery_time": express_earliest.isoformat(),
+            "latest_delivery_time": express_latest.isoformat(),
+            "subtotal": 1299,
+            "tax": 0,
+            "total": 1299,
+        },
+    ]
+
+
+def _dict_to_fulfillment_option(data: dict[str, Any]) -> ShippingFulfillmentOption:
+    """Convert dictionary to FulfillmentOption response model."""
+    return ShippingFulfillmentOption(
+        type=data["type"],
+        id=data["id"],
+        title=data["title"],
+        subtitle=data["subtitle"],
+        carrier_info=data["carrier_info"],
+        earliest_delivery_time=data["earliest_delivery_time"],
+        latest_delivery_time=data["latest_delivery_time"],
+        subtotal=data["subtotal"],
+        tax=data["tax"],
+        total=data["total"],
+    )
+
+
+def _calculate_totals(
+    line_items: list[dict[str, Any]],
+    fulfillment_options: list[dict[str, Any]],
+    selected_option_id: str | None,
+) -> list[dict[str, Any]]:
+    """Calculate checkout totals.
+
+    Args:
+        line_items: List of line item dictionaries.
+        fulfillment_options: List of fulfillment option dictionaries.
+        selected_option_id: ID of selected fulfillment option.
+
+    Returns:
+        List of total dictionaries.
+    """
+    items_base_amount: int = sum(item["base_amount"] for item in line_items)
+    items_discount: int = sum(item["discount"] for item in line_items)
+    items_subtotal: int = sum(item["subtotal"] for item in line_items)
+    items_tax: int = sum(item["tax"] for item in line_items)
+
+    # Get fulfillment cost if option selected
+    fulfillment_cost: int = 0
+    if selected_option_id:
+        for option in fulfillment_options:
+            if option["id"] == selected_option_id:
+                fulfillment_cost = int(option["total"])
+                break
+
+    total: int = items_subtotal + items_tax + fulfillment_cost
+
+    totals: list[dict[str, Any]] = [
+        {
+            "type": TotalTypeEnum.ITEMS_BASE_AMOUNT.value,
+            "display_text": "Items",
+            "amount": items_base_amount,
+        },
+    ]
+
+    if items_discount > 0:
+        totals.append(
+            {
+                "type": TotalTypeEnum.ITEMS_DISCOUNT.value,
+                "display_text": "Discount",
+                "amount": items_discount,
+            }
+        )
+
+    totals.extend(
+        [
+            {
+                "type": TotalTypeEnum.SUBTOTAL.value,
+                "display_text": "Subtotal",
+                "amount": items_subtotal,
+            },
+            {
+                "type": TotalTypeEnum.TAX.value,
+                "display_text": "Tax",
+                "amount": items_tax,
+            },
+        ]
+    )
+
+    if fulfillment_cost > 0:
+        totals.append(
+            {
+                "type": TotalTypeEnum.FULFILLMENT.value,
+                "display_text": "Shipping",
+                "amount": fulfillment_cost,
+            }
+        )
+
+    totals.append(
+        {
+            "type": TotalTypeEnum.TOTAL.value,
+            "display_text": "Total",
+            "amount": total,
+        }
+    )
+
+    return totals
+
+
+def _dict_to_total(data: dict[str, Any]) -> Total:
+    """Convert dictionary to Total response model."""
+    return Total(
+        type=TotalTypeEnum(data["type"]),
+        display_text=data["display_text"],
+        amount=data["amount"],
+    )
+
+
+def _generate_default_links() -> list[dict[str, Any]]:
+    """Generate default HATEOAS links."""
+    return [
+        {
+            "type": LinkTypeEnum.TERMS_OF_USE.value,
+            "url": f"{DEFAULT_SHOP_URL}/terms",
+        },
+        {
+            "type": LinkTypeEnum.PRIVACY_POLICY.value,
+            "url": f"{DEFAULT_SHOP_URL}/privacy",
+        },
+        {
+            "type": LinkTypeEnum.SELLER_SHOP_POLICIES.value,
+            "url": f"{DEFAULT_SHOP_URL}/policies",
+        },
+    ]
+
+
+def _dict_to_link(data: dict[str, Any]) -> Link:
+    """Convert dictionary to Link response model."""
+    return Link(type=LinkTypeEnum(data["type"]), url=data["url"])
+
+
+def _check_ready_for_payment(session: CheckoutSession) -> bool:
+    """Check if session has all required fields for payment.
+
+    A session is ready for payment when:
+    - At least one line item exists
+    - Buyer info is provided
+    - Fulfillment address is provided
+    - Fulfillment option is selected
+
+    Args:
+        session: CheckoutSession database model.
+
+    Returns:
+        True if ready for payment, False otherwise.
+    """
+    line_items = json.loads(session.line_items_json)
+    if not line_items:
+        return False
+
+    if session.buyer_json is None:
+        return False
+
+    if session.fulfillment_address_json is None:
+        return False
+
+    return session.selected_fulfillment_option_id is not None
+
+
+def _session_to_response(session: CheckoutSession) -> CheckoutSessionResponse:
+    """Convert CheckoutSession database model to API response.
+
+    Args:
+        session: CheckoutSession database model.
+
+    Returns:
+        CheckoutSessionResponse for API.
+    """
+    # Parse JSON fields
+    line_items_data: list[dict[str, Any]] = json.loads(session.line_items_json)
+    fulfillment_options_data: list[dict[str, Any]] = json.loads(
+        session.fulfillment_options_json
+    )
+    totals_data: list[dict[str, Any]] = (
+        json.loads(session.totals_json) if session.totals_json != "{}" else []
+    )
+    messages_data: list[dict[str, Any]] = json.loads(session.messages_json)
+    links_data: list[dict[str, Any]] = json.loads(session.links_json)
+
+    # Convert to response models
+    line_items = [_dict_to_line_item(item) for item in line_items_data]
+    fulfillment_options: list[ShippingFulfillmentOption] = [
+        _dict_to_fulfillment_option(opt) for opt in fulfillment_options_data
+    ]
+    totals = [_dict_to_total(t) for t in totals_data] if totals_data else []
+    links = [_dict_to_link(link) for link in links_data]
+
+    # Parse optional fields
+    buyer = None
+    if session.buyer_json:
+        buyer_data = json.loads(session.buyer_json)
+        buyer = _dict_to_buyer(buyer_data)
+
+    fulfillment_address = None
+    if session.fulfillment_address_json:
+        address_data = json.loads(session.fulfillment_address_json)
+        fulfillment_address = _dict_to_address(address_data)
+
+    order = None
+    if session.order_json:
+        order_data = json.loads(session.order_json)
+        order = Order(
+            id=order_data["id"],
+            checkout_session_id=order_data["checkout_session_id"],
+            permalink_url=order_data["permalink_url"],
+        )
+
+    # Convert messages
+    messages: list[MessageInfo] = [
+        MessageInfo(
+            param=msg_data["param"],
+            content_type=ContentTypeEnum(msg_data["content_type"]),
+            content=msg_data["content"],
+        )
+        for msg_data in messages_data
+    ]
+
+    return CheckoutSessionResponse(
+        id=session.id,
+        buyer=buyer,
+        payment_provider=PaymentProvider(
+            provider=PaymentProviderEnum.STRIPE,
+            supported_payment_methods=[PaymentMethodEnum.CARD],
+        ),
+        status=CheckoutStatusEnum(session.status.value),
+        currency=session.currency.lower(),
+        line_items=line_items,
+        fulfillment_address=fulfillment_address,
+        fulfillment_options=list(fulfillment_options),  # Cast for type compatibility
+        fulfillment_option_id=session.selected_fulfillment_option_id,
+        totals=totals,
+        messages=list(messages),  # Cast for type compatibility
+        links=links,
+        order=order,
+    )
+
+
+# =============================================================================
+# Service Functions
+# =============================================================================
+
+
+class CheckoutServiceError(Exception):
+    """Base exception for checkout service errors."""
+
+    def __init__(self, message: str, code: str = "internal_error"):
+        self.message = message
+        self.code = code
+        super().__init__(message)
+
+
+class SessionNotFoundError(CheckoutServiceError):
+    """Raised when a checkout session is not found."""
+
+    def __init__(self, session_id: str):
+        super().__init__(
+            message=f"Checkout session '{session_id}' not found",
+            code="session_not_found",
+        )
+
+
+class ProductNotFoundError(CheckoutServiceError):
+    """Raised when a product is not found."""
+
+    def __init__(self, product_id: str):
+        super().__init__(
+            message=f"Product '{product_id}' not found",
+            code="product_not_found",
+        )
+
+
+class InvalidStateTransitionError(CheckoutServiceError):
+    """Raised when an invalid state transition is attempted."""
+
+    def __init__(self, current_status: str, action: str):
+        super().__init__(
+            message=f"Cannot {action} session with status '{current_status}'",
+            code="invalid_status_transition",
+        )
+
+
+def create_checkout_session(
+    db: Session, request: CreateCheckoutRequest
+) -> CheckoutSessionResponse:
+    """Create a new checkout session.
+
+    Args:
+        db: Database session.
+        request: CreateCheckoutRequest with items and optional buyer/address.
+
+    Returns:
+        CheckoutSessionResponse with the new session.
+
+    Raises:
+        ProductNotFoundError: If a product in items is not found.
+    """
+    session_id = _generate_session_id()
+
+    # Build line items from products
+    line_items: list[dict[str, Any]] = []
+    for item in request.items:
+        product = db.exec(select(Product).where(Product.id == item.id)).first()
+        if product is None:
+            raise ProductNotFoundError(item.id)
+
+        line_item = _calculate_line_item(product, item.quantity)
+        line_items.append(line_item)
+
+    # Process optional buyer
+    buyer_json = None
+    if request.buyer:
+        buyer_json = json.dumps(_buyer_input_to_dict(request.buyer))
+
+    # Process optional fulfillment address
+    fulfillment_address_json = None
+    has_address = request.fulfillment_address is not None
+    if request.fulfillment_address:
+        fulfillment_address_json = json.dumps(
+            _address_input_to_dict(request.fulfillment_address)
+        )
+
+    # Generate fulfillment options
+    fulfillment_options: list[dict[str, Any]] = _generate_fulfillment_options(
+        has_address
+    )
+
+    # Calculate totals
+    totals: list[dict[str, Any]] = _calculate_totals(
+        line_items, fulfillment_options, None
+    )
+
+    # Generate default links
+    links: list[dict[str, Any]] = _generate_default_links()
+
+    # Generate welcome message
+    messages: list[dict[str, Any]] = [
+        {
+            "type": "info",
+            "param": "$",
+            "content_type": "plain",
+            "content": "Welcome to checkout! Please complete all required fields.",
+        }
+    ]
+
+    # Create database record
+    checkout_session = CheckoutSession(
+        id=session_id,
+        status=CheckoutStatus.NOT_READY_FOR_PAYMENT,
+        currency=DEFAULT_CURRENCY.upper(),
+        line_items_json=json.dumps(line_items),
+        buyer_json=buyer_json,
+        fulfillment_address_json=fulfillment_address_json,
+        fulfillment_options_json=json.dumps(fulfillment_options),
+        totals_json=json.dumps(totals),
+        messages_json=json.dumps(messages),
+        links_json=json.dumps(links),
+    )
+
+    db.add(checkout_session)
+    db.commit()
+    db.refresh(checkout_session)
+
+    return _session_to_response(checkout_session)
+
+
+def get_checkout_session(db: Session, session_id: str) -> CheckoutSessionResponse:
+    """Get a checkout session by ID.
+
+    Args:
+        db: Database session.
+        session_id: Checkout session ID.
+
+    Returns:
+        CheckoutSessionResponse with the session.
+
+    Raises:
+        SessionNotFoundError: If session is not found.
+    """
+    session = db.exec(
+        select(CheckoutSession).where(CheckoutSession.id == session_id)
+    ).first()
+
+    if session is None:
+        raise SessionNotFoundError(session_id)
+
+    return _session_to_response(session)
+
+
+def update_checkout_session(
+    db: Session, session_id: str, request: UpdateCheckoutRequest
+) -> CheckoutSessionResponse:
+    """Update a checkout session.
+
+    Args:
+        db: Database session.
+        session_id: Checkout session ID.
+        request: UpdateCheckoutRequest with fields to update.
+
+    Returns:
+        CheckoutSessionResponse with the updated session.
+
+    Raises:
+        SessionNotFoundError: If session is not found.
+        ProductNotFoundError: If a product in items is not found.
+        InvalidStateTransitionError: If session is completed or canceled.
+    """
+    session = db.exec(
+        select(CheckoutSession).where(CheckoutSession.id == session_id)
+    ).first()
+
+    if session is None:
+        raise SessionNotFoundError(session_id)
+
+    # Check if session can be updated
+    if session.status in (CheckoutStatus.COMPLETED, CheckoutStatus.CANCELED):
+        raise InvalidStateTransitionError(session.status.value, "update")
+
+    # Update items if provided
+    if request.items is not None:
+        new_line_items: list[dict[str, Any]] = []
+        for item in request.items:
+            product = db.exec(select(Product).where(Product.id == item.id)).first()
+            if product is None:
+                raise ProductNotFoundError(item.id)
+            line_item = _calculate_line_item(product, item.quantity)
+            new_line_items.append(line_item)
+        session.line_items_json = json.dumps(new_line_items)
+
+    # Update buyer if provided
+    if request.buyer is not None:
+        session.buyer_json = json.dumps(_buyer_input_to_dict(request.buyer))
+
+    # Update fulfillment address if provided
+    if request.fulfillment_address is not None:
+        session.fulfillment_address_json = json.dumps(
+            _address_input_to_dict(request.fulfillment_address)
+        )
+        # Regenerate fulfillment options when address changes
+        new_options: list[dict[str, Any]] = _generate_fulfillment_options(
+            has_address=True
+        )
+        session.fulfillment_options_json = json.dumps(new_options)
+
+    # Update fulfillment option selection if provided
+    if request.fulfillment_option_id is not None:
+        # Validate the option exists
+        current_options: list[dict[str, Any]] = json.loads(
+            session.fulfillment_options_json
+        )
+        valid_ids = [opt["id"] for opt in current_options]
+        if request.fulfillment_option_id in valid_ids:
+            session.selected_fulfillment_option_id = request.fulfillment_option_id
+
+    # Recalculate totals
+    current_line_items: list[dict[str, Any]] = json.loads(session.line_items_json)
+    current_fulfillment_options: list[dict[str, Any]] = json.loads(
+        session.fulfillment_options_json
+    )
+    updated_totals: list[dict[str, Any]] = _calculate_totals(
+        current_line_items,
+        current_fulfillment_options,
+        session.selected_fulfillment_option_id,
+    )
+    session.totals_json = json.dumps(updated_totals)
+
+    # Check if ready for payment and update status
+    if _check_ready_for_payment(session):
+        session.status = CheckoutStatus.READY_FOR_PAYMENT
+        # Update message
+        ready_messages: list[dict[str, Any]] = [
+            {
+                "type": "info",
+                "param": "$",
+                "content_type": "plain",
+                "content": "Ready for payment! Review your order and proceed.",
+            }
+        ]
+        session.messages_json = json.dumps(ready_messages)
+
+    session.updated_at = datetime.now(UTC)
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    return _session_to_response(session)
+
+
+def complete_checkout_session(
+    db: Session,
+    session_id: str,
+    payment_data: PaymentDataInput,  # noqa: ARG001  # Reserved for payment validation
+    buyer: BuyerInput | None = None,
+) -> CheckoutSessionResponse:
+    """Complete a checkout session with payment.
+
+    Args:
+        db: Database session.
+        session_id: Checkout session ID.
+        payment_data: Payment data with token and provider.
+        buyer: Optional buyer info update.
+
+    Returns:
+        CheckoutSessionResponse with the completed session.
+
+    Raises:
+        SessionNotFoundError: If session is not found.
+        InvalidStateTransitionError: If session cannot be completed.
+    """
+    session = db.exec(
+        select(CheckoutSession).where(CheckoutSession.id == session_id)
+    ).first()
+
+    if session is None:
+        raise SessionNotFoundError(session_id)
+
+    # Check if session can be completed
+    if session.status == CheckoutStatus.COMPLETED:
+        raise InvalidStateTransitionError(session.status.value, "complete")
+
+    if session.status == CheckoutStatus.CANCELED:
+        raise InvalidStateTransitionError(session.status.value, "complete")
+
+    # Update buyer if provided
+    if buyer is not None:
+        session.buyer_json = json.dumps(_buyer_input_to_dict(buyer))
+
+    # Verify session is ready for payment (has all required fields)
+    if not _check_ready_for_payment(session):
+        raise InvalidStateTransitionError(session.status.value, "complete")
+
+    # Create order
+    order_id = _generate_order_id()
+    order_data = {
+        "id": order_id,
+        "checkout_session_id": session_id,
+        "permalink_url": f"{DEFAULT_SHOP_URL}/orders/{order_id}",
+    }
+    session.order_json = json.dumps(order_data)
+
+    # Update status
+    session.status = CheckoutStatus.COMPLETED
+
+    # Update message
+    complete_messages: list[dict[str, Any]] = [
+        {
+            "type": "info",
+            "param": "$",
+            "content_type": "plain",
+            "content": f"Order {order_id} confirmed! Thank you for your purchase.",
+        }
+    ]
+    session.messages_json = json.dumps(complete_messages)
+
+    session.updated_at = datetime.now(UTC)
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    return _session_to_response(session)
+
+
+def cancel_checkout_session(db: Session, session_id: str) -> CheckoutSessionResponse:
+    """Cancel a checkout session.
+
+    Args:
+        db: Database session.
+        session_id: Checkout session ID.
+
+    Returns:
+        CheckoutSessionResponse with the canceled session.
+
+    Raises:
+        SessionNotFoundError: If session is not found.
+        InvalidStateTransitionError: If session is already completed or canceled.
+    """
+    session = db.exec(
+        select(CheckoutSession).where(CheckoutSession.id == session_id)
+    ).first()
+
+    if session is None:
+        raise SessionNotFoundError(session_id)
+
+    # Check if session can be canceled
+    if session.status == CheckoutStatus.COMPLETED:
+        raise InvalidStateTransitionError(session.status.value, "cancel")
+
+    if session.status == CheckoutStatus.CANCELED:
+        raise InvalidStateTransitionError(session.status.value, "cancel")
+
+    # Update status
+    session.status = CheckoutStatus.CANCELED
+
+    # Update message
+    cancel_messages: list[dict[str, Any]] = [
+        {
+            "type": "info",
+            "param": "$",
+            "content_type": "plain",
+            "content": "Checkout session has been canceled.",
+        }
+    ]
+    session.messages_json = json.dumps(cancel_messages)
+
+    session.updated_at = datetime.now(UTC)
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    return _session_to_response(session)

--- a/tests/merchant/api/test_checkout.py
+++ b/tests/merchant/api/test_checkout.py
@@ -1,0 +1,806 @@
+"""Tests for the checkout session API endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class TestCreateCheckoutSession:
+    """Test suite for POST /checkout_sessions endpoint."""
+
+    def test_create_session_with_valid_items_returns_201(
+        self, client: TestClient
+    ) -> None:
+        """Happy path: Creating a session with valid items returns 201."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+
+        assert response.status_code == 201
+
+    def test_create_session_returns_session_id(self, client: TestClient) -> None:
+        """Happy path: Response contains a checkout session ID."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert "id" in data
+        assert data["id"].startswith("checkout_")
+
+    def test_create_session_has_not_ready_status(self, client: TestClient) -> None:
+        """Happy path: New session has not_ready_for_payment status."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert data["status"] == "not_ready_for_payment"
+
+    def test_create_session_calculates_line_items(self, client: TestClient) -> None:
+        """Happy path: Line items are calculated correctly."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 2}]},
+        )
+        data = response.json()
+
+        assert len(data["line_items"]) == 1
+        line_item = data["line_items"][0]
+        assert line_item["item"]["id"] == "prod_1"
+        assert line_item["item"]["quantity"] == 2
+        # prod_1 base_price is 2500 cents, so 2 * 2500 = 5000
+        assert line_item["base_amount"] == 5000
+        assert line_item["discount"] == 0
+        assert line_item["subtotal"] == 5000
+        # 10% tax
+        assert line_item["tax"] == 500
+        assert line_item["total"] == 5500
+
+    def test_create_session_with_buyer_info(self, client: TestClient) -> None:
+        """Happy path: Session includes buyer info when provided."""
+        response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {"first_name": "John", "email": "john@example.com"},
+            },
+        )
+        data = response.json()
+
+        assert data["buyer"] is not None
+        assert data["buyer"]["first_name"] == "John"
+        assert data["buyer"]["email"] == "john@example.com"
+
+    def test_create_session_with_fulfillment_address(self, client: TestClient) -> None:
+        """Happy path: Session includes address and fulfillment options when provided."""
+        response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "fulfillment_address": {
+                    "name": "John Doe",
+                    "line_one": "123 Main St",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "country": "US",
+                    "postal_code": "94102",
+                },
+            },
+        )
+        data = response.json()
+
+        assert data["fulfillment_address"] is not None
+        assert data["fulfillment_address"]["name"] == "John Doe"
+        assert len(data["fulfillment_options"]) > 0
+
+    def test_create_session_includes_payment_provider(self, client: TestClient) -> None:
+        """Happy path: Response includes payment provider configuration."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert "payment_provider" in data
+        assert data["payment_provider"]["provider"] == "stripe"
+        assert "card" in data["payment_provider"]["supported_payment_methods"]
+
+    def test_create_session_includes_totals(self, client: TestClient) -> None:
+        """Happy path: Response includes calculated totals."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert "totals" in data
+        assert len(data["totals"]) > 0
+        # Should have at least items_base_amount, subtotal, tax, total
+        total_types = [t["type"] for t in data["totals"]]
+        assert "items_base_amount" in total_types
+        assert "subtotal" in total_types
+        assert "tax" in total_types
+        assert "total" in total_types
+
+    def test_create_session_includes_messages(self, client: TestClient) -> None:
+        """Happy path: Response includes messages array."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert "messages" in data
+        assert isinstance(data["messages"], list)
+
+    def test_create_session_includes_links(self, client: TestClient) -> None:
+        """Happy path: Response includes HATEOAS links."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert "links" in data
+        assert len(data["links"]) == 3
+        link_types = [link["type"] for link in data["links"]]
+        assert "terms_of_use" in link_types
+        assert "privacy_policy" in link_types
+        assert "seller_shop_policies" in link_types
+
+    def test_create_session_with_invalid_product_returns_400(
+        self, client: TestClient
+    ) -> None:
+        """Failure case: Invalid product ID returns 400."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "invalid_product", "quantity": 1}]},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "product_not_found" in str(data)
+
+    def test_create_session_with_empty_items_returns_422(
+        self, client: TestClient
+    ) -> None:
+        """Failure case: Empty items list returns 422 validation error."""
+        response = client.post("/checkout_sessions", json={"items": []})
+
+        assert response.status_code == 422
+
+    def test_create_session_with_zero_quantity_returns_422(
+        self, client: TestClient
+    ) -> None:
+        """Failure case: Zero quantity returns 422 validation error."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 0}]},
+        )
+
+        assert response.status_code == 422
+
+    def test_create_session_with_multiple_items(self, client: TestClient) -> None:
+        """Edge case: Multiple items in a single session."""
+        response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [
+                    {"id": "prod_1", "quantity": 1},
+                    {"id": "prod_2", "quantity": 2},
+                ]
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 201
+        assert len(data["line_items"]) == 2
+
+
+class TestGetCheckoutSession:
+    """Test suite for GET /checkout_sessions/{id} endpoint."""
+
+    def test_get_existing_session_returns_200(self, client: TestClient) -> None:
+        """Happy path: Getting an existing session returns 200."""
+        # Create a session first
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        # Get the session
+        response = client.get(f"/checkout_sessions/{session_id}")
+
+        assert response.status_code == 200
+
+    def test_get_session_returns_correct_data(self, client: TestClient) -> None:
+        """Happy path: Get returns the same data that was created."""
+        # Create a session with specific data
+        create_response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 3}],
+                "buyer": {"first_name": "Jane", "email": "jane@example.com"},
+            },
+        )
+        created_data = create_response.json()
+        session_id = created_data["id"]
+
+        # Get the session
+        response = client.get(f"/checkout_sessions/{session_id}")
+        data = response.json()
+
+        assert data["id"] == session_id
+        assert data["buyer"]["first_name"] == "Jane"
+        assert data["line_items"][0]["item"]["quantity"] == 3
+
+    def test_get_nonexistent_session_returns_404(self, client: TestClient) -> None:
+        """Failure case: Getting a non-existent session returns 404."""
+        response = client.get("/checkout_sessions/nonexistent_id")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "session_not_found" in str(data)
+
+
+class TestUpdateCheckoutSession:
+    """Test suite for POST /checkout_sessions/{id} endpoint."""
+
+    def test_update_session_returns_200(self, client: TestClient) -> None:
+        """Happy path: Updating an existing session returns 200."""
+        # Create a session
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        # Update the session
+        response = client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"buyer": {"first_name": "Updated", "email": "updated@example.com"}},
+        )
+
+        assert response.status_code == 200
+
+    def test_update_session_with_buyer(self, client: TestClient) -> None:
+        """Happy path: Update adds buyer information."""
+        # Create a session without buyer
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        # Update with buyer
+        response = client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"buyer": {"first_name": "Alice", "email": "alice@example.com"}},
+        )
+        data = response.json()
+
+        assert data["buyer"]["first_name"] == "Alice"
+
+    def test_update_session_with_address_generates_fulfillment_options(
+        self, client: TestClient
+    ) -> None:
+        """Happy path: Adding address generates fulfillment options."""
+        # Create a session without address
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+        assert len(create_response.json()["fulfillment_options"]) == 0
+
+        # Update with address
+        response = client.post(
+            f"/checkout_sessions/{session_id}",
+            json={
+                "fulfillment_address": {
+                    "name": "Bob Smith",
+                    "line_one": "456 Oak Ave",
+                    "city": "Austin",
+                    "state": "TX",
+                    "country": "US",
+                    "postal_code": "78701",
+                }
+            },
+        )
+        data = response.json()
+
+        assert len(data["fulfillment_options"]) > 0
+
+    def test_update_session_with_fulfillment_option_selection(
+        self, client: TestClient
+    ) -> None:
+        """Happy path: Can select a fulfillment option."""
+        # Create a session with address
+        create_response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "fulfillment_address": {
+                    "name": "Bob Smith",
+                    "line_one": "456 Oak Ave",
+                    "city": "Austin",
+                    "state": "TX",
+                    "country": "US",
+                    "postal_code": "78701",
+                },
+            },
+        )
+        session_id = create_response.json()["id"]
+        fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
+
+        # Select fulfillment option
+        response = client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"fulfillment_option_id": fulfillment_option_id},
+        )
+        data = response.json()
+
+        assert data["fulfillment_option_id"] == fulfillment_option_id
+
+    def test_update_session_transitions_to_ready_for_payment(
+        self, client: TestClient
+    ) -> None:
+        """Happy path: Session transitions to ready_for_payment with all fields."""
+        # Create a session with address
+        create_response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "fulfillment_address": {
+                    "name": "Complete User",
+                    "line_one": "789 Pine St",
+                    "city": "Seattle",
+                    "state": "WA",
+                    "country": "US",
+                    "postal_code": "98101",
+                },
+            },
+        )
+        session_id = create_response.json()["id"]
+        fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
+
+        # Add buyer and select fulfillment option
+        response = client.post(
+            f"/checkout_sessions/{session_id}",
+            json={
+                "buyer": {"first_name": "Complete", "email": "complete@example.com"},
+                "fulfillment_option_id": fulfillment_option_id,
+            },
+        )
+        data = response.json()
+
+        assert data["status"] == "ready_for_payment"
+
+    def test_update_session_recalculates_totals(self, client: TestClient) -> None:
+        """Edge case: Updating items recalculates totals."""
+        # Create a session with 1 item
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+        original_total = next(
+            t["amount"]
+            for t in create_response.json()["totals"]
+            if t["type"] == "total"
+        )
+
+        # Update to 2 items
+        response = client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"items": [{"id": "prod_1", "quantity": 2}]},
+        )
+        data = response.json()
+        new_total = next(t["amount"] for t in data["totals"] if t["type"] == "total")
+
+        assert new_total == original_total * 2
+
+    def test_update_nonexistent_session_returns_404(self, client: TestClient) -> None:
+        """Failure case: Updating non-existent session returns 404."""
+        response = client.post(
+            "/checkout_sessions/nonexistent_id",
+            json={"buyer": {"first_name": "Test", "email": "test@example.com"}},
+        )
+
+        assert response.status_code == 404
+
+    def test_update_completed_session_returns_405(self, client: TestClient) -> None:
+        """Failure case: Updating a completed session returns 405."""
+        # Create and complete a session
+        create_response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {"first_name": "Test", "email": "test@example.com"},
+                "fulfillment_address": {
+                    "name": "Test User",
+                    "line_one": "123 Test St",
+                    "city": "Test City",
+                    "state": "TS",
+                    "country": "US",
+                    "postal_code": "12345",
+                },
+            },
+        )
+        session_id = create_response.json()["id"]
+        fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
+
+        # Select fulfillment option to make it ready
+        client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"fulfillment_option_id": fulfillment_option_id},
+        )
+
+        # Complete the session
+        client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={
+                "payment_data": {
+                    "token": "tok_test",
+                    "provider": "stripe",
+                }
+            },
+        )
+
+        # Try to update completed session
+        response = client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"buyer": {"first_name": "Updated", "email": "updated@example.com"}},
+        )
+
+        assert response.status_code == 405
+
+
+class TestCompleteCheckoutSession:
+    """Test suite for POST /checkout_sessions/{id}/complete endpoint."""
+
+    def _create_ready_session(self, client: TestClient) -> str:
+        """Helper to create a session ready for payment."""
+        create_response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {"first_name": "Ready", "email": "ready@example.com"},
+                "fulfillment_address": {
+                    "name": "Ready User",
+                    "line_one": "100 Ready St",
+                    "city": "Ready City",
+                    "state": "RD",
+                    "country": "US",
+                    "postal_code": "00000",
+                },
+            },
+        )
+        session_id = create_response.json()["id"]
+        fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
+
+        # Select fulfillment option to make it ready
+        client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"fulfillment_option_id": fulfillment_option_id},
+        )
+
+        return session_id
+
+    def test_complete_ready_session_returns_200(self, client: TestClient) -> None:
+        """Happy path: Completing a ready session returns 200."""
+        session_id = self._create_ready_session(client)
+
+        response = client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+
+        assert response.status_code == 200
+
+    def test_complete_session_sets_completed_status(self, client: TestClient) -> None:
+        """Happy path: Completed session has status 'completed'."""
+        session_id = self._create_ready_session(client)
+
+        response = client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+        data = response.json()
+
+        assert data["status"] == "completed"
+
+    def test_complete_session_creates_order(self, client: TestClient) -> None:
+        """Happy path: Completed session includes order object."""
+        session_id = self._create_ready_session(client)
+
+        response = client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+        data = response.json()
+
+        assert data["order"] is not None
+        assert data["order"]["id"].startswith("order_")
+        assert data["order"]["checkout_session_id"] == session_id
+        assert "permalink_url" in data["order"]
+
+    def test_complete_nonexistent_session_returns_404(self, client: TestClient) -> None:
+        """Failure case: Completing non-existent session returns 404."""
+        response = client.post(
+            "/checkout_sessions/nonexistent_id/complete",
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+
+        assert response.status_code == 404
+
+    def test_complete_not_ready_session_returns_405(self, client: TestClient) -> None:
+        """Failure case: Completing a not-ready session returns 405."""
+        # Create a session without all required fields
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        response = client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+
+        assert response.status_code == 405
+
+    def test_complete_already_completed_session_returns_405(
+        self, client: TestClient
+    ) -> None:
+        """Failure case: Completing an already completed session returns 405."""
+        session_id = self._create_ready_session(client)
+
+        # Complete once
+        client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+
+        # Try to complete again
+        response = client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_test2", "provider": "stripe"}},
+        )
+
+        assert response.status_code == 405
+
+
+class TestCancelCheckoutSession:
+    """Test suite for POST /checkout_sessions/{id}/cancel endpoint."""
+
+    def test_cancel_session_returns_200(self, client: TestClient) -> None:
+        """Happy path: Canceling a session returns 200."""
+        # Create a session
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        response = client.post(f"/checkout_sessions/{session_id}/cancel")
+
+        assert response.status_code == 200
+
+    def test_cancel_session_sets_canceled_status(self, client: TestClient) -> None:
+        """Happy path: Canceled session has status 'canceled'."""
+        # Create a session
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        response = client.post(f"/checkout_sessions/{session_id}/cancel")
+        data = response.json()
+
+        assert data["status"] == "canceled"
+
+    def test_cancel_ready_session_returns_200(self, client: TestClient) -> None:
+        """Happy path: Can cancel a ready_for_payment session."""
+        # Create a ready session
+        create_response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {"first_name": "Test", "email": "test@example.com"},
+                "fulfillment_address": {
+                    "name": "Test User",
+                    "line_one": "123 Test St",
+                    "city": "Test City",
+                    "state": "TS",
+                    "country": "US",
+                    "postal_code": "12345",
+                },
+            },
+        )
+        session_id = create_response.json()["id"]
+        fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
+
+        # Make it ready
+        client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"fulfillment_option_id": fulfillment_option_id},
+        )
+
+        response = client.post(f"/checkout_sessions/{session_id}/cancel")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "canceled"
+
+    def test_cancel_nonexistent_session_returns_404(self, client: TestClient) -> None:
+        """Failure case: Canceling non-existent session returns 404."""
+        response = client.post("/checkout_sessions/nonexistent_id/cancel")
+
+        assert response.status_code == 404
+
+    def test_cancel_completed_session_returns_405(self, client: TestClient) -> None:
+        """Failure case: Canceling a completed session returns 405."""
+        # Create and complete a session
+        create_response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {"first_name": "Test", "email": "test@example.com"},
+                "fulfillment_address": {
+                    "name": "Test User",
+                    "line_one": "123 Test St",
+                    "city": "Test City",
+                    "state": "TS",
+                    "country": "US",
+                    "postal_code": "12345",
+                },
+            },
+        )
+        session_id = create_response.json()["id"]
+        fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
+
+        # Make it ready and complete
+        client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"fulfillment_option_id": fulfillment_option_id},
+        )
+        client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+
+        response = client.post(f"/checkout_sessions/{session_id}/cancel")
+
+        assert response.status_code == 405
+
+    def test_cancel_already_canceled_session_returns_405(
+        self, client: TestClient
+    ) -> None:
+        """Failure case: Canceling an already canceled session returns 405."""
+        # Create and cancel a session
+        create_response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        client.post(f"/checkout_sessions/{session_id}/cancel")
+
+        # Try to cancel again
+        response = client.post(f"/checkout_sessions/{session_id}/cancel")
+
+        assert response.status_code == 405
+
+
+class TestCheckoutSessionResponseFormat:
+    """Test suite for verifying ACP-compliant response format."""
+
+    def test_response_has_all_required_fields(self, client: TestClient) -> None:
+        """Edge case: Response contains all ACP-required fields."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        required_fields = {
+            "id",
+            "payment_provider",
+            "status",
+            "currency",
+            "line_items",
+            "fulfillment_options",
+            "totals",
+            "messages",
+            "links",
+        }
+        assert required_fields <= set(data.keys())
+
+    def test_currency_is_lowercase(self, client: TestClient) -> None:
+        """Edge case: Currency is lowercase ISO 4217."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert data["currency"] == "usd"
+
+    def test_line_item_has_all_required_fields(self, client: TestClient) -> None:
+        """Edge case: Line items contain all required fields."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+        line_item = data["line_items"][0]
+
+        required_fields = {
+            "id",
+            "item",
+            "base_amount",
+            "discount",
+            "subtotal",
+            "tax",
+            "total",
+        }
+        assert required_fields <= set(line_item.keys())
+        assert "id" in line_item["item"]
+        assert "quantity" in line_item["item"]
+
+    def test_fulfillment_option_has_required_fields(self, client: TestClient) -> None:
+        """Edge case: Fulfillment options contain all required fields."""
+        response = client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "fulfillment_address": {
+                    "name": "Test User",
+                    "line_one": "123 Test St",
+                    "city": "Test City",
+                    "state": "TS",
+                    "country": "US",
+                    "postal_code": "12345",
+                },
+            },
+        )
+        data = response.json()
+        option = data["fulfillment_options"][0]
+
+        required_fields = {
+            "type",
+            "id",
+            "title",
+            "subtitle",
+            "subtotal",
+            "tax",
+            "total",
+        }
+        assert required_fields <= set(option.keys())
+
+    def test_response_json_content_type(self, client: TestClient) -> None:
+        """Edge case: Response has correct content type."""
+        response = client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+
+        assert "application/json" in response.headers["content-type"]
+
+    @pytest.mark.parametrize("method", ["PUT", "DELETE", "PATCH"])
+    def test_create_rejects_non_post_methods(
+        self, client: TestClient, method: str
+    ) -> None:
+        """Failure case: Create endpoint rejects non-POST methods."""
+        response = client.request(
+            method,
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+
+        assert response.status_code == 405


### PR DESCRIPTION
## Summary

Implements Feature 3: ACP Core Endpoints (CRUD) - the 5 ACP-compliant checkout session endpoints.

### Endpoints Added
| Endpoint | Method | Status | Description |
|----------|--------|--------|-------------|
| `/checkout_sessions` | POST | 201 | Create checkout session |
| `/checkout_sessions/{id}` | GET | 200/404 | Get checkout session |
| `/checkout_sessions/{id}` | POST | 200/404/405 | Update checkout session |
| `/checkout_sessions/{id}/complete` | POST | 200/404/405 | Complete with payment |
| `/checkout_sessions/{id}/cancel` | POST | 200/404/405 | Cancel checkout |

### Implementation Details
- **Pydantic schemas** (`src/merchant/api/schemas.py`) - All request/response models per ACP spec
- **Service layer** (`src/merchant/services/checkout.py`) - Business logic with state machine
- **API routes** (`src/merchant/api/routes/checkout.py`) - FastAPI endpoints
- **Tests** (`tests/merchant/api/test_checkout.py`) - 45 comprehensive tests

### State Machine
```
not_ready_for_payment → ready_for_payment → completed
                     ↘                   ↘
                       →    canceled    ←
```

### Features
- Line item calculations with 10% tax rate
- Fulfillment options (Standard $5.99, Express $12.99) when address provided
- ACP-compliant response structure (messages, links, totals, payment_provider)
- Proper error responses (400, 404, 405, 422)

## Test Plan
- [x] All 78 tests pass (45 new + 33 existing)
- [x] Ruff check passes
- [x] Ruff format passes  
- [x] Pyright strict mode passes
- [x] Manual curl validation of all endpoints
- [x] Verified state transitions work correctly
- [x] Verified error responses return correct status codes