### PR TITLE
docs: update ACP documentation with v2026-01-16 spec changes

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -40,7 +40,7 @@ For this project we will also build a **client agent simulator** that behaves li
 
 ### 2.1 ACP Checkout Endpoints (Per Official Specification)
 
-Implement the 5 required RESTful endpoints per the OpenAI/Stripe ACP specification:
+Implement the 5 required RESTful endpoints per the OpenAI/Stripe ACP specification (API Version: `2026-01-16`):
 
 #### FR-ACP-01: Create Checkout Session
 * **Endpoint**: `POST /checkout_sessions`
@@ -106,7 +106,26 @@ All successful responses return the full checkout state:
   "buyer": { ... },
   "payment_provider": {
     "provider": "stripe",
-    "supported_payment_methods": ["card"]
+    "supported_payment_methods": [
+      {
+        "type": "card",
+        "supported_card_networks": ["visa", "mastercard", "amex", "discover"]
+      }
+    ]
+  },
+  "seller_capabilities": {
+    "payment_methods": [
+      {
+        "method": "card",
+        "brands": ["visa", "mastercard", "amex"],
+        "funding_types": ["credit", "debit"]
+      }
+    ],
+    "interventions": {
+      "required": [],
+      "supported": ["3ds", "3ds_challenge", "3ds_frictionless"],
+      "enforcement": "conditional"
+    }
   },
   "line_items": [{
     "id": "item_123",
@@ -117,18 +136,31 @@ All successful responses return the full checkout state:
     "tax": 200,
     "total": 2700
   }],
-  "fulfillment_address": { ... },
+  "fulfillment_details": {
+    "name": "John Doe",
+    "phone_number": "15551234567",
+    "email": "john@example.com",
+    "address": { ... }
+  },
   "fulfillment_options": [{
     "type": "shipping",
     "id": "shipping_standard",
     "title": "Standard Shipping",
     "subtitle": "5-7 business days",
     "carrier": "USPS",
+    "earliest_delivery_time": "2026-01-28T00:00:00Z",
+    "latest_delivery_time": "2026-01-30T23:59:59Z",
     "subtotal": 500,
     "tax": 0,
     "total": 500
   }],
-  "fulfillment_option_id": "shipping_standard",
+  "selected_fulfillment_options": [{
+    "type": "shipping",
+    "shipping": {
+      "option_id": "shipping_standard",
+      "item_ids": ["item_123"]
+    }
+  }],
   "totals": [
     { "type": "subtotal", "display_text": "Subtotal", "amount": 2500 },
     { "type": "fulfillment", "display_text": "Shipping", "amount": 500 },
@@ -139,6 +171,16 @@ All successful responses return the full checkout state:
   "links": []
 }
 ```
+
+**Session Status Values:**
+| Status | Description |
+|--------|-------------|
+| `not_ready_for_payment` | Initial state, missing required data |
+| `ready_for_payment` | All requirements met, ready for payment |
+| `authentication_required` | 3D Secure or other authentication required |
+| `in_progress` | Payment is being processed |
+| `completed` | Successfully completed with order created |
+| `canceled` | Session has been canceled |
 
 ### 2.2 Intelligent Merchant Agents (NVIDIA NeMo Agent Toolkit)
 

--- a/docs/acp-spec.md
+++ b/docs/acp-spec.md
@@ -2,9 +2,17 @@
 
 **Call Direction**: OpenAI → Merchant (REST) | Merchant → OpenAI (Webhooks)
 
+**API Version**: `2026-01-16`
+
 ## Overview
 
 This document defines the REST endpoints and webhook events for the Agentic Checkout Protocol. Merchants implement these endpoints to enable end-to-end checkout flows inside ChatGPT.
+
+ACP Checkout Sessions provide a stateful model for managing the checkout experience where:
+- **Merchants remain the system of record** for orders, payments, taxes, and compliance
+- **Agents orchestrate checkout** through a standardized REST API
+- **Sessions return authoritative cart state** on every response
+- **All payments flow through merchant rails** via their existing PSP
 
 ### Checkout Flow
 
@@ -17,35 +25,73 @@ This document defines the REST endpoints and webhook events for the Agentic Chec
 ### Session States
 
 ```
-not_ready_for_payment → ready_for_payment → completed
-                     ↘                   ↘
-                       →    canceled    ←
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           CHECKOUT SESSION STATES                           │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   CREATE SESSION                                                            │
+│        ↓                                                                    │
+│   [not_ready_for_payment] ←── Missing required data (address, items)        │
+│        │                                                                    │
+│        ↓ UPDATE SESSION (add fulfillment, fix issues)                       │
+│   [ready_for_payment]                                                       │
+│        │                                                                    │
+│        ├──→ COMPLETE (no 3DS) ──→ [in_progress] ──→ [completed] + order     │
+│        │                                                                    │
+│        └──→ COMPLETE (3DS needed) ──→ [authentication_required]             │
+│                                              │                              │
+│                                              ↓                              │
+│                                        User completes 3DS                   │
+│                                              │                              │
+│                                              ↓                              │
+│                                   COMPLETE with auth_result                 │
+│                                              │                              │
+│                                              ↓                              │
+│                                        [completed] + order                  │
+│                                                                             │
+│   CANCEL SESSION (any non-final state) ──→ [canceled]                       │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
+
+| Status | Description |
+|--------|-------------|
+| `not_ready_for_payment` | Initial state, missing required data (fulfillment address, valid items) |
+| `ready_for_payment` | All requirements met, ready to accept payment |
+| `authentication_required` | 3D Secure or other authentication is required |
+| `in_progress` | Payment is being processed |
+| `completed` | Successfully completed with order created |
+| `canceled` | Session has been canceled |
 
 ---
 
 ## Common Request/Response Headers
 
-### Request Headers (All Endpoints)
+### Required Request Headers
 
 | Header          | Description                                      | Example                                         |
 |:----------------|:-------------------------------------------------|:------------------------------------------------|
 | Authorization   | API Key for authentication                       | `Bearer api_key_123`                            |
+| API-Version     | API version                                      | `2026-01-16`                                    |
+| Content-Type    | Request content type (for requests with body)    | `application/json`                              |
+
+### Recommended Request Headers
+
+| Header          | Description                                      | Example                                         |
+|:----------------|:-------------------------------------------------|:------------------------------------------------|
 | Accept-Language | Preferred locale for messages/errors             | `en-US`                                         |
-| User-Agent      | Client information                               | `ChatGPT/2.0 (Mac OS X 15.0.1; arm64; build 0)` |
-| Idempotency-Key | Ensures request idempotency                      | `idempotency_key_123`                           |
-| Request-Id      | Unique request identifier for tracing            | `request_id_123`                                |
-| Content-Type    | Request content type                             | `application/json`                              |
-| Signature       | Base64 encoded signature of request body         | `eyJtZX...`                                     |
-| Timestamp       | RFC 3339 formatted timestamp                     | `2025-09-25T10:30:00Z`                          |
-| API-Version     | API version                                      | `2025-09-12`                                    |
+| User-Agent      | Client identification                            | `ChatGPT/2.0`                                   |
+| Idempotency-Key | Ensures request idempotency                      | `idem_abc123`                                   |
+| Request-Id      | Unique request identifier for tracing            | `req_xyz789`                                    |
+| Signature       | Request signature (base64url)                    | `ZXltZX...`                                     |
+| Timestamp       | Request timestamp (RFC 3339)                     | `2025-09-29T10:30:00Z`                          |
 
 ### Response Headers
 
 | Header          | Description                       | Example               |
 |:----------------|:----------------------------------|:----------------------|
-| Idempotency-Key | Echoed from request               | `idempotency_key_123` |
-| Request-Id      | Echoed from request               | `request_id_123`      |
+| Idempotency-Key | Echo of request idempotency key   | `idem_abc123`         |
+| Request-Id      | Echo of request correlation ID    | `req_xyz789`          |
 
 ---
 
@@ -60,26 +106,53 @@ not_ready_for_payment → ready_for_payment → completed
 
 ```json
 {
-  "buyer": {                          // Optional
-    "first_name": "string",           // Required - max 256 chars
-    "email": "string",                // Required - max 256 chars
-    "phone_number": "string"          // Optional - E.164 format
-  },
   "items": [                          // Required - non-empty list
     {
       "id": "string",                 // Required - product ID
       "quantity": 1                   // Required - positive integer > 0
     }
   ],
-  "fulfillment_address": {            // Optional
-    "name": "string",                 // Required - max 256 chars
-    "line_one": "string",             // Required - max 60 chars
-    "line_two": "string",             // Optional - max 60 chars
-    "city": "string",                 // Required - max 60 chars
-    "state": "string",                // Required - ISO 3166-1
-    "country": "string",              // Required - ISO 3166-1
-    "postal_code": "string",          // Required - max 20 chars
+  "buyer": {                          // Optional
+    "first_name": "string",           // Required - max 256 chars
+    "last_name": "string",            // Required - max 256 chars
+    "email": "string",                // Required - max 256 chars (email format)
     "phone_number": "string"          // Optional - E.164 format
+  },
+  "fulfillment_details": {            // Optional - nested structure (preferred)
+    "name": "string",                 // Optional - recipient name
+    "phone_number": "string",         // Optional - E.164 format
+    "email": "string",                // Optional - email format
+    "address": {                      // Required for shipping
+      "name": "string",               // Optional - max 256 chars
+      "line_one": "string",           // Optional - max 60 chars
+      "line_two": "string",           // Optional - max 60 chars
+      "city": "string",               // Optional - max 60 chars
+      "state": "string",              // Optional - ISO-3166-2 for shipping
+      "country": "string",            // Optional - ISO 3166-1 alpha-2
+      "postal_code": "string"         // Optional - max 20 chars
+    }
+  },
+  "agent_capabilities": {             // Optional - declares agent's supported features
+    "interventions": {
+      "supported": [                  // Supported intervention types
+        "3ds", "3ds_redirect", "3ds_challenge", "3ds_frictionless",
+        "biometric", "otp", "email_verification", "sms_verification", "address_verification"
+      ],
+      "max_redirects": 1,             // Max redirects agent can handle (default: 0)
+      "redirect_context": "in_app",   // "in_app", "external_browser", or "none"
+      "max_interaction_depth": 2,     // Maximum nesting level (default: 1)
+      "display_context": "webview"    // "native", "webview", "modal", or "redirect"
+    },
+    "features": {
+      "async_completion": true,       // Optional - async completion support
+      "session_persistence": true     // Optional - session persistence support
+    }
+  },
+  "affiliate_attribution": {          // Optional - affiliate tracking
+    "provider": "impact.com",         // Attribution provider
+    "token": "atp_01J8Z3WXYZ9ABC",    // Attribution token
+    "publisher_id": "pub_123",        // Publisher identifier
+    "touchpoint": "first"             // "first" or "last" touch attribution
   }
 }
 ```
