### PR TITLE
feat: implement PSP delegated payments service (Feature 5)

### DIFF
--- a/.cursor/skills/features/SKILL.md
+++ b/.cursor/skills/features/SKILL.md
@@ -8,6 +8,7 @@ description: Backend development guidelines for python code
 ## Feature Development (Mandatory)
 - For every new feature, behavior, or refactor, ALWAYS create or update unit tests.
 - Do not add unnecessary comments unless it's complex code.
+- Do not add secrets, passwords and sensitive information.
 - Tests must exist before the task is considered complete.
 - Prefer pytest for all tests.
 - Include:
@@ -66,5 +67,9 @@ If any step fails or is missing, the work is incomplete.
 - No TODOs without an issue reference
 - No dead code
 - Clear, descriptive function and variable names
+
+## Update documentation
+- Add clear and simple instructions on the README.md
+- Update AGENTS.md and CLAUDE.md for agentic development.
 
 If these standards are not met, the solution MUST be revised.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,18 @@ pip install -e ".[dev]"
 uv pip install -e ".[dev]"
 ```
 
-### Running the Server
+### Running the Servers
 
 ```bash
-# Start the FastAPI server
+# Start the Merchant API server
 uvicorn src.merchant.main:app --reload
-
 # Server runs at http://localhost:8000
 # API docs at http://localhost:8000/docs
+
+# Start the PSP (Payment Service Provider) server
+uvicorn src.payment.main:app --reload --port 8001
+# Server runs at http://localhost:8001
+# API docs at http://localhost:8001/docs
 ```
 
 ### Frontend (Next.js UI)
@@ -184,13 +188,20 @@ Include:
 
 ```
 src/
-├── merchant/           # FastAPI backend
+├── merchant/           # Merchant API (FastAPI backend)
 │   ├── main.py         # Application entry point
 │   ├── config.py       # Environment configuration
 │   ├── api/            # API routes and schemas
 │   ├── agents/         # NAT agent implementations
 │   ├── db/             # Database models and utilities
 │   └── services/       # Business logic layer
+│
+├── payment/            # PSP Service (FastAPI backend, port 8001)
+│   ├── main.py         # PSP application entry point
+│   ├── config.py       # PSP environment configuration (PSP_API_KEY)
+│   ├── api/            # PSP API routes (delegate_payment, payment_intent)
+│   ├── db/             # PSP models (VaultToken, PaymentIntent, IdempotencyRecord)
+│   └── services/       # PSP business logic (vault tokens, idempotency)
 │
 └── ui/                 # Next.js frontend
     ├── app/            # Next.js App Router pages
@@ -203,7 +214,8 @@ src/
     └── data/           # Mock data for development
 
 tests/
-└── merchant/           # Backend test files mirror src structure
+├── merchant/           # Merchant API test files
+└── payment/            # PSP service test files
 
 docs/                   # Project documentation
 .cursor/skills/         # AI assistant skill definitions
@@ -211,16 +223,30 @@ docs/                   # Project documentation
 
 ## Helpful Commands
 
-### Backend
+### Merchant API (port 8000)
 
 | Task | Command |
 |------|---------|
 | Start server | `uvicorn src.merchant.main:app --reload` |
+| Run tests | `pytest tests/merchant/ -v` |
+| Health check | `curl http://localhost:8000/health` |
+
+### PSP Service (port 8001)
+
+| Task | Command |
+|------|---------|
+| Start server | `uvicorn src.payment.main:app --reload --port 8001` |
+| Run tests | `pytest tests/payment/ -v` |
+| Health check | `curl http://localhost:8001/health` |
+
+### Code Quality (Both Services)
+
+| Task | Command |
+|------|---------|
 | Run all tests | `pytest tests/ -v` |
 | Lint check | `ruff check src/ tests/` |
 | Format code | `ruff format src/ tests/` |
 | Type check | `pyright src/` |
-| Health check | `curl http://localhost:8000/health` |
 
 ### Frontend (run from `src/ui/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,15 +12,19 @@ This is a reference implementation of the **Agentic Commerce Protocol (ACP)**: a
 
 ### Server Operations
 ```bash
-# Start development server
+# Start Merchant API server
 uvicorn src.merchant.main:app --reload
-
 # Server runs at http://localhost:8000
 # API docs: http://localhost:8000/docs
-# ReDoc: http://localhost:8000/redoc
 
-# Health check
+# Start PSP (Payment Service Provider) server
+uvicorn src.payment.main:app --reload --port 8001
+# Server runs at http://localhost:8001
+# API docs: http://localhost:8001/docs
+
+# Health checks
 curl http://localhost:8000/health
+curl http://localhost:8001/health
 ```
 
 ### UI Operations (Next.js Frontend)
@@ -71,11 +75,19 @@ pip install -e ".[dev]"    # Include dev dependencies
 # Run all tests
 pytest tests/ -v
 
+# Run merchant tests only
+pytest tests/merchant/ -v
+
+# Run PSP tests only
+pytest tests/payment/ -v
+
 # Run specific test file
 pytest tests/merchant/api/test_checkout.py -v
+pytest tests/payment/api/test_payments.py -v
 
 # Run tests matching pattern
 pytest tests/ -v -k "test_create_checkout"
+pytest tests/ -v -k "test_delegate_payment"
 
 # Run with coverage
 pytest tests/ --cov=src
@@ -99,7 +111,7 @@ pyright src/                        # Run type checker
 
 ### Module Organization
 ```
-src/merchant/
+src/merchant/                # Merchant API (port 8000)
 ├── main.py              # FastAPI app entry point with lifespan management
 ├── config.py            # Environment configuration (pydantic-settings)
 ├── api/
@@ -114,6 +126,22 @@ src/merchant/
 │   ├── checkout.py     # Checkout session management
 │   └── idempotency.py  # Idempotency key handling
 └── middleware/         # Request/response middleware (logging, headers)
+
+src/payment/                 # PSP Service (port 8001)
+├── main.py              # FastAPI app entry point
+├── config.py            # PSP configuration (PSP_API_KEY)
+├── api/
+│   ├── routes/
+│   │   └── payments.py  # delegate_payment, create_and_process_payment_intent
+│   ├── schemas.py       # Pydantic models (PaymentMethod, Allowance, RiskSignal)
+│   └── dependencies.py  # verify_psp_api_key
+├── db/
+│   ├── models.py        # VaultToken, PaymentIntent, IdempotencyRecord
+│   └── database.py      # Shared database connection
+└── services/
+    ├── vault_token.py   # create_vault_token logic
+    ├── payment_intent.py # create_and_process_payment_intent logic
+    └── idempotency.py   # DatabaseIdempotencyService
 ```
 
 ### Key Architectural Patterns
@@ -168,6 +196,30 @@ All endpoints in `api/routes/checkout.py`:
 | `/checkout_sessions/{id}/cancel` | POST | 200 | Cancel session (if allowed) |
 
 **Critical**: All responses MUST include `messages[]` and `links[]` arrays per ACP spec.
+
+### PSP Endpoints Implementation
+
+All endpoints in `src/payment/api/routes/payments.py`:
+
+| Endpoint | Method | Status Code | Purpose |
+|----------|--------|-------------|---------|
+| `/health` | GET | 200 | Health check |
+| `/agentic_commerce/delegate_payment` | POST | 201 | Create vault token with payment constraints |
+| `/agentic_commerce/create_and_process_payment_intent` | POST | 200 | Process payment using vault token |
+
+**Vault Token Flow**:
+1. Agent calls `delegate_payment` with payment method, allowance constraints, and risk signals
+2. PSP validates checkout_session_id exists in merchant database
+3. PSP creates vault token (`vt_xxx`) with constraints (max_amount, currency, expiry)
+4. Agent receives opaque token (never sees actual card data)
+5. Agent calls `create_and_process_payment_intent` with vault token
+6. PSP validates token is active, not expired, amount/currency within allowance
+7. Payment is processed, vault token marked as `consumed` (single-use)
+
+**PSP Database Models**:
+- `VaultToken`: id, idempotency_key, payment_method_json, allowance_json, status (active/consumed)
+- `PaymentIntent`: id, vault_token_id (FK), amount, currency, status (pending/completed)
+- `IdempotencyRecord`: idempotency_key (PK), request_hash, response_status, response_body_json
 
 ## Code Standards
 
@@ -225,8 +277,10 @@ Additional security:
 - ✅ Feature 3: Five ACP core endpoints with state machine
 - ✅ Feature 4: API key auth + idempotency + validation
 
+**Completed (Phase 2)**:
+- ✅ Feature 5: PSP delegated payments (vault tokens + payment intents)
+
 **Planned (Phase 2)**:
-- Feature 5: PSP delegated payments (vault tokens + payment intents)
 - Feature 6: Promotion Agent (NAT-based dynamic pricing)
 - Feature 7: Recommendation Agent (NAT-based cross-sell)
 - Feature 8: Post-Purchase Agent (NAT-based multilingual updates)
