### PR TITLE
feat: add last_name field to Buyer schema per ACP spec

### DIFF
--- a/src/merchant/api/schemas.py
+++ b/src/merchant/api/schemas.py
@@ -108,6 +108,9 @@ class BuyerInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     first_name: Annotated[str, Field(max_length=256, description="First name")]
+    last_name: Annotated[
+        str | None, Field(default=None, max_length=256, description="Last name")
+    ] = None
     email: Annotated[str, Field(max_length=256, description="Email address")]
     phone_number: Annotated[
         str | None, Field(default=None, description="Phone number in E.164 format")
@@ -199,6 +202,7 @@ class Buyer(BaseModel):
     """Buyer information in response."""
 
     first_name: str = Field(..., description="First name")
+    last_name: str | None = Field(default=None, description="Last name")
     email: str = Field(..., description="Email address")
     phone_number: str | None = Field(default=None, description="Phone number")
 

--- a/src/merchant/services/checkout.py
+++ b/src/merchant/services/checkout.py
@@ -70,6 +70,7 @@ def _buyer_input_to_dict(buyer: BuyerInput) -> dict[str, Any]:
     """Convert BuyerInput to dictionary for JSON storage."""
     return {
         "first_name": buyer.first_name,
+        "last_name": buyer.last_name,
         "email": buyer.email,
         "phone_number": buyer.phone_number,
     }
@@ -79,6 +80,7 @@ def _dict_to_buyer(data: dict[str, Any]) -> Buyer:
     """Convert dictionary to Buyer response model."""
     return Buyer(
         first_name=data["first_name"],
+        last_name=data.get("last_name"),
         email=data["email"],
         phone_number=data.get("phone_number"),
     )

--- a/tests/merchant/api/test_checkout.py
+++ b/tests/merchant/api/test_checkout.py
@@ -205,6 +205,44 @@ class TestCreateCheckoutSession:
         assert response.status_code == 201
         assert len(data["line_items"]) == 2
 
+    def test_create_session_with_buyer_last_name(self, auth_client: TestClient) -> None:
+        """Happy path: Session includes buyer last_name when provided."""
+        response = auth_client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "email": "john.doe@example.com",
+                },
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 201
+        assert data["buyer"] is not None
+        assert data["buyer"]["first_name"] == "John"
+        assert data["buyer"]["last_name"] == "Doe"
+        assert data["buyer"]["email"] == "john.doe@example.com"
+
+    def test_create_session_buyer_last_name_optional(
+        self, auth_client: TestClient
+    ) -> None:
+        """Edge case: Buyer last_name is optional and can be omitted."""
+        response = auth_client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {"first_name": "Jane", "email": "jane@example.com"},
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 201
+        assert data["buyer"]["first_name"] == "Jane"
+        assert data["buyer"].get("last_name") is None
+
 
 class TestGetCheckoutSession:
     """Test suite for GET /checkout_sessions/{id} endpoint."""
@@ -540,6 +578,30 @@ class TestCompleteCheckoutSession:
         assert data["order"]["id"].startswith("order_")
         assert data["order"]["checkout_session_id"] == session_id
         assert "permalink_url" in data["order"]
+
+    def test_complete_session_with_buyer_last_name(
+        self, auth_client: TestClient
+    ) -> None:
+        """Happy path: Complete checkout can update buyer with last_name."""
+        session_id = self._create_ready_session(auth_client)
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={
+                "buyer": {
+                    "first_name": "Complete",
+                    "last_name": "User",
+                    "email": "complete.user@example.com",
+                },
+                "payment_data": {"token": "tok_test", "provider": "stripe"},
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["buyer"]["first_name"] == "Complete"
+        assert data["buyer"]["last_name"] == "User"
+        assert data["buyer"]["email"] == "complete.user@example.com"
 
     def test_complete_nonexistent_session_returns_404(
         self, auth_client: TestClient


### PR DESCRIPTION
## Summary

- Add optional `last_name` field to `BuyerInput` and `Buyer` schemas to align with ACP specification
- Update checkout service layer to serialize/deserialize `last_name` in buyer data
- Add test coverage for `last_name` field in create and complete checkout flows

## Context

The ACP spec (`docs/acp-spec.md` lines 192-197) defines that the Complete Checkout endpoint's buyer input can include a `last_name` field. This change aligns Feature #3 implementation with the updated specification.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes  
- [x] `pyright src/merchant/` passes with 0 errors
- [x] `pytest tests/ -v` passes (102 tests, including 3 new tests)

New tests added:
- `test_create_session_with_buyer_last_name` - verifies last_name is accepted and returned
- `test_create_session_buyer_last_name_optional` - verifies last_name is optional
- `test_complete_session_with_buyer_last_name` - verifies complete checkout accepts last_name