@@ -89,13 +162,41 @@ not_ready_for_payment → ready_for_payment → completed
 ```json
 {
   "id": "string",                     // Required - checkout session ID
+  "status": "not_ready_for_payment|ready_for_payment|authentication_required|in_progress|completed|canceled",  // Required
+  "currency": "usd",                  // Required - ISO 4217 lowercase
   "buyer": { },                       // Optional - Buyer object
   "payment_provider": {               // Required
-    "provider": "stripe|adyen",       // Required - enum
-    "supported_payment_methods": ["card"]  // Required - list of enums
+    "provider": "stripe",             // Required - enum (stripe)
+    "supported_payment_methods": [    // Required - list of payment method objects
+      {
+        "type": "card",               // Required - payment method type
+        "supported_card_networks": ["visa", "mastercard", "amex", "discover"]  // Required for cards
+      }
+    ]
   },
-  "status": "not_ready_for_payment|ready_for_payment|completed|canceled",  // Required
-  "currency": "usd",                  // Required - ISO 4217 lowercase
+  "seller_capabilities": {            // Required - merchant's supported features
+    "payment_methods": [              // Required - supported payment methods (detailed)
+      {
+        "method": "card",
+        "brands": ["visa", "mastercard", "amex"],
+        "funding_types": ["credit", "debit"]
+      },
+      "card.network_token",
+      "wallet.apple_pay",
+      "wallet.google_pay",
+      "bnpl.klarna"
+    ],
+    "interventions": {
+      "required": [],                 // Interventions REQUIRED for this session
+      "supported": ["3ds", "3ds_challenge", "3ds_frictionless"],  // Interventions seller supports
+      "enforcement": "conditional"    // "always", "conditional", or "optional"
+    },
+    "features": {
+      "partial_auth": true,           // Optional
+      "saved_payment_methods": true,  // Optional
+      "network_tokenization": true    // Optional
+    }
+  },
   "line_items": [                     // Required
     {
       "id": "string",                 // Required - line item ID
@@ -103,17 +204,29 @@ not_ready_for_payment → ready_for_payment → completed
         "id": "string",
         "quantity": 1
       },
-      "base_amount": 300,             // Required - integer >= 0
+      "name": "string",               // Optional - display name
+      "description": "string",        // Optional - product description
+      "images": ["uri"],              // Optional - product images
+      "unit_amount": 300,             // Optional - per-unit price
+      "base_amount": 300,             // Required - integer >= 0 (minor units)
       "discount": 0,                  // Required - integer >= 0
       "subtotal": 300,                // Required - equals base_amount - discount
       "tax": 30,                      // Required - integer >= 0
-      "total": 330                    // Required - equals subtotal + tax
+      "total": 330,                   // Required - equals subtotal + tax
+      "disclosures": [],              // Optional - product disclaimers
+      "custom_attributes": [],        // Optional - extended properties
+      "marketplace_seller_details": {} // Optional - seller info
     }
   ],
-  "fulfillment_address": { },         // Optional - Address object
+  "fulfillment_details": {            // Optional - nested structure
+    "name": "string",
+    "phone_number": "string",
+    "email": "string",
+    "address": { }
+  },
   "fulfillment_options": [            // Required
     {
-      "type": "shipping|digital",
+      "type": "shipping",
       "id": "string",
       "title": "string",
       "subtitle": "string",
@@ -125,12 +238,28 @@ not_ready_for_payment → ready_for_payment → completed
       "total": 100
     }
   ],
-  "fulfillment_option_id": "string",  // Optional - selected option
+  "selected_fulfillment_options": [   // Optional - supports multiple selections
+    {
+      "type": "shipping",
+      "shipping": {
+        "option_id": "fulfillment_option_123",
+        "item_ids": ["item_456", "item_789"]
+      }
+    },
+    {
+      "type": "digital",
+      "digital": {
+        "option_id": "fulfillment_option_456",
+        "item_ids": ["item_012"]
+      }
+    }
+  ],
   "totals": [                         // Required
     {
       "type": "items_base_amount|items_discount|subtotal|discount|fulfillment|tax|fee|total",
       "display_text": "string",
-      "amount": 0                     // integer >= 0
+      "amount": 0,                    // integer >= 0 (minor units)
+      "description": "string"         // Optional (for fees)
     }
   ],
   "messages": [                       // Required
@@ -144,10 +273,11 @@ not_ready_for_payment → ready_for_payment → completed
   ],
   "links": [                          // Required
     {
-      "type": "terms_of_use|privacy_policy|seller_shop_policies",
+      "type": "terms_of_use|privacy_policy|return_policy",
       "url": "string"
     }
-  ]
+  ],
+  "authentication_metadata": { }      // Present when status is authentication_required
 }
 ```
 
@@ -162,21 +292,42 @@ not_ready_for_payment → ready_for_payment → completed
 
 ```json
 {
-  "buyer": { },                       // Optional - Buyer object
+  "buyer": {                          // Optional - Buyer object
+    "first_name": "string",
+    "last_name": "string",
+    "email": "string"
+  },
   "items": [                          // Optional - updated items list
     {
       "id": "string",
       "quantity": 1
     }
   ],
-  "fulfillment_address": { },         // Optional - Address object
-  "fulfillment_option_id": "string"   // Optional - selected fulfillment option
+  "fulfillment_details": {            // Optional - nested structure
+    "address": {
+      "name": "string",
+      "line_one": "string",
+      "city": "string",
+      "state": "string",
+      "country": "string",
+      "postal_code": "string"
+    }
+  },
+  "selected_fulfillment_options": [   // Optional - supports multiple selections
+    {
+      "type": "shipping",
+      "shipping": {
+        "option_id": "fulfillment_option_123",
+        "item_ids": ["item_456"]
+      }
+    }
+  ]
 }
 ```
 
 #### Output Schema
 
-Same as **Create Checkout Session** output (full checkout state).
+Same as **Create Checkout Session** output (full checkout state with updated values).
 
 ---
 
@@ -185,7 +336,9 @@ Same as **Create Checkout Session** output (full checkout state).
 **Endpoint**: `POST /checkout_sessions/{id}/complete`  
 **Response Status**: `200 OK`
 