@@ -245,8 +299,11 @@ See `docs/features.md` for complete breakdown.
 
 Required variables in `.env` (see `env.example`):
 ```env
-# API Security
+# Merchant API Security
 API_KEY=your-api-key
+
+# PSP API Security
+PSP_API_KEY=psp-api-key-12345
 
 # NIM Configuration (for NAT agents)
 NIM_ENDPOINT=https://integrate.api.nvidia.com/v1
@@ -300,3 +357,6 @@ All jobs must pass before merge.
 4. **Direct DB Access in Agents**: Always use tool-calling pattern with parameterized queries
 5. **Skipping Tests**: Every feature requires comprehensive test coverage before completion
 6. **Type Errors**: Pyright runs in strict mode - all type hints must resolve cleanly
+7. **PSP Vault Token Reuse**: Vault tokens are single-use; always check status before processing
+8. **PSP Allowance Violations**: Always validate amount/currency against vault token allowance
+9. **Missing Risk Signals**: PSP `delegate_payment` requires at least one risk signal

--- a/README.md
+++ b/README.md
@@ -6,180 +6,61 @@
 
 </div>
 
-This repository is a **reference architecture** for the **Agentic Commerce Protocol (ACP)**: a retailer-operated system that keeps the merchant as **Merchant of Record**, while enabling **agentic negotiation** and “glass box” visibility into decisions and protocol traces.
+A **reference implementation** of the **Agentic Commerce Protocol (ACP)**: a retailer-operated checkout system that enables agentic negotiation while maintaining merchant control.
 
-> ⚠️ **Third-Party Software Notice**  
-> This project may download and install additional third-party open source software projects.  
+> **Third-Party Software Notice**
+> This project may download and install additional third-party open source software projects.
 > Please review the license terms of these open source projects before use.
 
-### What this blueprint includes (planned)
-- **ACP middleware**: Implements the required ACP checkout session endpoints and persists session state.
-- **Intelligent merchant agents**:
-  - Promotion agent (margin protection via competitor price + inventory signals)
-  - Recommendation agent (basket optimization with deterministic, in-stock rules)
-  - Post-purchase agent (multilingual shipping “pulses” to a single global webhook)
-- **Demo data layer**: A small catalog (4 products) + competitor prices + checkout session storage.
-- **Protocol Inspector UI**: A multi-panel “glass box” dashboard showing ACP JSON requests/responses plus a structured reasoning trace.
-- **Delegated payments simulator**: A minimal PSP flow for vault tokens + idempotency + payment intent processing.
-
----
-
-## Getting Started
+## Quick Start
 
 ### Prerequisites
 
-- Python 3.12 or higher
+- Python 3.12+
+- Node.js 18+ (for UI)
 - [uv](https://docs.astral.sh/uv/) (recommended) or pip
 
 ### Installation
 
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/NVIDIA/Retail-Agentic-Commerce.git
-   cd Retail-Agentic-Commerce
-   ```
-
-2. **Set up environment variables**
-   ```bash
-   cp env.example .env
-   # Edit .env with your configuration
-   ```
-
-3. **Install dependencies**
-
-   Using uv (recommended):
-   ```bash
-   uv sync
-   ```
-
-   Or using pip:
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-   pip install -e .
-   ```
-
-4. **Install dev dependencies** (optional, for testing/linting)
-   ```bash
-   uv sync --extra dev
-   # or
-   pip install -e ".[dev]"
-   ```
-
-### Running the Server
-
-Start the FastAPI server with uvicorn:
-
 ```bash
-uvicorn src.merchant.main:app --reload
+git clone https://github.com/NVIDIA/Retail-Agentic-Commerce.git
+cd Retail-Agentic-Commerce
+cp env.example .env
+uv sync
 ```
 
-The server will start at `http://localhost:8000`.
+### Run the Services
 
-### Verify Installation
+```bash
+# Merchant API (port 8000)
+uvicorn src.merchant.main:app --reload
 
-Check the health endpoint:
+# PSP Service (port 8001)
+uvicorn src.payment.main:app --reload --port 8001
+
+# Frontend UI (port 3000)
+cd src/ui && pnpm install && pnpm run dev
+```
+
+### Verify
+
 ```bash
 curl http://localhost:8000/health
+curl http://localhost:8001/health
 ```
 
-You should receive:
-```json
-{
-  "status": "healthy",
-  "version": "0.1.0"
-}
-```
+## API Documentation
 
-### API Documentation
+- **Merchant API**: http://localhost:8000/docs
+- **PSP Service**: http://localhost:8001/docs
 
-Once the server is running, visit:
-- **Swagger UI**: http://localhost:8000/docs
-- **ReDoc**: http://localhost:8000/redoc
+## Documentation
 
-### ACP Checkout Endpoints
-
-The following ACP-compliant checkout session endpoints are available:
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/checkout_sessions` | POST | Create a new checkout session |
-| `/checkout_sessions/{id}` | GET | Get checkout session by ID |
-| `/checkout_sessions/{id}` | POST | Update checkout session |
-| `/checkout_sessions/{id}/complete` | POST | Complete checkout with payment |
-| `/checkout_sessions/{id}/cancel` | POST | Cancel checkout session |
-
-Example: Create a checkout session
-```bash
-curl -X POST http://localhost:8000/checkout_sessions \
-  -H "Content-Type: application/json" \
-  -d '{"items": [{"id": "prod_1", "quantity": 1}]}'
-```
-
-### Running Tests
-
-```bash
-pytest
-```
-
----
-
-## Frontend UI
-
-The project includes a Next.js frontend for the Protocol Inspector UI and Agent Simulator.
-
-### Prerequisites
-
-- Node.js 18+
-- pnpm (recommended) or npm
-
-### Running the UI
-
-```bash
-# Navigate to the UI directory
-cd src/ui
-
-# Install dependencies
-pnpm install
-
-# Start development server
-pnpm run dev
-```
-
-The UI will be available at `http://localhost:3000`.
-
-### UI Development Commands
-
-```bash
-cd src/ui
-
-# Run tests
-pnpm test              # Run tests in watch mode
-pnpm test:run          # Run tests once
-
-# Linting and formatting
-pnpm lint              # Run ESLint
-pnpm format            # Format with Prettier
-pnpm format:check      # Check formatting
-
-# Type checking
-pnpm typecheck         # Run TypeScript type checker
-
-# Build for production
-pnpm build
-```
-
-### UI Features
-
-- **Agent Panel**: Simulates a client agent with product grid selection and checkout flow
-- **Merchant Panel**: Displays ACP protocol interactions and session state
-- **Checkout Flow**: Complete purchase journey from product selection to order confirmation
-
----
-
-## Docs
-- **Product requirements**: `docs/PRD.md`
-- **Architecture**: `docs/architecture.md`
-- **Agentic Commerce Protocol notes/spec**: `docs/acp-spec.md`
-- **Feature breakdown**: `docs/features.md`
-- **Validation plan**: `docs/validation.md`
+| Document | Description |
+|----------|-------------|
+| `docs/PRD.md` | Product requirements |
+| `docs/architecture.md` | System architecture |
+| `docs/acp-spec.md` | ACP protocol specification |
+| `docs/features.md` | Feature breakdown and status |
+| `CLAUDE.md` | Development guide for AI assistants |
+| `AGENTS.md` | Quick reference for contributors |

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,7 +12,7 @@ This document breaks down the project requirements into discrete, implementable 
 | 2 | Database Schema & Seed Data | P0 | Feature 1 | ✅ Complete |
 | 3 | ACP Core Endpoints (CRUD) | P0 | Feature 2 | ✅ Complete |
 | 4 | API Security & Validation | P0 | Feature 3 | ✅ Complete |
-| 5 | PSP - Delegated Payments | P1 | Feature 2 | |
+| 5 | PSP - Delegated Payments | P1 | Feature 2 | ✅ Complete |
 | 6 | Promotion Agent (NAT) | P1 | Features 3, 4 | |
 | 7 | Recommendation Agent (NAT) | P1 | Features 3, 4 | |
 | 8 | Post-Purchase Agent (NAT) | P1 | Features 3, 4 | |
@@ -484,43 +484,43 @@ When 3DS is required, the payment flow includes an authentication step.
 
 ### Tasks
 