-#### Input Schema
+Finalizes the checkout with payment data. MUST create an order on success.
+
+#### Input Schema (Standard)
 
 ```json
 {
@@ -196,8 +349,8 @@ Same as **Create Checkout Session** output (full checkout state).
     "phone_number": "string"
   },
   "payment_data": {                   // Required
-    "token": "string",                // Required - payment token (e.g., spt_123)
-    "provider": "stripe|adyen",       // Required - enum
+    "token": "string",                // Required - vault token (vt_...)
+    "provider": "stripe",             // Required - enum (stripe)
     "billing_address": {              // Optional - Address object
       "name": "string",
       "line_one": "string",
@@ -205,8 +358,33 @@ Same as **Create Checkout Session** output (full checkout state).
       "city": "string",
       "state": "string",
       "country": "string",
-      "postal_code": "string",
-      "phone_number": "string"
+      "postal_code": "string"
+    }
+  },
+  "affiliate_attribution": {          // Optional - affiliate tracking
+    "provider": "impact.com",
+    "token": "atp_01J8Z3WXYZ9ABC",
+    "touchpoint": "last"
+  }
+}
+```
+
+#### Input Schema (With 3DS Authentication)
+
+```json
+{
+  "buyer": { },
+  "payment_data": {
+    "token": "vt_01J8Z3WXYZ9ABC",
+    "provider": "stripe"
+  },
+  "authentication_result": {          // Required if status was authentication_required
+    "outcome": "authenticated",       // "authenticated", "denied", "canceled", "processing_error"
+    "outcome_details": {              // Required for authenticated outcome
+      "three_ds_cryptogram": "AAIBBYNoEQAAAAAAg4PyBhdAEQs=",  // Base64 encoded cryptogram
+      "electronic_commerce_indicator": "05",  // ECI value (01, 02, 05, 06, 07)
+      "transaction_id": "f38e6948-5388-41a6-bca4-b49723c19437",  // 3DS transaction ID
+      "version": "2.2.0"              // 3DS version
     }
   }
 }
@@ -219,7 +397,35 @@ Same as **Create Checkout Session** output, plus:
 ```json
 {
   "...": "...",
-  "order": {                          // Optional - created on success
+  "status": "completed|authentication_required|in_progress",
+  "authentication_metadata": {        // Present when status is authentication_required
+    "channel": {
+      "type": "browser",
+      "browser": {
+        "accept_header": "text/html,application/xhtml+xml",
+        "ip_address": "203.0.113.42",
+        "javascript_enabled": true,
+        "language": "en-US",
+        "user_agent": "Mozilla/5.0...",
+        "color_depth": 24,
+        "screen_height": 1440,
+        "screen_width": 900,
+        "timezone_offset": -480
+      }
+    },
+    "acquirer_details": {
+      "acquirer_bin": "123456",
+      "acquirer_country": "US",
+      "acquirer_merchant_id": "merchant_789",
+      "merchant_name": "Test Merchant"
+    },
+    "directory_server": "visa",
+    "flow_preference": {
+      "type": "challenge",
+      "challenge": { "type": "preferred" }
+    }
+  },
+  "order": {                          // Present when status is completed
     "id": "string",                   // Required - order ID
     "checkout_session_id": "string",  // Required
     "permalink_url": "string"         // Required - customer-accessible URL
@@ -234,9 +440,29 @@ Same as **Create Checkout Session** output, plus:
 **Endpoint**: `POST /checkout_sessions/{id}/cancel`  
 **Response Status**: `200 OK` | `405 Method Not Allowed` (if already completed/canceled)
 
+Cancels a session if not already completed or canceled.
+
 #### Input Schema
 
-None (empty body)
+```json
+{
+  "intent_trace": {                   // Optional - cancellation analytics
+    "reason_code": "shipping_cost",   // Reason for cancellation
+    "trace_summary": "User not willing to pay $10 for shipping.",
+    "metadata": {                     // Optional - additional context
+      "target_shipping_cost": 0,
+      "competitor_reference": "amazon_prime"
+    }
+  }
+}
+```
+
+**Common Reason Codes:**
+- `shipping_cost` - Shipping too expensive
+- `timing_deferred` - User plans to purchase later
+- `found_elsewhere` - Found product elsewhere
+- `price_too_high` - Total price too high
+- `changed_mind` - User changed mind
 
 #### Output Schema
 
@@ -259,16 +485,154 @@ Same as **Create Checkout Session** output.
 
 ---
 
-## Error Response
+## Capability Negotiation
+
+### Agent Capabilities
+
+Agents declare supported features when creating a session:
+
+```json
+{
+  "agent_capabilities": {
+    "interventions": {
+      "supported": [
+        "3ds", "3ds_redirect", "3ds_challenge", "3ds_frictionless",
+        "biometric", "otp", "email_verification", "sms_verification", "address_verification"
+      ],
+      "max_redirects": 1,
+      "redirect_context": "in_app",
+      "max_interaction_depth": 2,
+      "display_context": "webview"
+    },
+    "features": {
+      "async_completion": true,
+      "session_persistence": true
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `interventions.supported` | array | Intervention types the agent can handle |
+| `max_redirects` | integer | Maximum redirects in a flow (default: 0) |
+| `redirect_context` | enum | `in_app`, `external_browser`, or `none` |
+| `max_interaction_depth` | integer | Maximum nesting level (default: 1) |
+| `display_context` | enum | `native`, `webview`, `modal`, or `redirect` |
+
+### Seller Capabilities
+
+Merchants advertise their capabilities in the response:
+
+```json
+{
+  "seller_capabilities": {
+    "payment_methods": [
+      {
+        "method": "card",
+        "brands": ["visa", "mastercard", "amex"],
+        "funding_types": ["credit", "debit"]
+      },
+      "card.network_token",
+      "wallet.apple_pay",
+      "wallet.google_pay",
+      "bnpl.klarna"
+    ],
+    "interventions": {
+      "required": ["3ds"],
+      "supported": ["3ds", "3ds_challenge", "3ds_frictionless"],
+      "enforcement": "conditional"
+    },
+    "features": {
+      "partial_auth": true,
+      "saved_payment_methods": true,
+      "network_tokenization": true
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `payment_methods` | array | Supported payment method identifiers |
+| `interventions.required` | array | Interventions REQUIRED for this session |
+| `interventions.supported` | array | Interventions seller can handle |
+| `interventions.enforcement` | enum | `always`, `conditional`, or `optional` |
+
+### Supported Interventions
+
+| Intervention | Description |
+|--------------|-------------|
+| `3ds` | Generic 3D Secure (version-agnostic) |
+| `3ds2` | EMVCo 3DS 2.x protocol |
+| `3ds_redirect` | Full-page redirect for 3DS |
+| `3ds_challenge` | In-context 3DS challenge frame |
+| `3ds_frictionless` | 3DS without user interaction |
+| `biometric` | Biometric authentication |
+| `otp` | One-Time Password |
+| `email_verification` | Email verification |
+| `sms_verification` | SMS verification |
+| `address_verification` | Address confirmation |
+
+---
+
+## Error Handling
+
+### Error Response Format
 
 **Status**: `4xx` or `5xx`
 
 ```json
 {
-  "type": "invalid_request",          // Required - enum
-  "code": "request_not_idempotent",   // Required - enum
-  "message": "string",                // Required - human-readable
-  "param": "$.field"                  // Optional - JSONPath to offending field
+  "type": "invalid_request",          // Required - error type
+  "code": "requires_3ds",             // Required - specific error code
+  "message": "This checkout session requires issuer authentication.",  // Required - human-readable
+  "param": "$.authentication_result"  // Optional - JSONPath to offending field
+}
+```
+
+### Error Types
+
+| Type | Description |
+|------|-------------|
+| `invalid_request` | Client error (bad params, validation) |
+| `request_not_idempotent` | Same idempotency key, different params |
+| `processing_error` | Server-side processing failure |
+| `service_unavailable` | Service temporarily down |
+
+### Error Codes
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `missing` | 4XX | Required field missing |
+| `invalid` | 4XX | Invalid format/value |
+| `out_of_stock` | 4XX | Item unavailable |
+| `payment_declined` | 4XX | Card authorization failed |
+| `requires_sign_in` | 4XX | Customer must authenticate |
+| `requires_3ds` | 4XX | 3D Secure required |
+| `idempotency_conflict` | 409 | Different params with same key |
+
+### Session-Level Messages
+
+Sessions include a `messages[]` array with validation feedback:
+
+**Info Message:**
+```json
+{
+  "type": "info",
+  "content_type": "plain",
+  "content": "Free shipping on orders over $50"
+}
+```
+
+**Error Message:**
+```json
+{
+  "type": "error",
+  "code": "out_of_stock",
+  "content_type": "plain",
+  "content": "Item 'Blue Widget' is no longer available",
+  "param": "$.line_items[0]"
 }
 ```
 
@@ -287,49 +651,203 @@ Same as **Create Checkout Session** output.
 
 | Field        | Type   | Required | Description                    | Validation                |
 |:-------------|:-------|:---------|:-------------------------------|:--------------------------|
-| name         | string | Yes      | Recipient name                 | Max 256 chars             |
-| line_one     | string | Yes      | Address line 1                 | Max 60 chars              |
+| name         | string | No       | Recipient name                 | Max 256 chars             |
+| line_one     | string | No       | Address line 1                 | Max 60 chars              |
 | line_two     | string | No       | Address line 2                 | Max 60 chars              |
-| city         | string | Yes      | City/district/suburb           | Max 60 chars              |
-| state        | string | Yes      | State/province/region          | ISO 3166-1                |
-| country      | string | Yes      | Country code                   | ISO 3166-1                |
-| postal_code  | string | Yes      | Postal/ZIP code                | Max 20 chars              |
-| phone_number | string | No       | Phone number                   | E.164 format              |
+| city         | string | No       | City/district/suburb           | Max 60 chars              |
+| state        | string | No       | State/province/region          | ISO-3166-2 for shipping   |
+| country      | string | No       | Country code                   | ISO-3166-1 alpha-2        |
+| postal_code  | string | No       | Postal/ZIP code                | Max 20 chars              |
+
+### FulfillmentDetails
+
+| Field        | Type    | Required | Description                    |
+|:-------------|:--------|:---------|:-------------------------------|
+| name         | string  | No       | Recipient name                 |
+| phone_number | string  | No       | Phone number (E.164 format)    |
+| email        | string  | No       | Email address                  |
+| address      | Address | No       | Shipping address               |
+
+### SelectedFulfillmentOption
+
+Supports multiple selections for mixed carts (physical + digital items).
+
+| Field    | Type   | Required | Description                    |
+|:---------|:-------|:---------|:-------------------------------|
+| type     | enum   | Yes      | `shipping` or `digital`        |
+| shipping | object | Cond.    | Required when type is shipping |
+| digital  | object | Cond.    | Required when type is digital  |
+
+**shipping/digital object:**
+| Field     | Type     | Required | Description              |
+|:----------|:---------|:---------|:-------------------------|
+| option_id | string   | Yes      | Fulfillment option ID    |
+| item_ids  | string[] | Yes      | Items for this option    |
 
 ### Buyer
 
 | Field        | Type   | Required | Description        | Validation         |
 |:-------------|:-------|:---------|:-------------------|:-------------------|
 | first_name   | string | Yes      | First name         | Max 256 chars      |
-| email        | string | Yes      | Email address      | Max 256 chars      |
+| last_name    | string | Yes      | Last name          | Max 256 chars      |
+| email        | string | Yes      | Email address      | Email format       |
 | phone_number | string | No       | Phone number       | E.164 format       |
 
 ### PaymentProvider
 
 | Field                     | Type         | Required | Description                | Values              |
 |:--------------------------|:-------------|:---------|:---------------------------|:--------------------|
-| provider                  | string enum  | Yes      | Payment processor          | `stripe`, `adyen`   |
-| supported_payment_methods | string[] enum| Yes      | Accepted payment methods   | `card`              |
+| provider                  | string enum  | Yes      | Payment processor          | `stripe`            |
+| supported_payment_methods | PaymentMethod[] | Yes   | Accepted payment methods   | Array of PaymentMethod objects |
+
+### PaymentMethod
+
+| Field                    | Type         | Required | Description                | Values                                    |
+|:-------------------------|:-------------|:---------|:---------------------------|:------------------------------------------|
+| type                     | string enum  | Yes      | Payment method type        | `card`                                    |
+| supported_card_networks  | string[] enum| Yes (for card) | Supported card networks | `visa`, `mastercard`, `amex`, `discover` |
+
+### SellerCapabilities
+
+| Field            | Type         | Required | Description                | Values              |
+|:-----------------|:-------------|:---------|:---------------------------|:--------------------|
+| payment_methods  | array        | Yes      | Supported payment methods  | See below           |
+| interventions    | object       | Yes      | Intervention capabilities  | See below           |
+| features         | object       | No       | Optional features          | See below           |
+
+#### SellerCapabilities.payment_methods (detailed format)
+
+Can be strings or objects:
+- String format: `"card"`, `"card.network_token"`, `"wallet.apple_pay"`, `"bnpl.klarna"`
+- Object format with detailed info:
+
+| Field        | Type     | Required | Description                |
+|:-------------|:---------|:---------|:---------------------------|
+| method       | string   | Yes      | Payment method type        |
+| brands       | string[] | No       | Supported card brands      |
+| funding_types| string[] | No       | `credit`, `debit`, `prepaid` |
+
+#### SellerCapabilities.interventions
+
+| Field       | Type         | Required | Description                          |
+|:------------|:-------------|:---------|:-------------------------------------|
+| required    | string[]     | Yes      | Interventions REQUIRED for session   |
+| supported   | string[]     | Yes      | Interventions merchant supports      |
+| enforcement | string enum  | No       | `always`, `conditional`, or `optional` |
+
+#### SellerCapabilities.features
+
+| Field               | Type    | Required | Description                     |
+|:--------------------|:--------|:---------|:--------------------------------|
+| partial_auth        | boolean | No       | Partial authorization support   |
+| saved_payment_methods| boolean | No      | Saved payment methods support   |
+| network_tokenization| boolean | No       | Network tokenization support    |
+
+### AgentCapabilities
+
+| Field         | Type   | Required | Description                |
+|:--------------|:-------|:---------|:---------------------------|
+| interventions | object | No       | Intervention capabilities  |
+| features      | object | No       | Optional features          |
+
+#### AgentCapabilities.interventions
+
+| Field                  | Type         | Required | Description                          |
+|:-----------------------|:-------------|:---------|:-------------------------------------|
+| supported              | string[]     | No       | Supported intervention types         |
+| max_redirects          | integer      | No       | Maximum redirects agent can handle (default: 0) |
+| redirect_context       | string enum  | No       | `in_app`, `external_browser`, `none` |
+| max_interaction_depth  | integer      | No       | Maximum nesting level (default: 1)   |
+| display_context        | string enum  | No       | `native`, `webview`, `modal`, `redirect` |
+
+#### AgentCapabilities.features
+
+| Field               | Type    | Required | Description                     |
+|:--------------------|:--------|:---------|:--------------------------------|
+| async_completion    | boolean | No       | Async completion support        |
+| session_persistence | boolean | No       | Session persistence support     |
 
 ### PaymentData
 
 | Field           | Type        | Required | Description                | Values              |
 |:----------------|:------------|:---------|:---------------------------|:--------------------|
-| token           | string      | Yes      | Payment method token       | -                   |
-| provider        | string enum | Yes      | Payment processor          | `stripe`, `adyen`   |
+| token           | string      | Yes      | Vault token (`vt_...`)     | -                   |
+| provider        | string enum | Yes      | Payment processor          | `stripe`            |
 | billing_address | Address     | No       | Billing address            | -                   |
+
+### AuthenticationResult
+
+| Field           | Type        | Required | Description                |
+|:----------------|:------------|:---------|:---------------------------|
+| outcome         | string enum | Yes      | Authentication outcome (`authenticated`, `denied`, `canceled`, `processing_error`) |
+| outcome_details | object      | Conditional | Required when outcome is `authenticated` |
+
+#### AuthenticationResult.outcome_details
+
+| Field                        | Type   | Required | Description                |
+|:-----------------------------|:-------|:---------|:---------------------------|
+| three_ds_cryptogram          | string | Yes      | Base64-encoded cryptogram  |
+| electronic_commerce_indicator| string | Yes      | ECI value (`01`, `02`, `05`, `06`, `07`) |
+| transaction_id               | string | Yes      | 3DS transaction identifier |
+| version                      | string | Yes      | 3DS version (e.g., `2.2.0`) |
+
+### AuthenticationMetadata
+
+| Field            | Type   | Required | Description                |
+|:-----------------|:-------|:---------|:---------------------------|
+| channel          | object | No       | Channel information        |
+| acquirer_details | object | No       | Acquirer information       |
+| directory_server | string | No       | Directory server (e.g., `visa`) |
+| flow_preference  | object | No       | Flow preference settings   |
+
+#### AuthenticationMetadata.channel
+
+| Field   | Type   | Required | Description                |
+|:--------|:-------|:---------|:---------------------------|
+| type    | string | Yes      | `browser` or `app`         |
+| browser | object | No       | Browser details (when type is browser) |
+
+#### AuthenticationMetadata.channel.browser
+
+| Field               | Type    | Required | Description                |
+|:--------------------|:--------|:---------|:---------------------------|
+| accept_header       | string  | No       | Accept header value        |
+| ip_address          | string  | No       | Client IP address          |
+| javascript_enabled  | boolean | No       | JavaScript support         |
+| language            | string  | No       | Browser language           |
+| user_agent          | string  | No       | User agent string          |
+| color_depth         | integer | No       | Screen color depth         |
+| screen_height       | integer | No       | Screen height in pixels    |
+| screen_width        | integer | No       | Screen width in pixels     |
+| timezone_offset     | integer | No       | Timezone offset in minutes |
+
+#### AuthenticationMetadata.acquirer_details
+
+| Field               | Type   | Required | Description                |
+|:--------------------|:-------|:---------|:---------------------------|
+| acquirer_bin        | string | No       | Acquirer BIN               |
+| acquirer_country    | string | No       | Acquirer country code      |
+| acquirer_merchant_id| string | No       | Acquirer merchant ID       |
+| merchant_name       | string | No       | Merchant display name      |
 
 ### LineItem
 
-| Field       | Type    | Required | Description                              | Validation                            |
-|:------------|:--------|:---------|:-----------------------------------------|:--------------------------------------|
-| id          | string  | Yes      | Unique line item ID                      | -                                     |
-| item        | Item    | Yes      | Item reference                           | -                                     |
-| base_amount | integer | Yes      | Base price before adjustments            | >= 0                                  |
-| discount    | integer | Yes      | Discount amount                          | >= 0                                  |
-| subtotal    | integer | Yes      | Amount after adjustments                 | = base_amount - discount, >= 0        |
-| tax         | integer | Yes      | Tax amount                               | >= 0                                  |
-| total       | integer | Yes      | Final amount                             | = subtotal + tax, >= 0                |
+| Field                       | Type     | Required | Description                              | Validation                            |
+|:----------------------------|:---------|:---------|:-----------------------------------------|:--------------------------------------|
+| id                          | string   | Yes      | Unique line item ID                      | -                                     |
+| item                        | Item     | Yes      | Item reference                           | -                                     |
+| name                        | string   | No       | Display name                             | -                                     |
+| description                 | string   | No       | Product description                      | -                                     |
+| images                      | uri[]    | No       | Product images                           | -                                     |
+| unit_amount                 | integer  | No       | Per-unit price                           | >= 0                                  |
+| base_amount                 | integer  | Yes      | Base price before adjustments            | >= 0                                  |
+| discount                    | integer  | Yes      | Discount amount                          | >= 0                                  |
+| subtotal                    | integer  | Yes      | Amount after adjustments                 | = base_amount - discount, >= 0        |
+| tax                         | integer  | Yes      | Tax amount                               | >= 0                                  |
+| total                       | integer  | Yes      | Final amount                             | = subtotal + tax, >= 0                |
+| disclosures                 | array    | No       | Product disclaimers                      | -                                     |
+| custom_attributes           | array    | No       | Extended properties                      | -                                     |
+| marketplace_seller_details  | object   | No       | Seller info (for marketplaces)           | -                                     |
 
 ### Total
 
@@ -338,6 +856,7 @@ Same as **Create Checkout Session** output.
 | type         | string enum | Yes      | Total category        | `items_base_amount`, `items_discount`, `subtotal`, `discount`, `fulfillment`, `tax`, `fee`, `total` |
 | display_text | string      | Yes      | Customer-facing label | -                                                                                   |
 | amount       | integer     | Yes      | Amount in minor units | >= 0                                                                                |
+| description  | string      | No       | Optional description (for fees) | -                                                                         |
 
 ### FulfillmentOption (shipping)
 
@@ -347,9 +866,9 @@ Same as **Create Checkout Session** output.
 | id                     | string  | Yes      | Unique option ID          | Unique across options    |
 | title                  | string  | Yes      | Display title             | -                        |
 | subtitle               | string  | Yes      | Delivery estimate         | -                        |
-| carrier_info           | string  | Yes      | Carrier name              | -                        |
-| earliest_delivery_time | string  | Yes      | Earliest delivery         | RFC 3339 format          |
-| latest_delivery_time   | string  | Yes      | Latest delivery           | RFC 3339 format          |
+| carrier                | string  | No       | Carrier name (e.g., USPS) | -                        |
+| earliest_delivery_time | string  | No       | Earliest delivery         | RFC 3339 format          |
+| latest_delivery_time   | string  | No       | Latest delivery           | RFC 3339 format          |
 | subtotal               | integer | Yes      | Shipping cost             | >= 0                     |
 | tax                    | integer | Yes      | Shipping tax              | >= 0                     |
 | total                  | integer | Yes      | Total shipping cost       | = subtotal + tax         |
@@ -389,7 +908,7 @@ Same as **Create Checkout Session** output.
 
 | Field | Type        | Required | Description    | Values                                                |
 |:------|:------------|:---------|:---------------|:------------------------------------------------------|
-| type  | string enum | Yes      | Link category  | `terms_of_use`, `privacy_policy`, `seller_shop_policies` |
+| type  | string enum | Yes      | Link category  | `terms_of_use`, `privacy_policy`, `return_policy`     |
 | url   | string      | Yes      | Link URL       | -                                                     |
 
 ### Order
@@ -399,6 +918,30 @@ Same as **Create Checkout Session** output.
 | id                  | string | Yes      | Unique order ID                      |
 | checkout_session_id | string | Yes      | Associated checkout session          |
 | permalink_url       | string | Yes      | Customer-accessible order detail URL |
+
+### IntentTrace (Cancellation Analytics)
+
+| Field         | Type   | Required | Description                          |
+|:--------------|:-------|:---------|:-------------------------------------|
+| reason_code   | string | Yes      | Reason for cancellation              |
+| trace_summary | string | No       | Human-readable summary               |
+| metadata      | object | No       | Additional context data              |
+
+**Common Reason Codes:**
+- `shipping_cost` - Shipping too expensive
+- `timing_deferred` - User plans to purchase later
+- `found_elsewhere` - Found product elsewhere
+- `price_too_high` - Total price too high
+- `changed_mind` - User changed mind
+
+### AffiliateAttribution
+
+| Field        | Type   | Required | Description                          |
+|:-------------|:-------|:---------|:-------------------------------------|
+| provider     | string | Yes      | Attribution provider (e.g., `impact.com`) |
+| token        | string | Yes      | Attribution token                    |
+| publisher_id | string | No       | Publisher identifier                 |
+| touchpoint   | enum   | No       | `first` or `last` touch attribution  |
 
 ---
 
@@ -455,10 +998,113 @@ Merchants send webhook events to OpenAI for order lifecycle updates. Events are 
 
 ## Quick Reference
 
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│ CHECKOUT SESSION ENDPOINTS                                                 │
+│ POST   /checkout_sessions                      Create session (201)        │
+│ GET    /checkout_sessions/{id}                 Get session (200)           │
+│ POST   /checkout_sessions/{id}                 Update session (200)        │
+│ POST   /checkout_sessions/{id}/complete        Complete checkout (200)     │
+│ POST   /checkout_sessions/{id}/cancel          Cancel session (200)        │
+├────────────────────────────────────────────────────────────────────────────┤
+│ REQUIRED HEADERS                                                           │
+│ Authorization: Bearer {token}                                              │
+│ API-Version: 2026-01-16                                                    │
+│ Content-Type: application/json                                             │
+├────────────────────────────────────────────────────────────────────────────┤
+│ SESSION STATES                                                             │
+│ not_ready_for_payment → ready_for_payment → completed                      │
+│                              ↓                                             │
+│                    authentication_required (if 3DS)                        │
+│                              ↓                                             │
+│                         completed                                          │
+├────────────────────────────────────────────────────────────────────────────┤
+│ FULFILLMENT TYPES: shipping, digital                                       │
+│ PAYMENT PROVIDER: stripe                                                   │
+│ CARD NETWORKS: visa, mastercard, amex, discover                            │
+│ AMOUNTS: Always in minor units (cents)                                     │
+│ CURRENCY: ISO-4217 lowercase (usd, eur, etc.)                              │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Checkout Endpoints
+
 | Endpoint                            | Method | Input Required    | Status Code     |
 |:------------------------------------|:-------|:------------------|:----------------|
 | `/checkout_sessions`                | POST   | items (required)  | 201             |
 | `/checkout_sessions/{id}`           | POST   | any updates       | 200             |
 | `/checkout_sessions/{id}`           | GET    | none              | 200 / 404       |
 | `/checkout_sessions/{id}/complete`  | POST   | payment_data      | 200             |
-| `/checkout_sessions/{id}/cancel`    | POST   | none              | 200 / 405       |
+| `/checkout_sessions/{id}/cancel`    | POST   | none (optional intent_trace) | 200 / 405 |
+
+### Delegate Payment Endpoint (PSP)
+
+| Endpoint                                | Method | Input Required                      | Status Code |
+|:----------------------------------------|:-------|:------------------------------------|:------------|
+| `/agentic_commerce/delegate_payment`    | POST   | payment_method, allowance, risk_signals | 201     |
+
+### Session Status Values
+
+| Status                    | Description                                    |
+|:--------------------------|:-----------------------------------------------|
+| `not_ready_for_payment`   | Initial state, missing required data           |
+| `ready_for_payment`       | All requirements met, ready for payment        |
+| `authentication_required` | 3D Secure or other authentication required     |
+| `in_progress`             | Payment is being processed                     |
+| `completed`               | Payment processed, order created               |
+| `canceled`                | Session was canceled                           |
+
+### Supported Card Networks
+
+`visa`, `mastercard`, `amex`, `discover`
+
+### Amount Handling
+
+All monetary values are in **minor units** (cents, not dollars):
+- $20.00 = 2000
+- $99.99 = 9999
+
+Currency is ISO-4217 lowercase (e.g., `"usd"`, `"eur"`)
+
+---
+
+## Implementation Checklists
+
+### For Agents
+
+- [ ] Handle all session states (`not_ready_for_payment`, `ready_for_payment`, `authentication_required`, `in_progress`, `completed`, `canceled`)
+- [ ] Send `agent_capabilities` declaring supported interventions
+- [ ] Check `seller_capabilities` for merchant requirements
+- [ ] Validate card network is supported before collecting payment
+- [ ] Implement 3DS flow when `authentication_required`
+- [ ] Include `authentication_result` when completing 3DS sessions
+- [ ] Support `selected_fulfillment_options` array (multiple selections)
+- [ ] Use unique `Idempotency-Key` for create and complete requests
+- [ ] Handle all error codes and session messages gracefully
+- [ ] Process `fulfillment_options` and present choices to user
+
+### For Merchants
+
+- [ ] Implement all five endpoints (create, retrieve, update, complete, cancel)
+- [ ] Return authoritative cart state on every response
+- [ ] Return accurate `payment_provider` with supported card networks
+- [ ] Return `seller_capabilities` with payment methods and interventions
+- [ ] Compute and return accurate totals, tax, and fulfillment costs
+- [ ] Set session status to `authentication_required` when 3DS needed
+- [ ] Include `authentication_metadata` for agent 3DS flows
+- [ ] Validate `authentication_result` before completing transaction
+- [ ] Create order on successful completion
+- [ ] Send `order_create` webhook to agent platform
+- [ ] Use `fulfillment_details` nested structure (not flat address)
+- [ ] Support `selected_fulfillment_options[]` array
+- [ ] Implement idempotency semantics and conflict detection
+
+### Security Requirements
+
+- [ ] Use HTTPS/TLS 1.2+ for all requests
+- [ ] Validate `Authorization: Bearer {token}` header
+- [ ] Verify `API-Version` header matches supported version
+- [ ] Use `Idempotency-Key` for safe retries
+- [ ] Validate `Signature` and `Timestamp` headers (recommended)
+- [ ] Never expose raw card data in logs or responses
+- [ ] Emit flat error objects with `type/code/message/param`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@
 ### Draft Content: High-Level Overview
 
 **1. Technical Summary**
-The **Intelligent ACP Middleware** is a Python **3.12+**-based reference architecture designed to host autonomous merchant agents. It exposes five RESTful endpoints compliant with the **Agentic Commerce Protocol v2025-09-29** and utilizes the **NVIDIA NeMo Agent Toolkit** to perform real-time business logic optimization. The system uses an "Async Parallel Orchestration" pattern to ensure fast, responsive agent reasoning.
+The **Intelligent ACP Middleware** is a Python **3.12+**-based reference architecture designed to host autonomous merchant agents. It exposes five RESTful endpoints compliant with the **Agentic Commerce Protocol v2026-01-16** and utilizes the **NVIDIA NeMo Agent Toolkit** to perform real-time business logic optimization. The system uses an "Async Parallel Orchestration" pattern to ensure fast, responsive agent reasoning.
 
 **Simulator (demo client)**
 We will also build a **client agent simulator** that plays the "client" role:
@@ -51,8 +51,10 @@ graph TD
         K3[Right: Chain of Thought - Optional]
     end
 
-    subgraph "Payments"
-        P[PSP (delegated payments)]
+    subgraph "Payments (PSP)"
+        P1[delegate_payment → vt_...]
+        P2[create_and_process_payment_intent → pi_...]
+        P3[3DS Authentication]
     end
 
     subgraph "Webhooks"
@@ -67,8 +69,11 @@ graph TD
     A -.->|Simulation View| K1
     B & C -.->|JSON/Protocol State| K2
     D & E & F -.->|Agent Reasoning| K3
-    B -->|complete checkout (token)| P
-    A -->|delegate payment (vt_...)| P
+    A -->|delegate payment| P1
+    P1 -->|vault token| A
+    B -->|complete checkout (token)| P2
+    P2 -.->|3DS required?| P3
+    P3 -->|authentication_result| B
     F -->|Post-purchase events| W
 
 ```
@@ -88,9 +93,23 @@ graph TD
   2. Simulator displays 4 product cards with images and prices
   3. User clicks a product to start checkout via ACP protocol
 * **Static Product Catalog**: 4 pre-populated products stored in SQLite.
-* **Delegated payments (PSP)**:
-  * Client calls `POST /agentic_commerce/delegate_payment` → `vt_...` (idempotent by `Idempotency-Key`)
-  * Merchant calls `POST /agentic_commerce/create_and_process_payment_intent` → `pi_...`, token becomes `consumed`
+* **Delegated Payments (PSP)** - ACP-compliant payment flow:
+  1. **Client/Agent obtains vault token**: `POST /agentic_commerce/delegate_payment`
+     - Sends: `payment_method` (card details), `allowance` (constraints), `risk_signals`
+     - Requires: `Idempotency-Key` header for safe retries
+     - Returns: Vault token `vt_...` with metadata
+  2. **Client/Agent completes checkout**: `POST /checkout_sessions/{id}/complete`
+     - Sends: `payment_data` with vault token and provider
+     - May return: `status: authentication_required` (3DS needed)
+  3. **3D Secure flow** (if required):
+     - Session returns `authentication_metadata` with challenge URL
+     - Client redirects user or embeds 3DS challenge
+     - After 3DS completion, client calls complete again with `authentication_result`
+  4. **Merchant processes payment**: Calls PSP `create_and_process_payment_intent`
+     - Validates vault token is `active` and not expired
+     - Validates amount within `allowance.max_amount`
+     - Marks vault token as `consumed` (single-use)
+     - Creates order on success
 * **Global Webhook Delivery**: Post-purchase shipping pulses are delivered to a **single global webhook URL** configured at the application level. The Post-Purchase Agent uses the **Brand Persona** to generate multilingual updates.
 * **Configurable NIM Endpoint**: Supports both NVIDIA hosted API and local Docker deployment via environment variable.
 * **API Key Auth**: All ACP endpoints require an API key (e.g., `Authorization: Bearer <API_KEY>` or `X-API-Key: <API_KEY>`). Unauthorized requests return 401/403.

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,6 +20,7 @@ This document breaks down the project requirements into discrete, implementable 
 | 10 | Multi-Panel Protocol Inspector UI | P2 | Feature 9 | |
 | 11 | Webhook Integration | P2 | Feature 8 | |
 | 12 | Agent Panel Checkout Flow Simulation | P1 | Feature 9 | ✅ Complete |
+| 13 | Integration of UI and ACP Server | P1 | Features 3, 5, 9, 12 | |
 
 ---
 
@@ -158,9 +159,11 @@ This document breaks down the project requirements into discrete, implementable 
 - [x] Implement all 5 endpoints
 - [x] Handle session state transitions:
   ```
-  not_ready_for_payment → ready_for_payment → completed
-                       ↘                   ↘
-                         →    canceled    ←
+  not_ready_for_payment → ready_for_payment → in_progress → completed
+                       ↘                   ↘              ↘
+                         →      canceled      ←─────────────┘
+                                    ↑
+                    authentication_required (if 3DS) ─────────┘
   ```
 - [x] Calculate line_items totals (base_amount, discount, tax, total)
 - [x] Generate fulfillment_options based on address
@@ -208,25 +211,32 @@ This document breaks down the project requirements into discrete, implementable 
 
 ## Feature 5: PSP - Delegated Payments
 
-**Goal**: Implement the demo Payment Service Provider for vault tokens and payment intents.
+**Goal**: Implement the Payment Service Provider for delegated vault tokens with proper ACP compliance, including 3D Secure authentication support.
+
+**Key Principle**: Agents never see actual card data. They receive opaque vault tokens (`vt_...`) with explicit usage constraints. Payments stay on merchant rails via Stripe.
 
 ### Database Tables
 
 ```sql
 vault_tokens:
-  - id (vt_...)
-  - idempotency_key (unique)
-  - payment_method (json)
-  - allowance (json: max_amount, currency, expires_at, merchant_id, checkout_session_id)
-  - status (active | consumed)
+  - id (vt_01J8Z3...)           -- Unique token ID
+  - idempotency_key (unique)    -- For safe retries
+  - payment_method (json)       -- PaymentMethodCard schema
+  - allowance (json)            -- Constraints: max_amount, currency, expires_at, etc.
+  - billing_address (json)      -- Optional billing address
+  - risk_signals (json)         -- Array of risk assessments
+  - status (active | consumed)  -- Token lifecycle state
   - created_at
+  - metadata (json)             -- source, merchant_id, etc.
 
 payment_intents:
   - id (pi_...)
   - vault_token_id (fk)
   - amount
   - currency
-  - status (pending | completed)
+  - status (pending | requires_authentication | completed | failed)
+  - authentication_metadata (json)  -- For 3DS flow
+  - authentication_result (json)    -- 3DS outcome
   - created_at
   - completed_at
 
@@ -241,29 +251,276 @@ idempotency_store:
 ### Endpoints
 
 #### 5.1 Delegate Payment
+
+Creates a vault token with constrained allowance for agent-initiated payments.
+
 - **Endpoint**: `POST /agentic_commerce/delegate_payment`
+- **API Version**: `2026-01-16`
 - **Status**: `201 Created`
-- **Input**: Card details (simulated), allowance parameters
-- **Output**: Vault token `vt_xxx`
-- **Idempotency**: Same key + same request → cached response; different request → 409
+- **Headers**:
+  - `Authorization: Bearer {token}`
+  - `Content-Type: application/json`
+  - `API-Version: 2025-09-29`
+  - `Idempotency-Key: {unique-key}` (required)
+
+**Request Schema**:
+```json
+{
+  "payment_method": {
+    "type": "card",
+    "card_number_type": "fpan",
+    "virtual": false,
+    "number": "4242424242424242",
+    "exp_month": "12",
+    "exp_year": "2027",
+    "name": "John Doe",
+    "cvc": "123",
+    "display_card_funding_type": "credit",
+    "display_brand": "visa",
+    "display_last4": "4242"
+  },
+  "allowance": {
+    "reason": "one_time",
+    "max_amount": 5000,
+    "currency": "usd",
+    "checkout_session_id": "cs_abc123",
+    "merchant_id": "merchant_xyz",
+    "expires_at": "2025-12-01T12:00:00Z"
+  },
+  "risk_signals": [
+    {
+      "type": "card_testing",
+      "score": 10,
+      "action": "authorized"
+    }
+  ],
+  "billing_address": {
+    "name": "John Doe",
+    "line_one": "123 Main St",
+    "city": "San Francisco",
+    "state": "CA",
+    "country": "US",
+    "postal_code": "94102"
+  }
+}
+```
+
+**Response Schema** (201 Created):
+```json
+{
+  "id": "vt_01J8Z3WXYZ9ABC",
+  "created": "2025-09-29T11:00:00Z",
+  "metadata": {
+    "source": "agent_checkout",
+    "merchant_id": "merchant_xyz",
+    "idempotency_key": "idem_abc123"
+  }
+}
+```
+
+**Idempotency Behavior**:
+- Same key + same request → cached response (201)
+- Same key + different request → 409 Conflict
 
 #### 5.2 Create and Process Payment Intent
+
+Called by merchant backend to process payment using the vault token.
+
 - **Endpoint**: `POST /agentic_commerce/create_and_process_payment_intent`
-- **Status**: `200 OK`
+- **Status**: `200 OK` | `202 Accepted` (if 3DS required)
 - **Input**: Vault token `vt_xxx`, amount, currency
-- **Output**: Payment intent `pi_xxx` with `status: completed`
-- **Logic**:
-  - Validate token is `active` and not expired
-  - Validate amount/currency within allowance
-  - Create payment intent
-  - Mark vault token as `consumed`
+- **Output**: Payment intent `pi_xxx` with status
+
+**Request Schema**:
+```json
+{
+  "vault_token": "vt_01J8Z3WXYZ9ABC",
+  "amount": 3200,
+  "currency": "usd",
+  "checkout_session_id": "cs_abc123"
+}
+```
+
+**Response Schema** (Success):
+```json
+{
+  "id": "pi_xyz789",
+  "vault_token_id": "vt_01J8Z3WXYZ9ABC",
+  "amount": 3200,
+  "currency": "usd",
+  "status": "completed",
+  "created_at": "2025-09-29T11:05:00Z",
+  "completed_at": "2025-09-29T11:05:02Z"
+}
+```
+
+**Response Schema** (3DS Required):
+```json
+{
+  "id": "pi_xyz789",
+  "status": "requires_authentication",
+  "authentication_metadata": {
+    "redirect_url": "https://3ds.example.com/challenge/abc",
+    "acquirer_details": { },
+    "directory_server_info": { }
+  }
+}
+```
+
+**Processing Logic**:
+1. Validate vault token is `active` and not expired
+2. Validate amount ≤ `max_amount` and currency matches
+3. Check if 3DS authentication is required (based on risk, card issuer)
+4. If 3DS required: return `requires_authentication` with metadata
+5. If no 3DS: create Stripe PaymentIntent, capture payment
+6. Mark vault token as `consumed`
+7. Return completed payment intent
+
+### PaymentMethodCard Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Must be `"card"` |
+| `card_number_type` | enum | Yes | `"fpan"` or `"network_token"` |
+| `virtual` | boolean | Yes | Whether card is virtual/digital |
+| `number` | string | Yes | Card number (FPAN, DPAN, or network token) |
+| `exp_month` | string | Yes | Expiry month (`"01"`-`"12"`) |
+| `exp_year` | string | Yes | Four-digit expiry year |
+| `name` | string | No | Cardholder name |
+| `cvc` | string | No | Card verification code (max 4 chars) |
+| `cryptogram` | string | No | For tokenized cards |
+| `eci_value` | string | No | Electronic Commerce Indicator (max 2 chars) |
+| `checks_performed` | array | No | `["avs", "cvv", "ani", "auth0"]` |
+| `iin` | string | No | Issuer Identification Number (max 6 chars) |
+| `display_card_funding_type` | enum | Yes | `"credit"`, `"debit"`, or `"prepaid"` |
+| `display_wallet_type` | string | No | e.g., `"apple_pay"` |
+| `display_brand` | string | No | e.g., `"visa"`, `"amex"` |
+| `display_last4` | string | Yes | Last 4 digits (pattern: `^[0-9]{4}$`) |
+| `metadata` | object | No | Additional data (issuing bank, etc.) |
+
+### Allowance Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `reason` | string | Yes | Must be `"one_time"` |
+| `max_amount` | integer | Yes | Max amount in minor units (e.g., $20 = 2000) |
+| `currency` | string | Yes | ISO-4217 lowercase (e.g., `"usd"`) |
+| `checkout_session_id` | string | Yes | Associated checkout session |
+| `merchant_id` | string | Yes | Merchant identifier (max 256 chars) |
+| `expires_at` | string | Yes | RFC 3339 timestamp |
+
+### RiskSignal Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Must be `"card_testing"` |
+| `score` | integer | No | Risk score (0-100) |
+| `action` | enum | Yes | `"blocked"`, `"manual_review"`, or `"authorized"` |
+
+### 3D Secure Authentication
+
+When 3DS is required, the payment flow includes an authentication step.
+
+**Authentication Flow**:
+```
+1. create_and_process_payment_intent returns status: "requires_authentication"
+   └─ Includes authentication_metadata (redirect URL, acquirer details)
+
+2. Agent/UI performs 3DS challenge:
+   └─ Redirect user to 3DS URL or embed challenge iframe
+
+3. After 3DS completion, call endpoint with authentication_result:
+   └─ outcome, cryptogram, ECI, transaction_id, version
+```
+
+**AuthenticationResult Schema**:
+```json
+{
+  "authentication_result": {
+    "outcome": "authenticated",
+    "outcome_details": {
+      "three_ds_cryptogram": "AAIBBYNoEQAAAAAAg4PyBhdAEQs=",
+      "electronic_commerce_indicator": "05",
+      "transaction_id": "f38e6948-5388-41a6-bca4-b49723c19437",
+      "version": "2.2.0"
+    }
+  }
+}
+```
+
+**Authentication Outcomes**:
+
+| Outcome | Description |
+|---------|-------------|
+| `authenticated` | Successfully authenticated |
+| `denied` | Authentication denied by issuer |
+| `canceled` | User canceled authentication |
+| `processing_error` | Error during authentication |
+
+**ECI Values**:
+
+| Value | Meaning |
+|-------|---------|
+| `01` | 3DS1 authentication attempted (Mastercard) |
+| `02` | 3DS1 successful authentication (Mastercard) |
+| `05` | 3DS2 successful authentication (Visa) |
+| `06` | 3DS2 attempted (Visa) |
+| `07` | Non-authenticated (fallback) |
+
+### Error Handling
+
+| HTTP | Type | Code | Description |
+|------|------|------|-------------|
+| 400 | `invalid_request` | `invalid_card` | Invalid card field |
+| 400 | `invalid_request` | `missing` | Required field missing |
+| 409 | `invalid_request` | `idempotency_conflict` | Different params with same Idempotency-Key |
+| 409 | `invalid_request` | `token_consumed` | Vault token already used |
+| 410 | `invalid_request` | `token_expired` | Vault token has expired |
+| 422 | `invalid_request` | `amount_exceeded` | Amount exceeds allowance max_amount |
+| 422 | `invalid_request` | `currency_mismatch` | Currency doesn't match allowance |
+| 429 | `rate_limit_exceeded` | `too_many_requests` | Rate limited |
+| 500 | `processing_error` | `internal_server_error` | Server error |
+| 503 | `service_unavailable` | `service_unavailable` | Service down |
+
+### Tasks
+
+- [ ] Create SQLModel models for `VaultToken` and `PaymentIntent`
+- [ ] Implement `delegate_payment` endpoint with full schema validation
+  - [ ] Validate PaymentMethodCard schema (all required fields)
+  - [ ] Validate Allowance constraints
+  - [ ] Require at least one RiskSignal
+  - [ ] Store billing_address if provided
+- [ ] Implement idempotency handling
+  - [ ] Hash request body for comparison
+  - [ ] Return cached response for matching key + request
+  - [ ] Return 409 for matching key + different request
+- [ ] Implement `create_and_process_payment_intent` endpoint
+  - [ ] Validate vault token status and expiration
+  - [ ] Validate amount/currency against allowance
+  - [ ] Integrate with Stripe for actual payment processing
+  - [ ] Handle 3DS authentication flow
+- [ ] Implement 3D Secure support
+  - [ ] Detect when 3DS is required (risk-based)
+  - [ ] Return authentication_metadata
+  - [ ] Accept and validate authentication_result
+- [ ] Add comprehensive error handling with proper codes
+- [ ] Create unit tests for all scenarios
 
 ### Acceptance Criteria
 
-- Vault tokens are created with proper allowances
-- Idempotency works correctly (same key → same response)
-- Payment intents consume vault tokens (single-use)
-- Expired/consumed tokens are rejected
+- [ ] Vault tokens are created with proper allowances and constraints
+- [ ] PaymentMethodCard schema is fully validated (type, card_number_type, display fields)
+- [ ] At least one RiskSignal is required for delegate_payment
+- [ ] Idempotency works correctly:
+  - Same key + same request → cached 201 response
+  - Same key + different request → 409 Conflict
+- [ ] Payment intents validate against allowance constraints
+- [ ] Payment intents consume vault tokens (single-use)
+- [ ] Expired tokens are rejected with 410 Gone
+- [ ] Consumed tokens are rejected with 409 Conflict
+- [ ] 3DS flow returns proper authentication_metadata when required
+- [ ] 3DS authentication_result is validated before completing payment
+- [ ] All amounts are handled in minor units (cents)
 
 ---
 
@@ -634,6 +891,523 @@ Recommended animation properties:
 
 ---
 
+## Feature 13: Integration of UI and ACP Server
+
+**Goal**: Connect the frontend checkout flow to the real ACP backend endpoints, enabling end-to-end transactions from product selection through payment completion, including 3D Secure authentication support.
+
+**Key Principle**: The UI acts as the agent, collecting user input and orchestrating API calls. Actual card data is tokenized via the PSP's `delegate_payment` endpoint—the merchant backend only receives opaque vault tokens.
+
+### Overview
+
+This feature replaces the mock data flow in the Agent Panel with actual API calls to the merchant backend and PSP, creating a fully functional checkout experience that follows the ACP payment protocol.
+
+### Checkout Session States
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           CHECKOUT SESSION STATES                           │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   CREATE SESSION                                                            │
+│        ↓                                                                    │
+│   [not_ready_for_payment] ←── Missing required data (address, items)        │
+│        │                                                                    │
+│        ↓ UPDATE SESSION (add fulfillment, fix issues)                       │
+│   [ready_for_payment]                                                       │
+│        │                                                                    │
+│        ├──→ COMPLETE (no 3DS) ──→ [in_progress] ──→ [completed] + order     │
+│        │                                                                    │
+│        └──→ COMPLETE (3DS needed) ──→ [authentication_required]             │
+│                                              │                              │
+│                                              ↓                              │
+│                                        User completes 3DS                   │
+│                                              │                              │
+│                                              ↓                              │
+│                                   COMPLETE with auth_result                 │
+│                                              │                              │
+│                                              ↓                              │
+│                                        [completed] + order                  │
+│                                                                             │
+│   CANCEL SESSION (any non-final state) ──→ [canceled]                       │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Session Status Values:**
+
+| Status | Description |
+|--------|-------------|
+| `not_ready_for_payment` | Initial state, missing required data (fulfillment address, valid items) |
+| `ready_for_payment` | All requirements met, ready to accept payment |
+| `authentication_required` | 3D Secure or other authentication is required |
+| `in_progress` | Payment is being processed |
+| `completed` | Successfully completed with order created |
+| `canceled` | Session has been canceled |
+
+### Integration Flow
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Product Grid   │────▶│  Create Session │────▶│  Update Session │────▶│    Complete     │
+│    (Display)    │     │   (Backend)     │     │   (Backend)     │     │   (PSP + ACP)   │
+└─────────────────┘     └─────────────────┘     └─────────────────┘     └─────────────────┘
+        │                       │                       │                       │
+        ▼                       ▼                       ▼                       ▼
+   UI displays            POST /checkout_         POST /checkout_         1. UI calls PSP
+   products from          sessions               sessions/{id}              delegate_payment
+   mock data or           - Send items,          - Update quantity,      2. PSP returns vault
+   product API              fulfillment_details    shipping option          token (vt_xxx)
+                          - Send agent_          - Session transitions   3. UI calls POST
+                            capabilities           to ready_for_payment     /checkout_sessions
+                          - Receive session,                                /{id}/complete
+                            payment_provider,                            4. IF 3DS required:
+                            seller_capabilities                             handle auth flow
+                                                                         5. Backend processes
+                                                                            payment via Stripe
+                                                                         6. Order created
+```
+
+### API Interactions
+
+#### 13.1 Product Selection → Create Checkout Session
+
+When user clicks a product card:
+
+- **Endpoint**: `POST /checkout_sessions`
+- **API Version**: `2026-01-16`
+- **Request**:
+  ```json
+  {
+    "items": [
+      {
+        "id": "prod_1",
+        "quantity": 1
+      }
+    ],
+    "fulfillment_details": {
+      "name": "John Doe",
+      "phone_number": "15551234567",
+      "email": "john@example.com",
+      "address": {
+        "name": "John Doe",
+        "line_one": "123 Main St",
+        "city": "San Francisco",
+        "state": "CA",
+        "country": "US",
+        "postal_code": "94102"
+      }
+    },
+    "agent_capabilities": {
+      "interventions": {
+        "supported": ["3ds", "3ds_redirect", "3ds_challenge"],
+        "max_redirects": 1,
+        "redirect_context": "in_app",
+        "display_context": "webview"
+      }
+    }
+  }
+  ```
+
+- **Response**:
+  ```json
+  {
+    "id": "cs_abc123",
+    "status": "not_ready_for_payment",
+    "currency": "usd",
+    "payment_provider": {
+      "provider": "stripe",
+      "supported_payment_methods": [
+        {
+          "type": "card",
+          "supported_card_networks": ["visa", "mastercard", "amex", "discover"]
+        }
+      ]
+    },
+    "seller_capabilities": {
+      "payment_methods": [
+        {
+          "method": "card",
+          "brands": ["visa", "mastercard", "amex"],
+          "funding_types": ["credit", "debit"]
+        }
+      ],
+      "interventions": {
+        "required": [],
+        "supported": ["3ds", "3ds_challenge", "3ds_frictionless"],
+        "enforcement": "conditional"
+      }
+    },
+    "totals": [
+      { "type": "subtotal", "display_text": "Subtotal", "amount": 2500 },
+      { "type": "tax", "display_text": "Tax", "amount": 200 },
+      { "type": "fulfillment", "display_text": "Shipping", "amount": 0 },
+      { "type": "total", "display_text": "Total", "amount": 2700 }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "ship_standard",
+        "title": "Standard Shipping",
+        "subtitle": "5-7 business days",
+        "carrier": "USPS",
+        "earliest_delivery_time": "2026-01-28T00:00:00Z",
+        "latest_delivery_time": "2026-01-30T23:59:59Z",
+        "subtotal": 500,
+        "tax": 0,
+        "total": 500
+      }
+    ],
+    "messages": [],
+    "links": []
+  }
+  ```
+- **UI Action**: 
+  - Store session ID
+  - Check `payment_provider.supported_payment_methods` to know which card networks are supported
+  - Check `seller_capabilities` to understand 3DS requirements
+  - Transition to checkout view
+
+#### 13.2 Quantity/Shipping Updates → Update Checkout Session
+
+When user changes quantity or selects shipping option:
+
+- **Endpoint**: `POST /checkout_sessions/{id}`
+- **Request** (quantity update):
+  ```json
+  {
+    "items": [
+      {
+        "id": "prod_1",
+        "quantity": 2
+      }
+    ]
+  }
+  ```
+- **Request** (fulfillment selection using new `selected_fulfillment_options` array):
+  ```json
+  {
+    "selected_fulfillment_options": [
+      {
+        "type": "shipping",
+        "shipping": {
+          "option_id": "ship_standard",
+          "item_ids": ["prod_1"]
+        }
+      }
+    ]
+  }
+  ```
+- **Response**: Updated checkout session with recalculated totals
+  - Status transitions to `ready_for_payment` when all required fields are present
+- **UI Action**: 
+  - Update displayed totals
+  - Enable Pay button when `status: ready_for_payment`
+
+#### 13.3 Payment Flow → PSP + Complete Checkout
+
+When user clicks Pay button:
+
+**Step 1: Get Vault Token from PSP**
+
+- **Endpoint**: `POST /agentic_commerce/delegate_payment`
+- **API Version**: `2026-01-16`
+- **Headers**:
+  - `Authorization: Bearer {token}`
+  - `Content-Type: application/json`
+  - `API-Version: 2025-09-29`
+  - `Idempotency-Key: {unique-key}`
+- **Request**:
+  ```json
+  {
+    "payment_method": {
+      "type": "card",
+      "card_number_type": "fpan",
+      "virtual": false,
+      "number": "4242424242424242",
+      "exp_month": "12",
+      "exp_year": "2027",
+      "name": "John Doe",
+      "cvc": "123",
+      "display_card_funding_type": "credit",
+      "display_brand": "visa",
+      "display_last4": "4242"
+    },
+    "allowance": {
+      "reason": "one_time",
+      "max_amount": 3200,
+      "currency": "usd",
+      "checkout_session_id": "cs_abc123",
+      "merchant_id": "merchant_xyz",
+      "expires_at": "2026-01-21T12:00:00Z"
+    },
+    "risk_signals": [
+      {
+        "type": "card_testing",
+        "score": 10,
+        "action": "authorized"
+      }
+    ],
+    "billing_address": {
+      "name": "John Doe",
+      "line_one": "123 Main St",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "US",
+      "postal_code": "94102"
+    }
+  }
+  ```
+- **Response**:
+  ```json
+  {
+    "id": "vt_01J8Z3WXYZ9ABC",
+    "created": "2026-01-21T11:00:00Z",
+    "metadata": {
+      "source": "agent_checkout",
+      "merchant_id": "merchant_xyz"
+    }
+  }
+  ```
+
+**Step 2: Complete Checkout with Merchant**
+
+- **Endpoint**: `POST /checkout_sessions/{id}/complete`
+- **Request**:
+  ```json
+  {
+    "payment_data": {
+      "token": "vt_01J8Z3WXYZ9ABC",
+      "provider": "stripe",
+      "billing_address": {
+        "name": "John Doe",
+        "line_one": "123 Main St",
+        "city": "San Francisco",
+        "state": "CA",
+        "country": "US",
+        "postal_code": "94102"
+      }
+    }
+  }
+  ```
+
+**Response (Success - No 3DS)**:
+```json
+{
+  "id": "cs_abc123",
+  "status": "completed",
+  "order": {
+    "id": "order_xyz789",
+    "checkout_session_id": "cs_abc123",
+    "permalink_url": "https://merchant.com/orders/xyz789"
+  }
+}
+```
+
+**Response (3DS Required)**:
+```json
+{
+  "id": "cs_abc123",
+  "status": "authentication_required",
+  "authentication_metadata": {
+    "redirect_url": "https://3ds.stripe.com/challenge/abc",
+    "acquirer_details": { },
+    "directory_server_info": { }
+  },
+  "messages": [
+    {
+      "type": "error",
+      "code": "requires_3ds",
+      "param": "$.authentication_result",
+      "content_type": "plain",
+      "content": "This checkout session requires issuer authentication"
+    }
+  ]
+}
+```
+
+**Step 3: Handle 3DS Authentication (if required)**
+
+If session status is `authentication_required`:
+
+1. UI redirects user to `authentication_metadata.redirect_url` or embeds 3DS challenge iframe
+2. User completes 3DS verification with their bank
+3. 3DS provider returns authentication result
+4. UI calls complete endpoint again with `authentication_result`:
+
+```json
+{
+  "payment_data": {
+    "token": "vt_01J8Z3WXYZ9ABC",
+    "provider": "stripe"
+  },
+  "authentication_result": {
+    "outcome": "authenticated",
+    "outcome_details": {
+      "three_ds_cryptogram": "AAIBBYNoEQAAAAAAg4PyBhdAEQs=",
+      "electronic_commerce_indicator": "05",
+      "transaction_id": "f38e6948-5388-41a6-bca4-b49723c19437",
+      "version": "2.2.0"
+    }
+  }
+}
+```
+
+### Tasks
+
+- [ ] Create API client service in UI (`lib/api-client.ts`)
+  - [ ] Configure base URL and authentication headers
+  - [ ] Add `API-Version` header support
+  - [ ] Implement `Idempotency-Key` generation for payment requests
+  - [ ] Implement error handling and retry logic
+  - [ ] Add request/response type definitions matching ACP schemas
+- [ ] Update `useCheckoutFlow` hook to call real APIs
+  - [ ] Send `agent_capabilities` in session creation
+  - [ ] Parse `payment_provider` and `seller_capabilities` from response
+  - [ ] Validate card network against `supported_card_networks` before payment
+  - [ ] Handle all session states including `authentication_required`
+  - [ ] Implement session updates on quantity/shipping changes
+- [ ] Implement PSP integration in UI
+  - [ ] Create payment form with proper PaymentMethodCard fields
+  - [ ] Call PSP `delegate_payment` endpoint with full schema
+  - [ ] Include at least one RiskSignal in request
+  - [ ] Handle vault token response
+- [ ] Implement 3D Secure flow
+  - [ ] Detect `authentication_required` status
+  - [ ] Redirect user to 3DS challenge URL or embed iframe
+  - [ ] Capture authentication_result after 3DS completion
+  - [ ] Call complete endpoint with authentication_result
+  - [ ] Handle all authentication outcomes (authenticated, denied, canceled, processing_error)
+- [ ] Update `CheckoutCard` component
+  - [ ] Pass vault token and provider to complete endpoint
+  - [ ] Display loading states during API calls
+  - [ ] Show 3DS challenge UI when required
+  - [ ] Handle and display API errors gracefully
+- [ ] Update `ConfirmationCard` component
+  - [ ] Display real order data from API response
+  - [ ] Show order ID and `permalink_url` for order tracking
+- [ ] Add environment configuration
+  - [ ] `NEXT_PUBLIC_API_URL` for merchant backend
+  - [ ] `NEXT_PUBLIC_PSP_URL` for PSP endpoints
+  - [ ] `NEXT_PUBLIC_API_VERSION` for version header
+- [ ] Implement error handling UI
+  - [ ] Network error states with retry
+  - [ ] Validation error display (`missing`, `invalid` codes)
+  - [ ] Payment failure handling (`payment_declined`)
+  - [ ] Out of stock handling (`out_of_stock`)
+  - [ ] 3DS failure handling (`requires_3ds`, `denied`, `canceled`)
+- [ ] Add loading states and optimistic updates
+  - [ ] Skeleton loaders during API calls
+  - [ ] Disable buttons during processing
+  - [ ] Show processing indicator during payment and 3DS
+
+### State Management
+
+```typescript
+type SessionStatus = 
+  | 'not_ready_for_payment' 
+  | 'ready_for_payment' 
+  | 'authentication_required' 
+  | 'in_progress'
+  | 'completed' 
+  | 'canceled';
+
+interface PaymentProvider {
+  provider: 'stripe';
+  supported_payment_methods: Array<{
+    type: 'card';
+    supported_card_networks: Array<'visa' | 'mastercard' | 'amex' | 'discover'>;
+  }>;
+}
+
+interface SellerCapabilities {
+  payment_methods: string[];
+  interventions: {
+    required: string[];
+    supported: string[];
+  };
+}
+
+interface CheckoutSession {
+  id: string;
+  status: SessionStatus;
+  payment_provider: PaymentProvider;
+  seller_capabilities: SellerCapabilities;
+  totals: {
+    subtotal: number;
+    tax: number;
+    shipping: number;
+    total: number;
+    currency: string;
+  };
+  fulfillment_options: FulfillmentOption[];
+  authentication_metadata?: AuthenticationMetadata;
+  order?: Order;
+  messages: Message[];
+  links: Link[];
+}
+
+interface CheckoutState {
+  sessionId: string | null;
+  session: CheckoutSession | null;
+  vaultToken: string | null;
+  authenticationResult: AuthenticationResult | null;
+  isLoading: boolean;
+  is3DSPending: boolean;
+  error: string | null;
+}
+
+type CheckoutAction =
+  | { type: 'CREATE_SESSION_START' }
+  | { type: 'CREATE_SESSION_SUCCESS'; payload: CheckoutSession }
+  | { type: 'UPDATE_SESSION_START' }
+  | { type: 'UPDATE_SESSION_SUCCESS'; payload: CheckoutSession }
+  | { type: 'DELEGATE_PAYMENT_SUCCESS'; payload: string }
+  | { type: 'COMPLETE_CHECKOUT_START' }
+  | { type: 'COMPLETE_CHECKOUT_SUCCESS'; payload: CheckoutSession }
+  | { type: 'AUTHENTICATION_REQUIRED'; payload: CheckoutSession }
+  | { type: 'AUTHENTICATION_COMPLETE'; payload: AuthenticationResult }
+  | { type: 'SET_ERROR'; payload: string }
+  | { type: 'RESET' };
+```
+
+### Error Handling
+
+| HTTP | Code | Error Scenario | UI Behavior |
+|------|------|---------------|-------------|
+| 400 | `missing` | Required field missing | Highlight missing fields, show validation errors |
+| 400 | `invalid` | Invalid format/value | Show specific field errors |
+| 400 | `out_of_stock` | Item unavailable | Show out of stock message, offer alternatives |
+| 401 | - | Unauthorized | Redirect to login or show auth error |
+| 404 | - | Session not found | Redirect to product grid, show error toast |
+| 405 | - | Invalid state transition | Show error message, refresh session state |
+| 409 | `idempotency_conflict` | Duplicate request with different params | Generate new idempotency key, retry |
+| 422 | `payment_declined` | Card authorization failed | Show decline message, allow retry |
+| 422 | `requires_3ds` | 3D Secure required | Initiate 3DS flow |
+| 500 | - | Server error | Show generic error, offer retry |
+| 503 | - | Service unavailable | Show maintenance message, auto-retry |
+
+### Acceptance Criteria
+
+- [ ] Clicking a product creates a real checkout session via API with `agent_capabilities`
+- [ ] UI correctly parses `payment_provider` and `seller_capabilities` from response
+- [ ] Card network is validated against `supported_card_networks` before payment
+- [ ] Quantity changes update the session and recalculate totals
+- [ ] Shipping option selection updates session with fulfillment details
+- [ ] Pay button is disabled until session reaches `ready_for_payment` status
+- [ ] Payment flow successfully obtains vault token from PSP with proper schema
+- [ ] At least one `risk_signal` is included in delegate_payment request
+- [ ] Complete endpoint processes payment and creates order
+- [ ] 3DS flow is handled when `authentication_required` status is returned
+- [ ] Authentication result is properly captured and sent to complete endpoint
+- [ ] All authentication outcomes are handled (success, denied, canceled, error)
+- [ ] Confirmation displays real order details including `permalink_url`
+- [ ] Loading states are shown during all API operations
+- [ ] All ACP error codes are handled with user-friendly messages
+- [ ] Session state is preserved on page refresh (via session ID in URL or storage)
+- [ ] All amounts are displayed in proper format (minor units converted to dollars)
+
+---
+
 ## Implementation Order
 
 ### Phase 1: Foundation (Features 1-4)
@@ -652,13 +1426,14 @@ Add payment processing and intelligent agents.
 7. **Feature 7**: Recommendation Agent
 8. **Feature 8**: Post-Purchase Agent
 
-### Phase 3: Experience (Features 9-12)
-Build the frontend and observability layer.
+### Phase 3: Experience (Features 9-13)
+Build the frontend, observability layer, and backend integration.
 
 9. **Feature 9**: Client Agent Simulator
 10. **Feature 10**: Multi-Panel Protocol Inspector
 11. **Feature 11**: Webhook Integration
 12. **Feature 12**: Agent Panel Checkout Flow Simulation
+13. **Feature 13**: Integration of UI and ACP Server
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates all documentation in `docs/` to align with ACP v2026-01-16 specification
- Adds comprehensive capability negotiation section for agents and merchants
- Expands schema definitions with new fields from the checkout sessions guide

## Changes

### API Version
- Updated API version from `2025-09-12`/`2025-09-29` to `2026-01-16`

### Session States
- Added `in_progress` state to session state machine
- Improved state machine diagrams with visual box format

### Capability Negotiation (New Section)
- `agent_capabilities`: supported interventions, max_redirects, redirect_context, display_context
- `seller_capabilities`: payment methods (detailed), interventions with enforcement, features

### Fulfillment Options
- Added `fulfillment_details` nested structure (name, phone, email, address)
- Added `selected_fulfillment_options` array for mixed carts (physical + digital)

### Cancel Endpoint
- Added `intent_trace` optional input for cancellation analytics

### Authentication
- Expanded `authentication_metadata` with channel/browser details and acquirer info

### Object Definitions
- Updated `LineItem` with optional fields (name, description, images, etc.)
- Added `FulfillmentDetails`, `SelectedFulfillmentOption`, `IntentTrace`, `AffiliateAttribution`
- Enhanced `SellerCapabilities` with detailed payment methods and enforcement

### Implementation Checklists
- Added checklists for agents and merchants
- Added security requirements checklist

## Files Changed
- `docs/acp-spec.md` - Major updates to API specification
- `docs/features.md` - Updated Feature 5 and 13 with new schemas
- `docs/architecture.md` - Updated API version reference
- `docs/PRD.md` - Updated response schemas and session states

## Test Plan
- [x] Documentation renders correctly in GitHub markdown preview
- [x] All API version references are consistent (2026-01-16)
- [x] State machine diagrams display properly
- [x] Object definition tables are formatted correctly