-- [ ] Create SQLModel models for `VaultToken` and `PaymentIntent`
-- [ ] Implement `delegate_payment` endpoint with full schema validation
-  - [ ] Validate PaymentMethodCard schema (all required fields)
-  - [ ] Validate Allowance constraints
-  - [ ] Require at least one RiskSignal
-  - [ ] Store billing_address if provided
-- [ ] Implement idempotency handling
-  - [ ] Hash request body for comparison
-  - [ ] Return cached response for matching key + request
-  - [ ] Return 409 for matching key + different request
-- [ ] Implement `create_and_process_payment_intent` endpoint
-  - [ ] Validate vault token status and expiration
-  - [ ] Validate amount/currency against allowance
-  - [ ] Integrate with Stripe for actual payment processing
-  - [ ] Handle 3DS authentication flow
-- [ ] Implement 3D Secure support
+- [x] Create SQLModel models for `VaultToken` and `PaymentIntent`
+- [x] Implement `delegate_payment` endpoint with full schema validation
+  - [x] Validate PaymentMethodCard schema (all required fields)
+  - [x] Validate Allowance constraints
+  - [x] Require at least one RiskSignal
+  - [x] Store billing_address if provided
+- [x] Implement idempotency handling
+  - [x] Hash request body for comparison
+  - [x] Return cached response for matching key + request
+  - [x] Return 409 for matching key + different request
+- [x] Implement `create_and_process_payment_intent` endpoint
+  - [x] Validate vault token status and expiration
+  - [x] Validate amount/currency against allowance
+  - [ ] Integrate with Stripe for actual payment processing (simulated in MVP)
+  - [ ] Handle 3DS authentication flow (deferred to Feature 13)
+- [ ] Implement 3D Secure support (deferred to Feature 13)
   - [ ] Detect when 3DS is required (risk-based)
   - [ ] Return authentication_metadata
   - [ ] Accept and validate authentication_result
-- [ ] Add comprehensive error handling with proper codes
-- [ ] Create unit tests for all scenarios
+- [x] Add comprehensive error handling with proper codes
+- [x] Create unit tests for all scenarios
 
 ### Acceptance Criteria
 
-- [ ] Vault tokens are created with proper allowances and constraints
-- [ ] PaymentMethodCard schema is fully validated (type, card_number_type, display fields)
-- [ ] At least one RiskSignal is required for delegate_payment
-- [ ] Idempotency works correctly:
+- [x] Vault tokens are created with proper allowances and constraints
+- [x] PaymentMethodCard schema is fully validated (type, card_number_type, display fields)
+- [x] At least one RiskSignal is required for delegate_payment
+- [x] Idempotency works correctly:
   - Same key + same request → cached 201 response
   - Same key + different request → 409 Conflict
-- [ ] Payment intents validate against allowance constraints
-- [ ] Payment intents consume vault tokens (single-use)
-- [ ] Expired tokens are rejected with 410 Gone
-- [ ] Consumed tokens are rejected with 409 Conflict
-- [ ] 3DS flow returns proper authentication_metadata when required
-- [ ] 3DS authentication_result is validated before completing payment
-- [ ] All amounts are handled in minor units (cents)
+- [x] Payment intents validate against allowance constraints
+- [x] Payment intents consume vault tokens (single-use)
+- [x] Expired tokens are rejected with 410 Gone
+- [x] Consumed tokens are rejected with 409 Conflict
+- [ ] 3DS flow returns proper authentication_metadata when required (deferred to Feature 13)
+- [ ] 3DS authentication_result is validated before completing payment (deferred to Feature 13)
+- [x] All amounts are handled in minor units (cents)
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -19,3 +19,6 @@ WEBHOOK_SECRET=whsec_xxx
 
 # API Security
 API_KEY=your-api-key
+
+# PSP API Security
+PSP_API_KEY=psp-api-key-12345

--- a/src/payment/__init__.py
+++ b/src/payment/__init__.py
@@ -1,0 +1,1 @@
+"""PSP (Payment Service Provider) module for delegated payments."""

--- a/src/payment/api/__init__.py
+++ b/src/payment/api/__init__.py
@@ -1,0 +1,1 @@
+"""API module for the PSP service."""

--- a/src/payment/api/dependencies.py
+++ b/src/payment/api/dependencies.py
@@ -1,0 +1,80 @@
+"""FastAPI dependency injection utilities for PSP API security."""
+
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from src.payment.config import PaymentSettings, get_payment_settings
+
+# Optional bearer token scheme (auto_error=False allows X-API-Key fallback)
+psp_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def verify_psp_api_key(
+    settings: Annotated[PaymentSettings, Depends(get_payment_settings)],
+    bearer_credentials: Annotated[
+        HTTPAuthorizationCredentials | None, Depends(psp_bearer_scheme)
+    ] = None,
+    x_api_key: Annotated[str | None, Header(alias="X-API-Key")] = None,
+) -> str:
+    """Verify PSP API key from Authorization header or X-API-Key header.
+
+    Supports two authentication methods:
+    1. Authorization: Bearer <PSP_API_KEY>
+    2. X-API-Key: <PSP_API_KEY>
+
+    Args:
+        settings: Payment settings containing the valid PSP API key.
+        bearer_credentials: Optional Bearer token from Authorization header.
+        x_api_key: Optional API key from X-API-Key header.
+
+    Returns:
+        The validated PSP API key.
+
+    Raises:
+        HTTPException: 401 if no API key provided, 403 if invalid.
+    """
+    # Extract API key from either source
+    api_key: str | None = None
+
+    if bearer_credentials is not None:
+        api_key = bearer_credentials.credentials
+    elif x_api_key is not None:
+        api_key = x_api_key
+
+    # No API key provided
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "type": "unauthorized",
+                "code": "missing_api_key",
+                "message": "PSP API key is required. Provide via 'Authorization: Bearer <key>' or 'X-API-Key' header.",
+            },
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Validate API key against configured value
+    if not settings.psp_api_key:
+        # No API key configured - reject all requests in production
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "type": "internal_error",
+                "code": "configuration_error",
+                "message": "PSP API key not configured on server.",
+            },
+        )
+
+    if api_key != settings.psp_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "type": "forbidden",
+                "code": "invalid_api_key",
+                "message": "Invalid PSP API key.",
+            },
+        )
+
+    return api_key

--- a/src/payment/api/routes/__init__.py
+++ b/src/payment/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Routes module for the PSP service."""

--- a/src/payment/api/routes/payments.py
+++ b/src/payment/api/routes/payments.py
@@ -1,0 +1,207 @@
+"""PSP delegated payment endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlmodel import Session
+
+from src.payment.api.dependencies import verify_psp_api_key
+from src.payment.api.schemas import (
+    CreatePaymentIntentRequest,
+    DelegatePaymentRequest,
+    DelegatePaymentResponse,
+    PaymentIntentResponse,
+)
+from src.payment.db.database import get_session
+from src.payment.services.idempotency import (
+    check_idempotency,
+    compute_request_hash,
+    store_idempotency_response,
+)
+from src.payment.services.payment_intent import (
+    AmountExceedsAllowanceError,
+    CurrencyMismatchError,
+    VaultTokenConsumedError,
+    VaultTokenExpiredError,
+    VaultTokenNotFoundError,
+    create_and_process_payment_intent,
+)
+from src.payment.services.vault_token import (
+    CheckoutSessionNotFoundError,
+    create_vault_token,
+)
+
+router = APIRouter(
+    prefix="/agentic_commerce",
+    tags=["agentic_commerce"],
+)
+
+
+@router.post(
+    "/delegate_payment",
+    response_model=DelegatePaymentResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        201: {"description": "Vault token created successfully"},
+        401: {"description": "Missing API key"},
+        403: {"description": "Invalid API key"},
+        404: {"description": "Checkout session not found"},
+        409: {"description": "Idempotency conflict"},
+        422: {"description": "Validation error"},
+    },
+)
+def delegate_payment(
+    request_data: DelegatePaymentRequest,
+    db: Annotated[Session, Depends(get_session)],
+    _api_key: Annotated[str, Depends(verify_psp_api_key)],
+    idempotency_key: Annotated[str, Header(alias="Idempotency-Key")],
+) -> DelegatePaymentResponse:
+    """Delegate a payment method to the PSP.
+
+    Creates a vault token that can be used to process payments.
+
+    Args:
+        request_data: The delegate payment request body.
+        db: Database session.
+        _api_key: Validated PSP API key (unused but required for auth).
+        idempotency_key: Idempotency key for request deduplication.
+
+    Returns:
+        DelegatePaymentResponse with the created vault token.
+
+    Raises:
+        HTTPException: Various status codes for different error conditions.
+    """
+    # Compute request hash for idempotency check
+    request_body = request_data.model_dump()
+    request_hash = compute_request_hash(
+        "POST", "/agentic_commerce/delegate_payment", request_body
+    )
+
+    # Check idempotency
+    idempotency_result = check_idempotency(db, idempotency_key, request_hash)
+
+    if idempotency_result.is_conflict:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "type": "conflict",
+                "code": "request_not_idempotent",
+                "message": "Request body differs from previous request with same Idempotency-Key.",
+            },
+        )
+
+    if idempotency_result.is_cached:
+        # Return cached response
+        return DelegatePaymentResponse.model_validate(idempotency_result.cached_body)
+
+    # Process the request
+    try:
+        response = create_vault_token(db, request_data, idempotency_key)
+    except CheckoutSessionNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "type": "not_found",
+                "code": "checkout_session_not_found",
+                "message": str(e),
+                "param": "allowance.checkout_session_id",
+            },
+        ) from e
+
+    # Store response for idempotency
+    response_body = response.model_dump()
+    store_idempotency_response(db, idempotency_key, request_hash, 201, response_body)
+
+    return response
+
+
+@router.post(
+    "/create_and_process_payment_intent",
+    response_model=PaymentIntentResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"description": "Payment processed successfully"},
+        401: {"description": "Missing API key"},
+        403: {"description": "Invalid API key"},
+        404: {"description": "Vault token not found"},
+        409: {"description": "Vault token already consumed"},
+        410: {"description": "Vault token expired"},
+        422: {"description": "Validation error (amount/currency)"},
+    },
+)
+def process_payment_intent(
+    request_data: CreatePaymentIntentRequest,
+    db: Annotated[Session, Depends(get_session)],
+    _api_key: Annotated[str, Depends(verify_psp_api_key)],
+) -> PaymentIntentResponse:
+    """Create and process a payment intent.
+
+    Uses a vault token to process a payment. The vault token is consumed
+    after successful processing (single-use).
+
+    Args:
+        request_data: The payment intent request body.
+        db: Database session.
+        _api_key: Validated PSP API key (unused but required for auth).
+
+    Returns:
+        PaymentIntentResponse with the processed payment details.
+
+    Raises:
+        HTTPException: Various status codes for different error conditions.
+    """
+    try:
+        response = create_and_process_payment_intent(db, request_data)
+    except VaultTokenNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "type": "not_found",
+                "code": "vault_token_not_found",
+                "message": str(e),
+                "param": "vault_token",
+            },
+        ) from e
+    except VaultTokenConsumedError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "type": "conflict",
+                "code": "vault_token_consumed",
+                "message": str(e),
+                "param": "vault_token",
+            },
+        ) from e
+    except VaultTokenExpiredError as e:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail={
+                "type": "gone",
+                "code": "vault_token_expired",
+                "message": str(e),
+                "param": "vault_token",
+            },
+        ) from e
+    except AmountExceedsAllowanceError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "type": "invalid_request",
+                "code": "amount_exceeds_allowance",
+                "message": str(e),
+                "param": "amount",
+            },
+        ) from e
+    except CurrencyMismatchError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "type": "invalid_request",
+                "code": "currency_mismatch",
+                "message": str(e),
+                "param": "currency",
+            },
+        ) from e
+
+    return response

--- a/src/payment/api/schemas.py
+++ b/src/payment/api/schemas.py
@@ -1,0 +1,236 @@
+"""Pydantic schemas for PSP delegated payment endpoints."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# =============================================================================
+# Enums
+# =============================================================================
+
+
+class CardNumberTypeEnum(str, Enum):
+    """Card number type."""
+
+    FPAN = "fpan"
+    DPAN = "dpan"
+
+
+class AllowanceReasonEnum(str, Enum):
+    """Allowance reason type."""
+
+    ONE_TIME = "one_time"
+    SUBSCRIPTION = "subscription"
+
+
+class PaymentIntentStatusEnum(str, Enum):
+    """Payment intent status."""
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+
+
+class RiskSignalTypeEnum(str, Enum):
+    """Risk signal types."""
+
+    CARD_TESTING = "card_testing"
+    FRAUD = "fraud"
+    VELOCITY = "velocity"
+
+
+class RiskSignalActionEnum(str, Enum):
+    """Risk signal actions."""
+
+    AUTHORIZED = "authorized"
+    BLOCKED = "blocked"
+    REVIEW = "review"
+
+
+# =============================================================================
+# Input Models (Request Schemas)
+# =============================================================================
+
+
+class PaymentMethodInput(BaseModel):
+    """Payment method input for delegate payment request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = Field(default="card", description="Payment method type")
+    card_number_type: CardNumberTypeEnum = Field(
+        ..., description="Card number type (fpan/dpan)"
+    )
+    virtual: bool = Field(default=False, description="Whether the card is virtual")
+    number: Annotated[
+        str, Field(min_length=13, max_length=19, description="Card number")
+    ]
+    exp_month: Annotated[
+        str, Field(min_length=1, max_length=2, description="Expiry month")
+    ]
+    exp_year: Annotated[
+        str, Field(min_length=2, max_length=4, description="Expiry year")
+    ]
+    display_card_funding_type: str = Field(
+        default="credit", description="Display card funding type"
+    )
+    display_last4: Annotated[
+        str, Field(min_length=4, max_length=4, description="Last 4 digits")
+    ]
+
+
+class AllowanceInput(BaseModel):
+    """Allowance constraints for the vault token."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reason: AllowanceReasonEnum = Field(..., description="Allowance reason")
+    max_amount: Annotated[
+        int, Field(gt=0, description="Maximum allowed amount in minor units")
+    ]
+    currency: Annotated[
+        str, Field(min_length=3, max_length=3, description="ISO 4217 currency code")
+    ]
+    checkout_session_id: str = Field(..., description="Associated checkout session ID")
+    merchant_id: str = Field(..., description="Merchant identifier")
+    expires_at: datetime = Field(..., description="Token expiration time (RFC 3339)")
+
+
+class RiskSignalInput(BaseModel):
+    """Risk signal for fraud prevention."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: RiskSignalTypeEnum = Field(..., description="Risk signal type")
+    action: RiskSignalActionEnum = Field(
+        ..., description="Action taken for this signal"
+    )
+
+
+class BillingAddressInput(BaseModel):
+    """Billing address for the payment method."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str, Field(max_length=256, description="Cardholder name")]
+    line_one: Annotated[str, Field(max_length=60, description="Address line 1")]
+    line_two: Annotated[
+        str | None, Field(default=None, max_length=60, description="Address line 2")
+    ] = None
+    city: Annotated[str, Field(max_length=60, description="City")]
+    state: Annotated[str, Field(description="State/province")]
+    country: Annotated[
+        str,
+        Field(
+            min_length=2, max_length=2, description="Country code (ISO 3166-1 alpha-2)"
+        ),
+    ]
+    postal_code: Annotated[str, Field(max_length=20, description="Postal code")]
+
+
+class DelegatePaymentRequest(BaseModel):
+    """Request body for delegating a payment method."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    payment_method: PaymentMethodInput = Field(
+        ..., description="Payment method details"
+    )
+    allowance: AllowanceInput = Field(..., description="Allowance constraints")
+    risk_signals: Annotated[
+        list[RiskSignalInput],
+        Field(min_length=1, description="Risk signals (at least one required)"),
+    ]
+    billing_address: BillingAddressInput | None = Field(
+        default=None, description="Billing address"
+    )
+
+
+class CreatePaymentIntentRequest(BaseModel):
+    """Request body for creating and processing a payment intent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    vault_token: str = Field(..., description="Vault token ID")
+    amount: Annotated[int, Field(gt=0, description="Payment amount in minor units")]
+    currency: Annotated[
+        str, Field(min_length=3, max_length=3, description="ISO 4217 currency code")
+    ]
+
+
+# =============================================================================
+# Output Models (Response Schemas)
+# =============================================================================
+
+
+class VaultTokenMetadata(BaseModel):
+    """Metadata in vault token response."""
+
+    source: str = Field(..., description="Source of the vault token")
+    merchant_id: str = Field(..., description="Merchant identifier")
+    idempotency_key: str = Field(..., description="Idempotency key used")
+
+
+class DelegatePaymentResponse(BaseModel):
+    """Response for delegate payment endpoint."""
+
+    id: str = Field(..., description="Vault token ID")
+    created: datetime = Field(..., description="Creation timestamp")
+    metadata: VaultTokenMetadata = Field(..., description="Token metadata")
+
+
+class PaymentIntentResponse(BaseModel):
+    """Response for payment intent endpoint."""
+
+    id: str = Field(..., description="Payment intent ID")
+    vault_token_id: str = Field(..., description="Associated vault token ID")
+    amount: int = Field(..., description="Payment amount in minor units")
+    currency: str = Field(..., description="ISO 4217 currency code")
+    status: PaymentIntentStatusEnum = Field(..., description="Payment status")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    completed_at: datetime | None = Field(
+        default=None, description="Completion timestamp"
+    )
+
+
+# =============================================================================
+# Error Response Schemas
+# =============================================================================
+
+
+class ErrorTypeEnum(str, Enum):
+    """Error response types."""
+
+    INVALID_REQUEST = "invalid_request"
+    NOT_FOUND = "not_found"
+    CONFLICT = "conflict"
+    GONE = "gone"
+    INTERNAL_ERROR = "internal_error"
+    UNAUTHORIZED = "unauthorized"
+    FORBIDDEN = "forbidden"
+
+
+class ErrorCodeEnum(str, Enum):
+    """Error response codes."""
+
+    CHECKOUT_SESSION_NOT_FOUND = "checkout_session_not_found"
+    VAULT_TOKEN_NOT_FOUND = "vault_token_not_found"
+    VAULT_TOKEN_CONSUMED = "vault_token_consumed"
+    VAULT_TOKEN_EXPIRED = "vault_token_expired"
+    AMOUNT_EXCEEDS_ALLOWANCE = "amount_exceeds_allowance"
+    CURRENCY_MISMATCH = "currency_mismatch"
+    REQUEST_NOT_IDEMPOTENT = "request_not_idempotent"
+    MISSING_API_KEY = "missing_api_key"
+    INVALID_API_KEY = "invalid_api_key"
+    CONFIGURATION_ERROR = "configuration_error"
+    VALIDATION_ERROR = "validation_error"
+
+
+class ErrorResponse(BaseModel):
+    """Error response schema."""
+
+    type: ErrorTypeEnum = Field(..., description="Error type")
+    code: ErrorCodeEnum = Field(..., description="Error code")
+    message: str = Field(..., description="Human-readable message")
+    param: str | None = Field(default=None, description="Related parameter path")

--- a/src/payment/config.py
+++ b/src/payment/config.py
@@ -1,0 +1,33 @@
+"""Payment service configuration using pydantic-settings."""
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class PaymentSettings(BaseSettings):
+    """Payment service settings loaded from environment variables."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    # Application
+    app_name: str = "PSP Delegated Payments"
+    app_version: str = "0.1.0"
+    debug: bool = False
+
+    # Database (shared with merchant service)
+    database_url: str = "sqlite:///./agentic_commerce.db"
+
+    # PSP API Security
+    psp_api_key: str = ""
+
+
+@lru_cache
+def get_payment_settings() -> PaymentSettings:
+    """Get cached payment service settings."""
+    return PaymentSettings()

--- a/src/payment/db/__init__.py
+++ b/src/payment/db/__init__.py
@@ -1,0 +1,27 @@
+"""Database module for the PSP service."""
+
+from src.payment.db.database import (
+    get_engine,
+    get_session,
+    init_payment_tables,
+    reset_engine,
+)
+from src.payment.db.models import (
+    IdempotencyRecord,
+    PaymentIntent,
+    PaymentIntentStatus,
+    VaultToken,
+    VaultTokenStatus,
+)
+
+__all__ = [
+    "get_engine",
+    "get_session",
+    "init_payment_tables",
+    "reset_engine",
+    "IdempotencyRecord",
+    "PaymentIntent",
+    "PaymentIntentStatus",
+    "VaultToken",
+    "VaultTokenStatus",
+]

--- a/src/payment/db/database.py
+++ b/src/payment/db/database.py
@@ -1,0 +1,60 @@
+"""Database connection and session management for the PSP service."""
+
+from collections.abc import Generator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from src.payment.config import get_payment_settings
+
+# Create engine lazily to allow settings to be loaded
+_engine = None
+
+
+def get_engine():
+    """Get or create the database engine.
+
+    Returns:
+        Engine: SQLAlchemy engine instance.
+    """
+    global _engine
+    if _engine is None:
+        settings = get_payment_settings()
+        _engine = create_engine(
+            settings.database_url,
+            echo=settings.debug,
+            connect_args={"check_same_thread": False},
+        )
+    return _engine
+
+
+def get_session() -> Generator[Session, None, None]:
+    """Get a database session.
+
+    Yields:
+        Session: A SQLModel session for database operations.
+    """
+    with Session(get_engine()) as session:
+        yield session
+
+
+def init_payment_tables() -> None:
+    """Initialize the PSP database tables.
+
+    Creates the vault_token, payment_intent, and idempotency_store tables.
+    Also creates the merchant tables if they don't exist (for testing).
+    """
+    # Import models to register them with SQLModel metadata
+    # These imports are necessary for table creation even if not directly used
+    from src.payment.db import (
+        models as _models,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    )
+
+    SQLModel.metadata.create_all(get_engine())
+
+
+def reset_engine() -> None:
+    """Reset the database engine. Useful for testing."""
+    global _engine
+    if _engine is not None:
+        _engine.dispose()
+        _engine = None

--- a/src/payment/db/models.py
+++ b/src/payment/db/models.py
@@ -1,0 +1,98 @@
+"""SQLModel database models for the PSP (Payment Service Provider)."""
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import ClassVar
+
+from sqlmodel import Field, SQLModel
+
+
+def _utc_now() -> datetime:
+    """Return current UTC datetime."""
+    return datetime.now(UTC)
+
+
+class VaultTokenStatus(str, Enum):
+    """Vault token status values."""
+
+    ACTIVE = "active"
+    CONSUMED = "consumed"
+
+
+class PaymentIntentStatus(str, Enum):
+    """Payment intent status values."""
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+
+
+class VaultToken(SQLModel, table=True):
+    """Vault token model for delegated payment methods.
+
+    Attributes:
+        id: Unique vault token identifier (e.g., "vt_a1b2c3d4e5f6")
+        idempotency_key: The idempotency key used to create this token
+        payment_method_json: JSON string of payment method details
+        allowance_json: JSON string of allowance constraints
+        billing_address_json: JSON string of billing address (optional)
+        risk_signals_json: JSON string of risk signals array
+        status: Current vault token status (active/consumed)
+        metadata_json: JSON string of additional metadata
+        created_at: Token creation timestamp
+    """
+
+    __tablename__: ClassVar[str] = "vault_token"  # type: ignore[assignment]
+
+    id: str = Field(primary_key=True)
+    idempotency_key: str = Field(unique=True, index=True)
+    payment_method_json: str
+    allowance_json: str
+    billing_address_json: str | None = Field(default=None)
+    risk_signals_json: str = Field(default="[]")
+    status: VaultTokenStatus = Field(default=VaultTokenStatus.ACTIVE)
+    metadata_json: str = Field(default="{}")
+    created_at: datetime = Field(default_factory=_utc_now)
+
+
+class PaymentIntent(SQLModel, table=True):
+    """Payment intent model for processing payments.
+
+    Attributes:
+        id: Unique payment intent identifier (e.g., "pi_x1y2z3w4v5u6")
+        vault_token_id: Reference to the vault token used
+        amount: Payment amount in minor units (cents)
+        currency: ISO 4217 currency code (lowercase)
+        status: Current payment intent status
+        created_at: Intent creation timestamp
+        completed_at: Payment completion timestamp (optional)
+    """
+
+    __tablename__: ClassVar[str] = "payment_intent"  # type: ignore[assignment]
+
+    id: str = Field(primary_key=True)
+    vault_token_id: str = Field(foreign_key="vault_token.id", index=True)
+    amount: int
+    currency: str
+    status: PaymentIntentStatus = Field(default=PaymentIntentStatus.PENDING)
+    created_at: datetime = Field(default_factory=_utc_now)
+    completed_at: datetime | None = Field(default=None)
+
+
+class IdempotencyRecord(SQLModel, table=True):
+    """Idempotency record for ensuring request idempotency.
+
+    Attributes:
+        idempotency_key: The unique idempotency key (primary key)
+        request_hash: SHA-256 hash of the request (method:path:body)
+        response_status: HTTP status code of the cached response
+        response_body_json: JSON string of the cached response body
+        created_at: Record creation timestamp
+    """
+
+    __tablename__: ClassVar[str] = "idempotency_store"  # type: ignore[assignment]
+
+    idempotency_key: str = Field(primary_key=True)
+    request_hash: str = Field(index=True)
+    response_status: int
+    response_body_json: str
+    created_at: datetime = Field(default_factory=_utc_now)

--- a/src/payment/main.py
+++ b/src/payment/main.py
@@ -1,0 +1,70 @@
+"""FastAPI application entry point for the PSP (Payment Service Provider)."""
+
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from src.payment.api.routes.payments import router as payments_router
+from src.payment.config import get_payment_settings
+from src.payment.db.database import init_payment_tables
+
+settings = get_payment_settings()
+
+# Configure logging
+logging.basicConfig(
+    level=logging.DEBUG if settings.debug else logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
+    """Application lifespan context manager.
+
+    Initializes the database tables on startup.
+
+    Args:
+        _app: FastAPI application instance (unused but required by protocol).
+
+    Yields:
+        None
+    """
+    # Initialize PSP tables (and merchant tables for foreign key support)
+    from src.merchant.db import init_and_seed_db
+
+    init_and_seed_db()  # Initialize merchant tables with seed data
+    init_payment_tables()  # Initialize PSP-specific tables
+    yield
+
+
+app = FastAPI(
+    title=settings.app_name,
+    version=settings.app_version,
+    description="PSP Delegated Payments for Agentic Commerce",
+    lifespan=lifespan,
+)
+
+# Configure CORS for development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"] if settings.debug else [],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Include routers
+app.include_router(payments_router)
+
+
+@app.get("/health", tags=["health"])
+def health_check() -> dict[str, str]:
+    """Health check endpoint.
+
+    Returns:
+        A dictionary with status "ok".
+    """
+    return {"status": "ok"}

--- a/src/payment/services/__init__.py
+++ b/src/payment/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services module for the PSP service."""

--- a/src/payment/services/idempotency.py
+++ b/src/payment/services/idempotency.py
@@ -1,0 +1,110 @@
+"""Database-backed idempotency service for PSP endpoints."""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from sqlmodel import Session, select
+
+from src.payment.db.models import IdempotencyRecord
+
+
+@dataclass
+class IdempotencyResult:
+    """Result of an idempotency check."""
+
+    is_cached: bool
+    is_conflict: bool
+    cached_status: int | None = None
+    cached_body: dict[str, Any] | None = None
+
+
+def compute_request_hash(method: str, path: str, body: dict[str, Any]) -> str:
+    """Compute SHA-256 hash of the request.
+
+    Args:
+        method: HTTP method (e.g., "POST")
+        path: Request path (e.g., "/agentic_commerce/delegate_payment")
+        body: Request body as a dictionary
+
+    Returns:
+        SHA-256 hash of the request signature
+    """
+    # Sort keys for consistent hashing
+    body_json = json.dumps(body, sort_keys=True, default=str)
+    signature = f"{method}:{path}:{body_json}"
+    return hashlib.sha256(signature.encode()).hexdigest()
+
+
+def check_idempotency(
+    db: Session, idempotency_key: str, request_hash: str
+) -> IdempotencyResult:
+    """Check if a request with the given idempotency key exists.
+
+    Args:
+        db: Database session
+        idempotency_key: The idempotency key from the request header
+        request_hash: Hash of the current request
+
+    Returns:
+        IdempotencyResult indicating whether the response is cached or conflicting
+    """
+    statement = select(IdempotencyRecord).where(
+        IdempotencyRecord.idempotency_key == idempotency_key
+    )
+    record = db.exec(statement).first()
+
+    if record is None:
+        return IdempotencyResult(is_cached=False, is_conflict=False)
+
+    # Same key but different request = conflict
+    if record.request_hash != request_hash:
+        return IdempotencyResult(is_cached=False, is_conflict=True)
+
+    # Same key and same request = return cached response
+    return IdempotencyResult(
+        is_cached=True,
+        is_conflict=False,
+        cached_status=record.response_status,
+        cached_body=json.loads(record.response_body_json),
+    )
+
+
+def store_idempotency_response(
+    db: Session,
+    idempotency_key: str,
+    request_hash: str,
+    response_status: int,
+    response_body: dict[str, Any],
+) -> None:
+    """Store a response for idempotency replay.
+
+    Args:
+        db: Database session
+        idempotency_key: The idempotency key from the request header
+        request_hash: Hash of the request
+        response_status: HTTP status code of the response
+        response_body: Response body as a dictionary
+    """
+    record = IdempotencyRecord(
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        response_status=response_status,
+        response_body_json=json.dumps(response_body, default=str),
+    )
+    db.add(record)
+    db.commit()
+
+
+def clear_idempotency_store(db: Session) -> None:
+    """Clear all idempotency records. Useful for testing.
+
+    Args:
+        db: Database session
+    """
+    statement = select(IdempotencyRecord)
+    records = db.exec(statement).all()
+    for record in records:
+        db.delete(record)
+    db.commit()

--- a/src/payment/services/payment_intent.py
+++ b/src/payment/services/payment_intent.py
@@ -1,0 +1,153 @@
+"""Payment intent service for processing payments."""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlmodel import Session
+
+from src.payment.api.schemas import (
+    CreatePaymentIntentRequest,
+    PaymentIntentResponse,
+    PaymentIntentStatusEnum,
+)
+from src.payment.db.models import PaymentIntent, PaymentIntentStatus, VaultTokenStatus
+from src.payment.services.vault_token import (
+    get_allowance,
+    get_vault_token,
+    is_token_expired,
+)
+
+
+class VaultTokenNotFoundError(Exception):
+    """Raised when a vault token is not found."""
+
+    def __init__(self, token_id: str):
+        self.token_id = token_id
+        super().__init__(f"Vault token '{token_id}' not found")
+
+
+class VaultTokenConsumedError(Exception):
+    """Raised when a vault token has already been consumed."""
+
+    def __init__(self, token_id: str):
+        self.token_id = token_id
+        super().__init__(f"Vault token '{token_id}' has already been consumed")
+
+
+class VaultTokenExpiredError(Exception):
+    """Raised when a vault token has expired."""
+
+    def __init__(self, token_id: str):
+        self.token_id = token_id
+        super().__init__(f"Vault token '{token_id}' has expired")
+
+
+class AmountExceedsAllowanceError(Exception):
+    """Raised when the payment amount exceeds the allowance."""
+
+    def __init__(self, amount: int, max_amount: int):
+        self.amount = amount
+        self.max_amount = max_amount
+        super().__init__(
+            f"Payment amount {amount} exceeds maximum allowance of {max_amount}"
+        )
+
+
+class CurrencyMismatchError(Exception):
+    """Raised when the currency doesn't match the allowance."""
+
+    def __init__(self, requested: str, allowed: str):
+        self.requested = requested
+        self.allowed = allowed
+        super().__init__(
+            f"Currency '{requested}' does not match allowance currency '{allowed}'"
+        )
+
+
+def generate_payment_intent_id() -> str:
+    """Generate a unique payment intent ID.
+
+    Returns:
+        A unique payment intent ID in the format 'pi_{uuid12}'
+    """
+    return f"pi_{uuid.uuid4().hex[:12]}"
+
+
+def create_and_process_payment_intent(
+    db: Session,
+    request: CreatePaymentIntentRequest,
+) -> PaymentIntentResponse:
+    """Create and process a payment intent.
+
+    Args:
+        db: Database session
+        request: The payment intent request
+
+    Returns:
+        PaymentIntentResponse with the processed payment intent details
+
+    Raises:
+        VaultTokenNotFoundError: If the vault token does not exist
+        VaultTokenConsumedError: If the vault token has already been used
+        VaultTokenExpiredError: If the vault token has expired
+        AmountExceedsAllowanceError: If the amount exceeds the allowance
+        CurrencyMismatchError: If the currency doesn't match
+    """
+    # Get the vault token
+    vault_token = get_vault_token(db, request.vault_token)
+
+    if vault_token is None:
+        raise VaultTokenNotFoundError(request.vault_token)
+
+    # Check if token is already consumed
+    if vault_token.status == VaultTokenStatus.CONSUMED:
+        raise VaultTokenConsumedError(request.vault_token)
+
+    # Check if token is expired
+    if is_token_expired(vault_token):
+        raise VaultTokenExpiredError(request.vault_token)
+
+    # Get allowance constraints
+    allowance = get_allowance(vault_token)
+
+    # Validate amount
+    max_amount: int = allowance.get("max_amount", 0)
+    if request.amount > max_amount:
+        raise AmountExceedsAllowanceError(request.amount, max_amount)
+
+    # Validate currency (case-insensitive comparison)
+    allowed_currency: str = str(allowance.get("currency", "")).lower()
+    if request.currency.lower() != allowed_currency:
+        raise CurrencyMismatchError(request.currency.lower(), allowed_currency)
+
+    # Generate payment intent ID
+    payment_intent_id = generate_payment_intent_id()
+    now = datetime.now(UTC)
+
+    # Create payment intent record
+    payment_intent = PaymentIntent(
+        id=payment_intent_id,
+        vault_token_id=vault_token.id,
+        amount=request.amount,
+        currency=request.currency.lower(),
+        status=PaymentIntentStatus.COMPLETED,
+        created_at=now,
+        completed_at=now,
+    )
+
+    # Mark vault token as consumed (single-use)
+    vault_token.status = VaultTokenStatus.CONSUMED
+
+    db.add(payment_intent)
+    db.commit()
+    db.refresh(payment_intent)
+
+    return PaymentIntentResponse(
+        id=payment_intent.id,
+        vault_token_id=payment_intent.vault_token_id,
+        amount=payment_intent.amount,
+        currency=payment_intent.currency,
+        status=PaymentIntentStatusEnum.COMPLETED,
+        created_at=payment_intent.created_at,
+        completed_at=payment_intent.completed_at,
+    )

--- a/src/payment/services/vault_token.py
+++ b/src/payment/services/vault_token.py
@@ -1,0 +1,161 @@
+"""Vault token service for delegated payment methods."""
+
+import json
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlmodel import Session, select
+
+from src.merchant.db.models import CheckoutSession
+from src.payment.api.schemas import (
+    DelegatePaymentRequest,
+    DelegatePaymentResponse,
+    VaultTokenMetadata,
+)
+from src.payment.db.models import VaultToken
+
+
+class CheckoutSessionNotFoundError(Exception):
+    """Raised when a checkout session is not found."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        super().__init__(f"Checkout session '{session_id}' not found")
+
+
+def generate_vault_token_id() -> str:
+    """Generate a unique vault token ID.
+
+    Returns:
+        A unique vault token ID in the format 'vt_{uuid12}'
+    """
+    return f"vt_{uuid.uuid4().hex[:12]}"
+
+
+def validate_checkout_session(db: Session, checkout_session_id: str) -> None:
+    """Validate that a checkout session exists.
+
+    Args:
+        db: Database session
+        checkout_session_id: The checkout session ID to validate
+
+    Raises:
+        CheckoutSessionNotFoundError: If the checkout session does not exist
+    """
+    statement = select(CheckoutSession).where(CheckoutSession.id == checkout_session_id)
+    session = db.exec(statement).first()
+
+    if session is None:
+        raise CheckoutSessionNotFoundError(checkout_session_id)
+
+
+def create_vault_token(
+    db: Session,
+    request: DelegatePaymentRequest,
+    idempotency_key: str,
+) -> DelegatePaymentResponse:
+    """Create a vault token for delegated payment.
+
+    Args:
+        db: Database session
+        request: The delegate payment request
+        idempotency_key: The idempotency key from the request header
+
+    Returns:
+        DelegatePaymentResponse with the created vault token details
+
+    Raises:
+        CheckoutSessionNotFoundError: If the checkout session does not exist
+    """
+    # Validate checkout session exists
+    validate_checkout_session(db, request.allowance.checkout_session_id)
+
+    # Generate vault token ID
+    vault_token_id = generate_vault_token_id()
+
+    # Serialize nested objects to JSON
+    payment_method_dict = request.payment_method.model_dump()
+    allowance_dict = request.allowance.model_dump()
+    risk_signals_list = [rs.model_dump() for rs in request.risk_signals]
+    billing_address_json = None
+    if request.billing_address is not None:
+        billing_address_json = json.dumps(request.billing_address.model_dump())
+
+    metadata = {
+        "source": "agent_checkout",
+        "merchant_id": request.allowance.merchant_id,
+        "idempotency_key": idempotency_key,
+    }
+
+    # Create vault token record
+    vault_token = VaultToken(
+        id=vault_token_id,
+        idempotency_key=idempotency_key,
+        payment_method_json=json.dumps(payment_method_dict, default=str),
+        allowance_json=json.dumps(allowance_dict, default=str),
+        billing_address_json=billing_address_json,
+        risk_signals_json=json.dumps(risk_signals_list, default=str),
+        metadata_json=json.dumps(metadata),
+    )
+
+    db.add(vault_token)
+    db.commit()
+    db.refresh(vault_token)
+
+    return DelegatePaymentResponse(
+        id=vault_token.id,
+        created=vault_token.created_at,
+        metadata=VaultTokenMetadata(
+            source="agent_checkout",
+            merchant_id=request.allowance.merchant_id,
+            idempotency_key=idempotency_key,
+        ),
+    )
+
+
+def get_vault_token(db: Session, vault_token_id: str) -> VaultToken | None:
+    """Get a vault token by ID.
+
+    Args:
+        db: Database session
+        vault_token_id: The vault token ID
+
+    Returns:
+        The VaultToken if found, None otherwise
+    """
+    statement = select(VaultToken).where(VaultToken.id == vault_token_id)
+    return db.exec(statement).first()
+
+
+def get_allowance(vault_token: VaultToken) -> dict[str, Any]:
+    """Get the allowance constraints from a vault token.
+
+    Args:
+        vault_token: The vault token
+
+    Returns:
+        The allowance constraints as a dictionary
+    """
+    result: dict[str, Any] = json.loads(vault_token.allowance_json)
+    return result
+
+
+def is_token_expired(vault_token: VaultToken) -> bool:
+    """Check if a vault token is expired.
+
+    Args:
+        vault_token: The vault token to check
+
+    Returns:
+        True if the token is expired, False otherwise
+    """
+    allowance = get_allowance(vault_token)
+    expires_at_str: str | None = allowance.get("expires_at")
+
+    if expires_at_str is None:
+        return False
+
+    # Parse the expiration time
+    expires_at = datetime.fromisoformat(expires_at_str.replace("Z", "+00:00"))
+    return datetime.now(expires_at.tzinfo) > expires_at

--- a/tests/payment/__init__.py
+++ b/tests/payment/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PSP (Payment Service Provider) module."""

--- a/tests/payment/api/__init__.py
+++ b/tests/payment/api/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PSP API module."""

--- a/tests/payment/api/test_payments.py
+++ b/tests/payment/api/test_payments.py
@@ -1,0 +1,476 @@
+"""Tests for the PSP delegated payment API endpoints."""
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+class TestDelegatePayment:
+    """Test suite for POST /agentic_commerce/delegate_payment endpoint."""
+
+    def test_delegate_payment_returns_201(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Valid delegate payment request returns 201."""
+        response = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+
+        assert response.status_code == 201
+
+    def test_delegate_payment_returns_vault_token_id(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Response contains vault token ID."""
+        response = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+        data = response.json()
+
+        assert "id" in data
+        assert data["id"].startswith("vt_")
+
+    def test_delegate_payment_returns_created_timestamp(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Response contains created timestamp."""
+        response = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+        data = response.json()
+
+        assert "created" in data
+
+    def test_delegate_payment_returns_metadata(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Response contains metadata."""
+        idempotency_key = str(uuid.uuid4())
+        response = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": idempotency_key},
+        )
+        data = response.json()
+
+        assert "metadata" in data
+        assert data["metadata"]["source"] == "agent_checkout"
+        assert data["metadata"]["merchant_id"] == "merchant_001"
+        assert data["metadata"]["idempotency_key"] == idempotency_key
+
+    def test_delegate_payment_validates_checkout_session(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Invalid checkout session ID returns 404."""
+        # Modify request to use non-existent checkout session
+        request = valid_delegate_payment_request.copy()
+        request["allowance"] = request["allowance"].copy()
+        request["allowance"]["checkout_session_id"] = "nonexistent_session"
+
+        response = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=request,
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"]["code"] == "checkout_session_not_found"
+
+    def test_delegate_payment_requires_risk_signal(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Empty risk_signals array returns 422."""
+        # Modify request to have empty risk_signals
+        request = valid_delegate_payment_request.copy()
+        request["risk_signals"] = []
+
+        response = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=request,
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+
+        assert response.status_code == 422
+
+    def test_delegate_payment_idempotency_cached(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Same idempotency key with same request returns cached response."""
+        idempotency_key = str(uuid.uuid4())
+
+        # First request
+        response1 = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": idempotency_key},
+        )
+        assert response1.status_code == 201
+        data1 = response1.json()
+
+        # Second request with same idempotency key
+        response2 = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": idempotency_key},
+        )
+        assert response2.status_code == 201
+        data2 = response2.json()
+
+        # Should return same vault token ID
+        assert data1["id"] == data2["id"]
+
+    def test_delegate_payment_idempotency_conflict(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Same idempotency key with different request returns 409."""
+        idempotency_key = str(uuid.uuid4())
+
+        # First request
+        response1 = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": idempotency_key},
+        )
+        assert response1.status_code == 201
+
+        # Second request with same idempotency key but different body
+        modified_request = valid_delegate_payment_request.copy()
+        modified_request["allowance"] = modified_request["allowance"].copy()
+        modified_request["allowance"]["max_amount"] = 9999
+
+        response2 = psp_auth_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=modified_request,
+            headers={"Idempotency-Key": idempotency_key},
+        )
+
+        assert response2.status_code == 409
+        data = response2.json()
+        assert data["detail"]["code"] == "request_not_idempotent"
+
+    def test_delegate_payment_requires_auth(
+        self,
+        psp_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Missing API key returns 401."""
+        response = psp_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+
+        assert response.status_code == 401
+
+    def test_delegate_payment_rejects_invalid_key(
+        self,
+        psp_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Invalid API key returns 403."""
+        response = psp_client.post(
+            "/agentic_commerce/delegate_payment",
+            json=valid_delegate_payment_request,
+            headers={
+                "Authorization": "Bearer invalid-key",
+                "Idempotency-Key": str(uuid.uuid4()),
+            },
+        )
+
+        assert response.status_code == 403
+
+
+class TestCreateAndProcessPaymentIntent:
+    """Test suite for POST /agentic_commerce/create_and_process_payment_intent endpoint."""
+
+    def _create_vault_token(self, client: TestClient, request_data: dict) -> str:
+        """Helper to create a vault token and return its ID."""
+        response = client.post(
+            "/agentic_commerce/delegate_payment",
+            json=request_data,
+            headers={"Idempotency-Key": str(uuid.uuid4())},
+        )
+        return response.json()["id"]
+
+    def test_create_payment_intent_returns_200(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Valid payment intent request returns 200."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+
+        assert response.status_code == 200
+
+    def test_payment_intent_returns_completed_status(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Payment intent has completed status."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+        data = response.json()
+
+        assert data["status"] == "completed"
+
+    def test_payment_intent_returns_intent_id(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Response contains payment intent ID."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+        data = response.json()
+
+        assert "id" in data
+        assert data["id"].startswith("pi_")
+
+    def test_payment_intent_returns_vault_token_id(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Happy path: Response contains vault token ID reference."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+        data = response.json()
+
+        assert data["vault_token_id"] == vault_token_id
+
+    def test_payment_intent_validates_token_exists(
+        self,
+        psp_auth_client: TestClient,
+    ) -> None:
+        """Failure case: Non-existent vault token returns 404."""
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": "vt_nonexistent",
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"]["code"] == "vault_token_not_found"
+
+    def test_payment_intent_rejects_consumed_token(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Consumed vault token returns 409."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        # First payment succeeds
+        response1 = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+        assert response1.status_code == 200
+
+        # Second payment fails because token is consumed
+        response2 = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 1000,
+                "currency": "usd",
+            },
+        )
+
+        assert response2.status_code == 409
+        data = response2.json()
+        assert data["detail"]["code"] == "vault_token_consumed"
+
+    def test_payment_intent_rejects_expired_token(
+        self,
+        psp_auth_client: TestClient,
+        expired_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Expired vault token returns 410."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, expired_delegate_payment_request
+        )
+
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+
+        assert response.status_code == 410
+        data = response.json()
+        assert data["detail"]["code"] == "vault_token_expired"
+
+    def test_payment_intent_validates_amount(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Amount exceeding allowance returns 422."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        # max_amount is 5000, try to charge 6000
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 6000,
+                "currency": "usd",
+            },
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert data["detail"]["code"] == "amount_exceeds_allowance"
+
+    def test_payment_intent_validates_currency(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Failure case: Currency mismatch returns 422."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        # Allowance is in USD, try to charge in EUR
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "eur",
+            },
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert data["detail"]["code"] == "currency_mismatch"
+
+    def test_payment_intent_consumes_token(
+        self,
+        psp_auth_client: TestClient,
+        valid_delegate_payment_request: dict,
+    ) -> None:
+        """Side effect: Token status changes to consumed after payment."""
+        vault_token_id = self._create_vault_token(
+            psp_auth_client, valid_delegate_payment_request
+        )
+
+        # Process payment
+        response = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 2500,
+                "currency": "usd",
+            },
+        )
+        assert response.status_code == 200
+
+        # Verify token is consumed by trying to use it again
+        response2 = psp_auth_client.post(
+            "/agentic_commerce/create_and_process_payment_intent",
+            json={
+                "vault_token": vault_token_id,
+                "amount": 100,
+                "currency": "usd",
+            },
+        )
+        assert response2.status_code == 409
+        assert response2.json()["detail"]["code"] == "vault_token_consumed"
+
+
+class TestHealthCheck:
+    """Test suite for GET /health endpoint."""
+
+    def test_health_check_returns_200(self, psp_client: TestClient) -> None:
+        """Happy path: Health check returns 200."""
+        response = psp_client.get("/health")
+        assert response.status_code == 200
+
+    def test_health_check_returns_ok_status(self, psp_client: TestClient) -> None:
+        """Happy path: Health check returns ok status."""
+        response = psp_client.get("/health")
+        data = response.json()
+        assert data["status"] == "ok"

--- a/tests/payment/conftest.py
+++ b/tests/payment/conftest.py
@@ -1,0 +1,185 @@
+"""Pytest configuration and fixtures for PSP tests."""
+
+import os
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from src.payment.config import get_payment_settings
+from src.payment.db.database import get_engine, reset_engine
+from src.payment.main import app
+from src.payment.services.idempotency import clear_idempotency_store
+
+# Test API keys
+TEST_PSP_API_KEY = "test-psp-api-key-12345"
+TEST_MERCHANT_API_KEY = "test-api-key-12345"
+
+
+@pytest.fixture(autouse=True)
+def setup_psp_test_environment() -> Generator[None, None, None]:
+    """Set up PSP test environment variables and clean up after tests.
+
+    This fixture runs automatically for all PSP tests to ensure:
+    - PSP_API_KEY environment variable is set for authenticated requests
+    - API_KEY environment variable is set for merchant service
+    - Settings cache is cleared to pick up the new environment variables
+    - Database is clean between tests
+    """
+    # Clear settings cache before setting environment variables
+    get_payment_settings.cache_clear()
+
+    # Store original values
+    original_psp_api_key = os.environ.get("PSP_API_KEY")
+    original_api_key = os.environ.get("API_KEY")
+
+    # Set up test API keys
+    os.environ["PSP_API_KEY"] = TEST_PSP_API_KEY
+    os.environ["API_KEY"] = TEST_MERCHANT_API_KEY
+
+    # Clear cache again to pick up the new values
+    get_payment_settings.cache_clear()
+
+    yield
+
+    # Clean up idempotency store
+    engine = get_engine()
+    with Session(engine) as session:
+        clear_idempotency_store(session)
+
+    # Reset engine
+    reset_engine()
+
+    # Restore original values
+    get_payment_settings.cache_clear()
+    if original_psp_api_key is not None:
+        os.environ["PSP_API_KEY"] = original_psp_api_key
+    elif "PSP_API_KEY" in os.environ:
+        del os.environ["PSP_API_KEY"]
+
+    if original_api_key is not None:
+        os.environ["API_KEY"] = original_api_key
+    elif "API_KEY" in os.environ:
+        del os.environ["API_KEY"]
+
+    get_payment_settings.cache_clear()
+
+
+@pytest.fixture
+def psp_client() -> Generator[TestClient, None, None]:
+    """Create a test client for the PSP application.
+
+    This client does NOT include authentication headers.
+    Use `psp_auth_client` for authenticated requests.
+
+    Yields:
+        TestClient: A test client instance for making HTTP requests.
+    """
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def psp_auth_client() -> Generator[TestClient, None, None]:
+    """Create an authenticated test client for the PSP application.
+
+    This client includes the Authorization header with a valid PSP API key.
+
+    Yields:
+        TestClient: An authenticated test client instance.
+    """
+    with TestClient(app) as test_client:
+        test_client.headers["Authorization"] = f"Bearer {TEST_PSP_API_KEY}"
+        yield test_client
+
+
+@pytest.fixture
+def valid_checkout_session_id() -> str:
+    """Create a valid checkout session and return its ID.
+
+    This fixture creates a checkout session via the merchant API
+    to be used in PSP tests.
+
+    Returns:
+        The ID of the created checkout session.
+    """
+    # Import merchant app and create a client for it
+    from src.merchant.main import app as merchant_app
+
+    with TestClient(merchant_app) as merchant_client:
+        merchant_client.headers["Authorization"] = f"Bearer {TEST_MERCHANT_API_KEY}"
+        response = merchant_client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        return response.json()["id"]
+
+
+@pytest.fixture
+def valid_delegate_payment_request(valid_checkout_session_id: str) -> dict:
+    """Create a valid delegate payment request body.
+
+    Args:
+        valid_checkout_session_id: ID of a valid checkout session.
+
+    Returns:
+        A dictionary with valid delegate payment request data.
+    """
+    expires_at = datetime.now(UTC) + timedelta(hours=1)
+    return {
+        "payment_method": {
+            "type": "card",
+            "card_number_type": "fpan",
+            "virtual": False,
+            "number": "4111111111111111",
+            "exp_month": "12",
+            "exp_year": "2027",
+            "display_card_funding_type": "credit",
+            "display_last4": "1111",
+        },
+        "allowance": {
+            "reason": "one_time",
+            "max_amount": 5000,
+            "currency": "usd",
+            "checkout_session_id": valid_checkout_session_id,
+            "merchant_id": "merchant_001",
+            "expires_at": expires_at.isoformat(),
+        },
+        "risk_signals": [{"type": "card_testing", "action": "authorized"}],
+    }
+
+
+@pytest.fixture
+def expired_delegate_payment_request(valid_checkout_session_id: str) -> dict:
+    """Create a delegate payment request with an expired allowance.
+
+    Args:
+        valid_checkout_session_id: ID of a valid checkout session.
+
+    Returns:
+        A dictionary with expired delegate payment request data.
+    """
+    expires_at = datetime.now(UTC) - timedelta(hours=1)
+    return {
+        "payment_method": {
+            "type": "card",
+            "card_number_type": "fpan",
+            "virtual": False,
+            "number": "4111111111111111",
+            "exp_month": "12",
+            "exp_year": "2027",
+            "display_card_funding_type": "credit",
+            "display_last4": "1111",
+        },
+        "allowance": {
+            "reason": "one_time",
+            "max_amount": 5000,
+            "currency": "usd",
+            "checkout_session_id": valid_checkout_session_id,
+            "merchant_id": "merchant_001",
+            "expires_at": expires_at.isoformat(),
+        },
+        "risk_signals": [{"type": "card_testing", "action": "authorized"}],
+    }


### PR DESCRIPTION
## Summary

- Add standalone PSP (Payment Service Provider) FastAPI application at `src/payment/`
- Implement vault token delegation with `POST /agentic_commerce/delegate_payment`
- Implement payment intent processing with `POST /agentic_commerce/create_and_process_payment_intent`
- Add database-backed idempotency for safe request retries
- Update documentation (README simplified, CLAUDE.md and AGENTS.md expanded)

## Test plan

- [x] `uv run ruff check src/payment/ tests/payment/` passes
- [x] `uv run pyright src/payment/` passes (0 errors)
- [x] `uv run pytest tests/payment/ -v` passes (22/22 tests)
- [x] Manual curl tests for all endpoints verified

🤖 Generated with [Claude Code](https://claude.ai/code)