### PR TITLE
fix(ui): improve Agent Activity panel with real LLM data

### DIFF
--- a/src/ui/components/agent-activity/AgentActivityItem.test.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.test.tsx
@@ -32,45 +32,56 @@ describe("AgentActivityItem", () => {
     expect(screen.getByText("Classic T-Shirt")).toBeInTheDocument();
   });
 
-  it("renders the PROMOTION badge", () => {
+  it("renders the Promotion Decision kicker", () => {
     render(<AgentActivityItem event={baseEvent} isLast={false} />);
-    expect(screen.getByText("PROMOTION")).toBeInTheDocument();
+    expect(screen.getByText("Promotion Decision")).toBeInTheDocument();
   });
 
-  it("renders the discount action badge", () => {
+  it("renders Applied status pill for positive outcomes", () => {
     render(<AgentActivityItem event={baseEvent} isLast={false} />);
-    expect(screen.getByText("10% OFF")).toBeInTheDocument();
+    expect(screen.getByText("Applied")).toBeInTheDocument();
   });
 
-  it("renders discount amount", () => {
+  it("renders the discount value", () => {
     render(<AgentActivityItem event={baseEvent} isLast={false} />);
-    expect(screen.getByText("-$2.50")).toBeInTheDocument();
+    expect(screen.getByText("−$2.50")).toBeInTheDocument();
   });
 
-  it("renders reason codes as pills", () => {
+  it("renders 'Why this happened' with LLM reasoning", () => {
     render(<AgentActivityItem event={baseEvent} isLast={false} />);
-    expect(screen.getByText("HIGH INVENTORY")).toBeInTheDocument();
-    expect(screen.getByText("BELOW MARKET")).toBeInTheDocument();
+    expect(screen.getByText("Why this happened")).toBeInTheDocument();
+    // Should show the actual LLM reasoning from the decision
+    expect(
+      screen.getByText("High inventory and below market price suggest a discount is appropriate.")
+    ).toBeInTheDocument();
   });
 
-  it("expands to show details when clicked", () => {
+  it("expands to show technical details when clicked", () => {
     render(<AgentActivityItem event={baseEvent} isLast={false} />);
 
-    // Initially details are hidden
-    expect(screen.queryByText("Input Signals")).not.toBeInTheDocument();
+    // Click to expand using the Details button
+    fireEvent.click(screen.getByText("Details"));
 
-    // Click to expand
-    fireEvent.click(screen.getByText("Show details"));
-
-    // Now details should be visible
-    expect(screen.getByText("Input Signals")).toBeInTheDocument();
-    expect(screen.getByText("Agent Reasoning")).toBeInTheDocument();
+    // Now technical details should be visible (using glass-kv format)
+    expect(screen.getByText("Stock level")).toBeInTheDocument();
     expect(screen.getByText("100 units")).toBeInTheDocument();
+    expect(screen.getByText("Base price")).toBeInTheDocument();
     expect(screen.getByText("$25.00")).toBeInTheDocument();
+    expect(screen.getByText("Market reference")).toBeInTheDocument();
     expect(screen.getByText("$28.00")).toBeInTheDocument();
+    expect(screen.getByText("Time to decide")).toBeInTheDocument();
+    expect(screen.getByText("150 ms")).toBeInTheDocument();
   });
 
-  it("renders NO_PROMO action correctly", () => {
+  it("shows reason codes in expanded view", () => {
+    render(<AgentActivityItem event={baseEvent} isLast={false} />);
+    fireEvent.click(screen.getByText("Details"));
+    // Details panel now shows reason codes instead of quoted reasoning
+    expect(screen.getByText("Reason codes:")).toBeInTheDocument();
+    expect(screen.getByText("HIGH_INVENTORY, BELOW_MARKET")).toBeInTheDocument();
+  });
+
+  it("renders NO_PROMO outcome correctly", () => {
     const noPromoEvent: AgentActivityEvent = {
       ...baseEvent,
       decision: {
@@ -81,10 +92,15 @@ describe("AgentActivityItem", () => {
       },
     };
     render(<AgentActivityItem event={noPromoEvent} isLast={false} />);
-    expect(screen.getByText("NO PROMO")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No promotion was applied — the agent determined pricing was already optimal."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("No change")).toBeInTheDocument();
   });
 
-  it("renders pending status with animation", () => {
+  it("renders pending status with evaluating message", () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { decision: _unused, ...baseEventWithoutDecision } = baseEvent;
     const pendingEvent: AgentActivityEvent = {
@@ -92,11 +108,14 @@ describe("AgentActivityItem", () => {
       status: "pending",
     };
     render(<AgentActivityItem event={pendingEvent} isLast={false} />);
-    // The component should still render without errors
+    expect(screen.getByText("Evaluating")).toBeInTheDocument();
     expect(screen.getByText("Classic T-Shirt")).toBeInTheDocument();
+    expect(
+      screen.getByText("Gathering context from the cart, inventory, and market signals…")
+    ).toBeInTheDocument();
   });
 
-  it("renders error status correctly", () => {
+  it("renders error status with error styling", () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { decision: _unused, ...baseEventWithoutDecision } = baseEvent;
     const errorEvent: AgentActivityEvent = {
@@ -106,14 +125,35 @@ describe("AgentActivityItem", () => {
     };
     render(<AgentActivityItem event={errorEvent} isLast={false} />);
 
-    // Expand to see error
-    fireEvent.click(screen.getByText("Show details"));
     expect(screen.getByText("Error")).toBeInTheDocument();
+    // Error message should be visible directly (not hidden)
     expect(screen.getByText("Agent timeout")).toBeInTheDocument();
   });
 
-  it("renders duration when available", () => {
-    render(<AgentActivityItem event={baseEvent} isLast={false} />);
-    expect(screen.getByText("150ms")).toBeInTheDocument();
+  it("displays 'Above market' position in expanded details", () => {
+    const aboveMarketEvent: AgentActivityEvent = {
+      ...baseEvent,
+      inputSignals: {
+        ...baseEvent.inputSignals,
+        competitionPosition: "above_market",
+      },
+    };
+    render(<AgentActivityItem event={aboveMarketEvent} isLast={false} />);
+    // Click to expand details
+    fireEvent.click(screen.getByText("Details"));
+    // Check that the price position shows "Above market" in the details
+    expect(screen.getByText("Price position")).toBeInTheDocument();
+    expect(screen.getByText("Above market")).toBeInTheDocument();
+  });
+
+  it("does not show Details button when pending", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { decision: _unused, ...baseEventWithoutDecision } = baseEvent;
+    const pendingEvent: AgentActivityEvent = {
+      ...baseEventWithoutDecision,
+      status: "pending",
+    };
+    render(<AgentActivityItem event={pendingEvent} isLast={false} />);
+    expect(screen.queryByText("Details")).not.toBeInTheDocument();
   });
 });

--- a/src/ui/components/agent-activity/AgentActivityItem.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Stack, Text, Badge, Flex } from "@kui/foundations-react-external";
 import type { AgentActivityEvent, AgentType } from "@/types";
 
 /**
@@ -9,52 +8,74 @@ import type { AgentActivityEvent, AgentType } from "@/types";
  */
 function getAgentTypeInfo(type: AgentType): {
   label: string;
-  color: "green" | "blue" | "purple" | "yellow" | "orange";
   icon: string;
 } {
   switch (type) {
     case "promotion":
-      return { label: "PROMOTION", color: "green", icon: "%" };
+      return { label: "Promotion", icon: "%" };
     case "recommendation":
-      return { label: "RECOMMEND", color: "blue", icon: "★" };
+      return { label: "Recommendation", icon: "★" };
     case "post_purchase":
-      return { label: "POST-PURCHASE", color: "purple", icon: "✉" };
+      return { label: "Post-Purchase", icon: "✉" };
   }
 }
 
 /**
- * Get display info for promotion actions
+ * Get human-readable action label and percentage
  */
 function getActionInfo(action: string): {
   label: string;
-  color: "green" | "blue" | "yellow" | "red" | "gray";
+  percentage: number;
+  shortLabel: string;
 } {
   switch (action) {
     case "DISCOUNT_5_PCT":
-      return { label: "5% OFF", color: "green" };
+      return { label: "5% discount applied", percentage: 5, shortLabel: "5% off" };
     case "DISCOUNT_10_PCT":
-      return { label: "10% OFF", color: "green" };
+      return { label: "10% discount applied", percentage: 10, shortLabel: "10% off" };
     case "DISCOUNT_15_PCT":
-      return { label: "15% OFF", color: "green" };
+      return { label: "15% discount applied", percentage: 15, shortLabel: "15% off" };
     case "FREE_SHIPPING":
-      return { label: "FREE SHIP", color: "blue" };
+      return { label: "Free shipping applied", percentage: 0, shortLabel: "Free shipping" };
     case "NO_PROMO":
-      return { label: "NO PROMO", color: "gray" };
+      return { label: "No promotion applied", percentage: 0, shortLabel: "No discount" };
     default:
-      return { label: action, color: "gray" };
+      return { label: action, percentage: 0, shortLabel: action };
   }
 }
 
 /**
- * Format timestamp to readable time
+ * Get human-readable outcome for promotion actions
  */
-function formatTime(date: Date): string {
-  return date.toLocaleTimeString("en-US", {
-    hour12: false,
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+function getOutcomeInfo(action: string, amount: number): {
+  label: string;
+  valueText: string;
+  isPositive: boolean;
+  actionInfo: ReturnType<typeof getActionInfo>;
+} {
+  const formattedAmount = `$${(amount / 100).toFixed(2)}`;
+  const actionInfo = getActionInfo(action);
+  
+  switch (action) {
+    case "DISCOUNT_5_PCT":
+    case "DISCOUNT_10_PCT":
+    case "DISCOUNT_15_PCT":
+      return { label: `${actionInfo.label} based on current checkout context.`, valueText: `−${formattedAmount}`, isPositive: true, actionInfo };
+    case "FREE_SHIPPING":
+      return { label: "Free shipping applied", valueText: "Free", isPositive: true, actionInfo };
+    case "NO_PROMO":
+      return { label: "No promotion was applied — the agent determined pricing was already optimal.", valueText: "$0.00", isPositive: false, actionInfo };
+    default:
+      return { label: action, valueText: "$0.00", isPositive: false, actionInfo };
+  }
+}
+
+/**
+ * Format duration to human-readable time
+ */
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return "—";
+  return `${ms} ms`;
 }
 
 /**
@@ -70,193 +91,157 @@ interface AgentActivityItemProps {
 }
 
 /**
- * Single Agent Activity event item in the timeline
+ * Decision Card - displays a single agent decision with glass design
  */
 export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const typeInfo = getAgentTypeInfo(event.agentType);
   const isPending = event.status === "pending";
   const isError = event.status === "error";
-  const isSkipped = event.status === "skipped";
 
   const toggleExpanded = () => setIsExpanded(!isExpanded);
 
+  // Get outcome info
+  const outcomeInfo = event.decision
+    ? getOutcomeInfo(event.decision.action, event.decision.discountAmount)
+    : null;
+
+  // Get the LLM reasoning - this is the actual explanation from the agent
+  const llmReasoning = event.decision?.reasoning;
+
+  // Determine card style
+  const isHighlight = outcomeInfo?.isPositive && !isError && !isPending;
+
   return (
-    <div className="relative flex gap-4 pb-7">
-      {/* Timeline connector */}
-      {!isLast && (
-        <div
-          className="absolute left-[11px] top-[28px] w-[2px] h-[calc(100%-14px)]"
-          style={{
-            background: isPending ? "linear-gradient(to bottom, #404040, transparent)" : "#333333",
-          }}
-        />
-      )}
-
-      {/* Timeline dot */}
-      <div className="relative z-10 flex-shrink-0">
-        <div
-          className={`w-6 h-6 rounded-full flex items-center justify-center text-xs
-            ${isPending ? "bg-[#333333] animate-pulse" : isError ? "bg-red-900/50 border border-red-700" : isSkipped ? "bg-gray-800/50 border border-gray-600" : "bg-[#242424] border border-[#404040]"}`}
-        >
-          {isPending ? (
-            <div className="w-2 h-2 rounded-full bg-gray-400 animate-pulse" />
-          ) : (
-            <span
-              className={isError ? "text-red-400" : isSkipped ? "text-gray-500" : "text-green-400"}
-            >
-              {isError ? "!" : typeInfo.icon}
-            </span>
-          )}
+    <div style={{ marginBottom: isLast ? 0 : "12px" }}>
+      {/* Decision Card */}
+      <div className={`glass-decision ${isHighlight ? "highlight" : ""}`}>
+        {/* Header row */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "12px" }}>
+          <div className="glass-kicker">
+            <span style={{
+              width: "8px",
+              height: "8px",
+              borderRadius: "50%",
+              background: isPending
+                ? "rgba(255, 255, 255, 0.4)"
+                : isError
+                  ? "#FF6B6B"
+                  : "rgba(118, 185, 0, 0.9)",
+              boxShadow: isPending
+                ? "none"
+                : isError
+                  ? "0 0 0 4px rgba(255, 107, 107, 0.12)"
+                  : "0 0 0 4px rgba(118, 185, 0, 0.12)",
+              display: "inline-block"
+            }}></span>
+            {typeInfo.label} Decision
+          </div>
+          <div className={`glass-pill ${isPending ? "yellow" : isError ? "" : outcomeInfo?.isPositive ? "green" : ""}`}>
+            {isPending ? "Evaluating" : isError ? "Error" : outcomeInfo?.isPositive ? "Applied" : "No change"}
+          </div>
         </div>
-      </div>
 
-      {/* Event content */}
-      <div className="flex-1 min-w-0">
-        {/* Header with badge and time */}
-        <Flex justify="between" align="center" className="mb-2">
-          <Badge
-            kind="solid"
-            color={isError ? "red" : isSkipped ? "gray" : typeInfo.color}
-            className="text-xs"
-          >
-            {typeInfo.label}
-          </Badge>
-          <Text kind="body/regular/sm" className="text-subtle">
-            {formatTime(event.timestamp)}
-          </Text>
-        </Flex>
-
-        {/* Product name */}
-        <Text kind="body/regular/md" className="text-secondary mb-1.5">
+        {/* Product Name */}
+        <div style={{ marginTop: "8px", fontSize: "13px", color: "var(--text-secondary)", fontWeight: "650" }}>
           {event.inputSignals.productName}
-        </Text>
+        </div>
 
-        {/* Decision badge */}
-        {event.decision && (
-          <Flex align="center" gap="2" className="mb-2">
-            <Badge
-              kind="solid"
-              color={getActionInfo(event.decision.action).color}
-              className="text-xs"
-            >
-              {getActionInfo(event.decision.action).label}
-            </Badge>
-            {event.decision.discountAmount > 0 && (
-              <Text kind="body/regular/sm" className="text-green-400">
-                -{formatCurrency(event.decision.discountAmount)}
-              </Text>
-            )}
-          </Flex>
-        )}
+        {/* Summary and Value */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginTop: "10px", gap: "12px" }}>
+          <div style={{ color: "var(--text-muted)", fontSize: "12px", lineHeight: "1.35" }}>
+            {isPending
+              ? "Gathering context from the cart, inventory, and market signals…"
+              : outcomeInfo?.label || "Processing..."}
+          </div>
+          <div className={`glass-value ${outcomeInfo?.isPositive ? "positive" : ""}`}>
+            {outcomeInfo?.valueText || "$0.00"}
+          </div>
+        </div>
 
-        {/* Reason codes pills */}
-        {event.decision && event.decision.reasonCodes.length > 0 && (
-          <Flex gap="1" wrap="wrap" className="mb-2">
-            {event.decision.reasonCodes.map((code, index) => (
-              <span
-                key={index}
-                className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-[#2a2a2a] text-gray-400 border border-[#404040]"
-              >
-                {code.replace(/_/g, " ")}
-              </span>
-            ))}
-          </Flex>
-        )}
-
-        {/* Expandable section for details */}
-        <button
-          onClick={toggleExpanded}
-          className="flex items-center gap-1 text-xs text-subtle hover:text-secondary transition-colors mt-2"
-        >
-          <span className="transform transition-transform duration-200">
-            {isExpanded ? "▼" : "▶"}
-          </span>
-          {isExpanded ? "Hide details" : "Show details"}
-        </button>
-
-        {isExpanded && (
-          <div className="mt-3 p-3 rounded-lg bg-[#1a1a1a] border border-[#333333]">
-            {/* Input Signals */}
-            <Text kind="label/semibold/sm" className="text-subtle mb-2 block">
-              Input Signals
-            </Text>
-            <Stack gap="1" className="mb-4">
-              <Flex justify="between" className="text-xs">
-                <span className="text-subtle">Stock Count:</span>
-                <span className="text-secondary font-mono">
-                  {event.inputSignals.stockCount} units
-                </span>
-              </Flex>
-              <Flex justify="between" className="text-xs">
-                <span className="text-subtle">Base Price:</span>
-                <span className="text-secondary font-mono">
-                  {formatCurrency(event.inputSignals.basePrice)}
-                </span>
-              </Flex>
-              {event.inputSignals.competitorPrice && (
-                <Flex justify="between" className="text-xs">
-                  <span className="text-subtle">Competitor Price:</span>
-                  <span className="text-secondary font-mono">
-                    {formatCurrency(event.inputSignals.competitorPrice)}
-                  </span>
-                </Flex>
-              )}
-              <Flex justify="between" className="text-xs">
-                <span className="text-subtle">Inventory Pressure:</span>
-                <span
-                  className={`font-mono ${event.inputSignals.inventoryPressure === "high" ? "text-yellow-400" : "text-gray-400"}`}
-                >
-                  {event.inputSignals.inventoryPressure.toUpperCase()}
-                </span>
-              </Flex>
-              <Flex justify="between" className="text-xs">
-                <span className="text-subtle">Competition Position:</span>
-                <span
-                  className={`font-mono ${
-                    event.inputSignals.competitionPosition === "above_market"
-                      ? "text-red-400"
-                      : event.inputSignals.competitionPosition === "below_market"
-                        ? "text-green-400"
-                        : "text-gray-400"
-                  }`}
-                >
-                  {event.inputSignals.competitionPosition.replace(/_/g, " ").toUpperCase()}
-                </span>
-              </Flex>
-            </Stack>
-
-            {/* Agent Reasoning */}
-            {event.decision?.reasoning && (
-              <>
-                <Text kind="label/semibold/sm" className="text-subtle mb-2 block">
-                  Agent Reasoning
-                </Text>
-                <Text kind="body/regular/sm" className="text-gray-400 italic leading-relaxed">
-                  &quot;{event.decision.reasoning}&quot;
-                </Text>
-              </>
-            )}
-
-            {/* Error message */}
-            {event.error && (
-              <>
-                <Text kind="label/semibold/sm" className="text-red-400 mb-2 block">
-                  Error
-                </Text>
-                <Text kind="body/regular/sm" className="text-red-400">
-                  {event.error}
-                </Text>
-              </>
-            )}
+        {/* Why this happened - shows LLM reasoning */}
+        {llmReasoning && !isPending && !isError && (
+          <div className="glass-section">
+            <h3>Why this happened</h3>
+            <p style={{ margin: 0, color: "var(--text-secondary)", fontSize: "12px", lineHeight: "1.45" }}>
+              {llmReasoning}
+            </p>
           </div>
         )}
 
-        {/* Duration */}
-        {event.duration !== undefined && !isPending && (
-          <Text kind="body/regular/sm" className="text-subtle mt-1.5">
-            {event.duration}ms
-          </Text>
+        {/* Error message */}
+        {isError && event.error && (
+          <div style={{
+            marginTop: "12px",
+            padding: "10px 12px",
+            borderRadius: "14px",
+            border: "1px solid rgba(255, 107, 107, 0.25)",
+            background: "rgba(255, 107, 107, 0.08)",
+            fontSize: "12px",
+            color: "#FF6B6B"
+          }}>
+            {event.error}
+          </div>
+        )}
+
+        {/* Details toggle */}
+        {!isPending && (
+          <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", marginTop: "12px" }}>
+            <button
+              className="glass-details-toggle"
+              onClick={toggleExpanded}
+              aria-expanded={isExpanded}
+              type="button"
+            >
+              <span className="glass-chevron"></span>
+              <span>Details</span>
+            </button>
+          </div>
+        )}
+
+        {/* Expandable details panel */}
+        {isExpanded && !isPending && (
+          <div className="glass-details" style={{ display: "block" }}>
+            <div className="glass-kv">
+              <div className="k">Stock level</div>
+              <div className="v">{event.inputSignals.stockCount} units</div>
+              <div className="k">Base price</div>
+              <div className="v">{formatCurrency(event.inputSignals.basePrice)}</div>
+              {event.inputSignals.competitorPrice && (
+                <>
+                  <div className="k">Market reference</div>
+                  <div className="v">{formatCurrency(event.inputSignals.competitorPrice)}</div>
+                </>
+              )}
+              <div className="k">Inventory state</div>
+              <div className="v">{event.inputSignals.inventoryPressure === "high" ? "High" : "Normal"}</div>
+              <div className="k">Price position</div>
+              <div className="v">
+                {event.inputSignals.competitionPosition === "above_market"
+                  ? "Above market"
+                  : event.inputSignals.competitionPosition === "below_market"
+                    ? "Below market"
+                    : event.inputSignals.competitionPosition === "at_market"
+                      ? "At market"
+                      : "Unknown"}
+              </div>
+              {event.duration !== undefined && (
+                <>
+                  <div className="k">Time to decide</div>
+                  <div className="v">{formatDuration(event.duration)}</div>
+                </>
+              )}
+            </div>
+            {event.decision?.reasonCodes && event.decision.reasonCodes.length > 0 && (
+              <>
+                <div className="glass-divider"></div>
+                <div style={{ color: "var(--text-muted)", fontSize: "12px" }}>
+                  <span style={{ fontWeight: "500" }}>Reason codes: </span>
+                  {event.decision.reasonCodes.join(", ")}
+                </div>
+              </>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/ui/components/agent-activity/AgentActivityItem.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.tsx
@@ -47,7 +47,10 @@ function getActionInfo(action: string): {
 /**
  * Get human-readable outcome for promotion actions
  */
-function getOutcomeInfo(action: string, amount: number): {
+function getOutcomeInfo(
+  action: string,
+  amount: number
+): {
   label: string;
   valueText: string;
   isPositive: boolean;
@@ -55,16 +58,26 @@ function getOutcomeInfo(action: string, amount: number): {
 } {
   const formattedAmount = `$${(amount / 100).toFixed(2)}`;
   const actionInfo = getActionInfo(action);
-  
+
   switch (action) {
     case "DISCOUNT_5_PCT":
     case "DISCOUNT_10_PCT":
     case "DISCOUNT_15_PCT":
-      return { label: `${actionInfo.label} based on current checkout context.`, valueText: `−${formattedAmount}`, isPositive: true, actionInfo };
+      return {
+        label: `${actionInfo.label} based on current checkout context.`,
+        valueText: `−${formattedAmount}`,
+        isPositive: true,
+        actionInfo,
+      };
     case "FREE_SHIPPING":
       return { label: "Free shipping applied", valueText: "Free", isPositive: true, actionInfo };
     case "NO_PROMO":
-      return { label: "No promotion was applied — the agent determined pricing was already optimal.", valueText: "$0.00", isPositive: false, actionInfo };
+      return {
+        label: "No promotion was applied — the agent determined pricing was already optimal.",
+        valueText: "$0.00",
+        isPositive: false,
+        actionInfo,
+      };
     default:
       return { label: action, valueText: "$0.00", isPositive: false, actionInfo };
   }
@@ -117,38 +130,70 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
       {/* Decision Card */}
       <div className={`glass-decision ${isHighlight ? "highlight" : ""}`}>
         {/* Header row */}
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "12px" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: "12px",
+          }}
+        >
           <div className="glass-kicker">
-            <span style={{
-              width: "8px",
-              height: "8px",
-              borderRadius: "50%",
-              background: isPending
-                ? "rgba(255, 255, 255, 0.4)"
-                : isError
-                  ? "#FF6B6B"
-                  : "rgba(118, 185, 0, 0.9)",
-              boxShadow: isPending
-                ? "none"
-                : isError
-                  ? "0 0 0 4px rgba(255, 107, 107, 0.12)"
-                  : "0 0 0 4px rgba(118, 185, 0, 0.12)",
-              display: "inline-block"
-            }}></span>
+            <span
+              style={{
+                width: "8px",
+                height: "8px",
+                borderRadius: "50%",
+                background: isPending
+                  ? "rgba(255, 255, 255, 0.4)"
+                  : isError
+                    ? "#FF6B6B"
+                    : "rgba(118, 185, 0, 0.9)",
+                boxShadow: isPending
+                  ? "none"
+                  : isError
+                    ? "0 0 0 4px rgba(255, 107, 107, 0.12)"
+                    : "0 0 0 4px rgba(118, 185, 0, 0.12)",
+                display: "inline-block",
+              }}
+            ></span>
             {typeInfo.label} Decision
           </div>
-          <div className={`glass-pill ${isPending ? "yellow" : isError ? "" : outcomeInfo?.isPositive ? "green" : ""}`}>
-            {isPending ? "Evaluating" : isError ? "Error" : outcomeInfo?.isPositive ? "Applied" : "No change"}
+          <div
+            className={`glass-pill ${isPending ? "yellow" : isError ? "" : outcomeInfo?.isPositive ? "green" : ""}`}
+          >
+            {isPending
+              ? "Evaluating"
+              : isError
+                ? "Error"
+                : outcomeInfo?.isPositive
+                  ? "Applied"
+                  : "No change"}
           </div>
         </div>
 
         {/* Product Name */}
-        <div style={{ marginTop: "8px", fontSize: "13px", color: "var(--text-secondary)", fontWeight: "650" }}>
+        <div
+          style={{
+            marginTop: "8px",
+            fontSize: "13px",
+            color: "var(--text-secondary)",
+            fontWeight: "650",
+          }}
+        >
           {event.inputSignals.productName}
         </div>
 
         {/* Summary and Value */}
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginTop: "10px", gap: "12px" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+            marginTop: "10px",
+            gap: "12px",
+          }}
+        >
           <div style={{ color: "var(--text-muted)", fontSize: "12px", lineHeight: "1.35" }}>
             {isPending
               ? "Gathering context from the cart, inventory, and market signals…"
@@ -163,7 +208,14 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
         {llmReasoning && !isPending && !isError && (
           <div className="glass-section">
             <h3>Why this happened</h3>
-            <p style={{ margin: 0, color: "var(--text-secondary)", fontSize: "12px", lineHeight: "1.45" }}>
+            <p
+              style={{
+                margin: 0,
+                color: "var(--text-secondary)",
+                fontSize: "12px",
+                lineHeight: "1.45",
+              }}
+            >
               {llmReasoning}
             </p>
           </div>
@@ -171,22 +223,31 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
 
         {/* Error message */}
         {isError && event.error && (
-          <div style={{
-            marginTop: "12px",
-            padding: "10px 12px",
-            borderRadius: "14px",
-            border: "1px solid rgba(255, 107, 107, 0.25)",
-            background: "rgba(255, 107, 107, 0.08)",
-            fontSize: "12px",
-            color: "#FF6B6B"
-          }}>
+          <div
+            style={{
+              marginTop: "12px",
+              padding: "10px 12px",
+              borderRadius: "14px",
+              border: "1px solid rgba(255, 107, 107, 0.25)",
+              background: "rgba(255, 107, 107, 0.08)",
+              fontSize: "12px",
+              color: "#FF6B6B",
+            }}
+          >
             {event.error}
           </div>
         )}
 
         {/* Details toggle */}
         {!isPending && (
-          <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", marginTop: "12px" }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "center",
+              marginTop: "12px",
+            }}
+          >
             <button
               className="glass-details-toggle"
               onClick={toggleExpanded}
@@ -214,7 +275,9 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
                 </>
               )}
               <div className="k">Inventory state</div>
-              <div className="v">{event.inputSignals.inventoryPressure === "high" ? "High" : "Normal"}</div>
+              <div className="v">
+                {event.inputSignals.inventoryPressure === "high" ? "High" : "Normal"}
+              </div>
               <div className="k">Price position</div>
               <div className="v">
                 {event.inputSignals.competitionPosition === "above_market"

--- a/src/ui/components/agent-activity/AgentActivityPanel.test.tsx
+++ b/src/ui/components/agent-activity/AgentActivityPanel.test.tsx
@@ -23,7 +23,9 @@ describe("AgentActivityPanel", () => {
     renderWithProviders(<AgentActivityPanel />);
     expect(screen.getByText("Waiting to observe")).toBeInTheDocument();
     expect(
-      screen.getByText("When you start a checkout, the AI agent will evaluate the context and make real-time decisions here.")
+      screen.getByText(
+        "When you start a checkout, the AI agent will evaluate the context and make real-time decisions here."
+      )
     ).toBeInTheDocument();
   });
 });

--- a/src/ui/components/agent-activity/AgentActivityPanel.test.tsx
+++ b/src/ui/components/agent-activity/AgentActivityPanel.test.tsx
@@ -19,11 +19,11 @@ describe("AgentActivityPanel", () => {
     expect(screen.getByRole("region", { name: "Agent Activity Panel" })).toBeInTheDocument();
   });
 
-  it("renders empty state when no agent activity", () => {
+  it("renders empty state with waiting message", () => {
     renderWithProviders(<AgentActivityPanel />);
-    expect(screen.getByText("No agent activity")).toBeInTheDocument();
+    expect(screen.getByText("Waiting to observe")).toBeInTheDocument();
     expect(
-      screen.getByText("Agent decisions will appear here when products are added to checkout.")
+      screen.getByText("When you start a checkout, the AI agent will evaluate the context and make real-time decisions here.")
     ).toBeInTheDocument();
   });
 });

--- a/src/ui/components/agent-activity/AgentActivityPanel.tsx
+++ b/src/ui/components/agent-activity/AgentActivityPanel.tsx
@@ -1,116 +1,141 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { Stack, Text, Badge, Flex } from "@kui/foundations-react-external";
 import { useAgentActivityLog } from "@/hooks/useAgentActivityLog";
 import { AgentActivityItem } from "./AgentActivityItem";
 
 /**
- * Empty state with visual placeholder
+ * Convert action code to human-readable text for timeline display
+ */
+function getHumanReadableAction(action: string): string {
+  switch (action) {
+    case "DISCOUNT_5_PCT":
+      return "Applied 5% discount";
+    case "DISCOUNT_10_PCT":
+      return "Applied 10% discount";
+    case "DISCOUNT_15_PCT":
+      return "Applied 15% discount";
+    case "FREE_SHIPPING":
+      return "Applied free shipping";
+    case "NO_PROMO":
+      return "No promotion needed";
+    default:
+      return action;
+  }
+}
+
+/**
+ * Empty state - shows agent waiting state
  */
 function EmptyState() {
   return (
-    <div className="flex-1 flex items-center justify-center p-6">
-      <Stack gap="3" align="center" className="max-w-xs text-center">
-        {/* Subtle icon placeholder */}
-        <div className="w-12 h-12 rounded-xl bg-[#242424] border border-[#333333] flex items-center justify-center mb-2">
-          <svg
-            className="w-6 h-6 text-subtle"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-            />
-          </svg>
-        </div>
-        <Text kind="label/semibold/md" className="text-secondary">
-          No agent activity
-        </Text>
-        <Text kind="body/regular/sm" className="text-subtle">
-          Agent decisions will appear here when products are added to checkout.
-        </Text>
-      </Stack>
+    <div className="glass-content" style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", flex: 1, padding: "48px 24px", textAlign: "center" }}>
+      {/* Icon */}
+      <div style={{
+        width: "48px",
+        height: "48px",
+        borderRadius: "14px",
+        background: "var(--block-bg)",
+        border: "1px solid var(--glass-border)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        marginBottom: "16px"
+      }}>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: "var(--text-muted)" }}>
+          <path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+        </svg>
+      </div>
+      <h3 style={{ margin: "0 0 8px", fontSize: "14px", fontWeight: "600", color: "var(--text-secondary)" }}>
+        Waiting to observe
+      </h3>
+      <p style={{ margin: 0, fontSize: "12px", color: "var(--text-muted)", lineHeight: "1.45", maxWidth: "260px" }}>
+        When you start a checkout, the AI agent will evaluate the context and make real-time decisions here.
+      </p>
     </div>
   );
 }
 
 /**
- * Active session view with agent activity timeline
+ * Get agent state label
+ */
+function getAgentState(events: ReturnType<typeof useAgentActivityLog>["state"]["events"]): {
+  label: string;
+  pillClass: string;
+} {
+  if (events.length === 0) return { label: "Idle", pillClass: "glass-pill green" };
+  const lastEvent = events[events.length - 1];
+  if (!lastEvent) return { label: "Idle", pillClass: "glass-pill green" };
+  if (lastEvent.status === "pending") return { label: "Reasoning", pillClass: "glass-pill green" };
+  if (lastEvent.status === "error") return { label: "Error", pillClass: "glass-pill" };
+  return { label: "Complete", pillClass: "glass-pill green" };
+}
+
+/**
+ * Active session view with agent activity decisions
  */
 function ActiveAgentActivity() {
   const { state } = useAgentActivityLog();
   const scrollRef = useRef<HTMLDivElement>(null);
+  const agentState = getAgentState(state.events);
 
-  // Auto-scroll to bottom when new events arrive
+  // Auto-scroll to top when new events arrive (newest first)
   useEffect(() => {
     if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      scrollRef.current.scrollTop = 0;
     }
   }, [state.events.length]);
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      {/* Session header */}
-      <div
-        className="border-b border-[#333333] bg-[#1a1a1a]"
-        style={{ padding: "32px 32px 16px 32px", marginTop: "16px" }}
-      >
-        <Flex justify="between" align="center">
-          <Text kind="label/semibold/md" className="text-secondary">
-            Agent Decisions
-          </Text>
-          <Flex align="center" gap="2">
-            <div className="w-2.5 h-2.5 rounded-full bg-green-500 animate-pulse" />
-            <Text kind="body/regular/sm" className="text-subtle">
-              {state.events.length} decision{state.events.length !== 1 ? "s" : ""}
-            </Text>
-          </Flex>
-        </Flex>
+    <div className="glass-content">
+      {/* Title Section */}
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "12px", marginBottom: "12px" }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: "16px", letterSpacing: "0.2px", color: "var(--text-primary)" }}>
+            Autonomous Decisions
+          </h2>
+        </div>
+        <div className={agentState.pillClass}>{agentState.label}</div>
       </div>
 
-      {/* Event timeline */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-6 pl-8 bg-[#171717]">
-        <Stack gap="0">
-          {state.events.map((event, index) => (
-            <AgentActivityItem
-              key={event.id}
-              event={event}
-              isLast={index === state.events.length - 1}
-            />
+      {/* Decision cards */}
+      <div ref={scrollRef} style={{ maxHeight: "calc(100vh - 350px)", overflowY: "auto" }}>
+        {state.events.map((event, index) => (
+          <AgentActivityItem
+            key={event.id}
+            event={event}
+            isLast={index === state.events.length - 1}
+          />
+        ))}
+      </div>
+
+      {/* Timeline */}
+      <div className="glass-section">
+        <h3>Agent Timeline</h3>
+        <div className="glass-timeline" style={{ maxHeight: "200px", overflowY: "auto" }}>
+          {[...state.events].reverse().map((event) => (
+            <div key={`timeline-${event.id}`} className="glass-event">
+              <div className="time">
+                {event.timestamp.toLocaleTimeString("en-US", {
+                  hour12: false,
+                  hour: "2-digit",
+                  minute: "2-digit",
+                  second: "2-digit",
+                })}
+              </div>
+              <div className="msg">
+                {event.status === "pending"
+                  ? `Evaluating ${event.inputSignals.productName}...`
+                  : event.decision
+                    ? `${getHumanReadableAction(event.decision.action)} for ${event.inputSignals.productName}`
+                    : `Processed ${event.inputSignals.productName}`}
+              </div>
+              <div className={`glass-tag ${event.status === "success" ? "green" : event.status === "error" ? "" : "yellow"}`}>
+                {event.status === "pending" ? "EVALUATING" : event.status === "success" ? "DECIDED" : event.status === "error" ? "ERROR" : "SKIPPED"}
+              </div>
+            </div>
           ))}
-        </Stack>
-      </div>
-
-      {/* Footer with legend */}
-      <div
-        className="border-t border-[#333333] bg-[#1a1a1a]"
-        style={{ padding: "16px 32px 16px 48px" }}
-      >
-        <Flex gap="6" wrap="wrap">
-          <Flex align="center" gap="2">
-            <div className="w-2.5 h-2.5 rounded-full bg-green-500 flex-shrink-0" />
-            <Text kind="body/regular/sm" className="text-subtle whitespace-nowrap">
-              Promotion
-            </Text>
-          </Flex>
-          <Flex align="center" gap="2">
-            <div className="w-2.5 h-2.5 rounded-full bg-green-500 flex-shrink-0" />
-            <Text kind="body/regular/sm" className="text-subtle whitespace-nowrap">
-              Discount Applied
-            </Text>
-          </Flex>
-          <Flex align="center" gap="2">
-            <div className="w-2.5 h-2.5 rounded-full bg-gray-500 flex-shrink-0" />
-            <Text kind="body/regular/sm" className="text-subtle whitespace-nowrap">
-              No Promo
-            </Text>
-          </Flex>
-        </Flex>
+        </div>
       </div>
     </div>
   );
@@ -118,21 +143,21 @@ function ActiveAgentActivity() {
 
 /**
  * Agent Activity Panel - displays agent decisions and reasoning
- * This panel sits next to the Merchant Server panel without a divider
+ * This panel shows how the AI agent evaluates context and makes decisions
+ * Uses glassmorphic design system
  */
 export function AgentActivityPanel() {
   const { state } = useAgentActivityLog();
+  const hasEvents = state.events.length > 0;
 
   return (
-    <section
-      className="flex-1 flex flex-col h-full overflow-hidden bg-[#1e1e1e] border border-[#333333] rounded-2xl"
-      aria-label="Agent Activity Panel"
-    >
-      {/* Clean header with badge */}
-      <div className="px-6 pt-5 pb-6 border-b border-[#333333]">
-        <Badge kind="solid" color="green">
+    <section className="glass-panel flex-1 flex flex-col h-full overflow-hidden" aria-label="Agent Activity Panel">
+      {/* Glass Panel Header */}
+      <div className="glass-panel-header">
+        <div className={`glass-badge ${hasEvents ? "green" : "gray"}`}>
+          <span className={`glass-dot ${hasEvents ? "live" : ""}`}></span>
           Agent Activity
-        </Badge>
+        </div>
       </div>
 
       {/* Content - either empty state or active session */}

--- a/src/ui/components/agent-activity/AgentActivityPanel.tsx
+++ b/src/ui/components/agent-activity/AgentActivityPanel.tsx
@@ -29,28 +29,67 @@ function getHumanReadableAction(action: string): string {
  */
 function EmptyState() {
   return (
-    <div className="glass-content" style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", flex: 1, padding: "48px 24px", textAlign: "center" }}>
-      {/* Icon */}
-      <div style={{
-        width: "48px",
-        height: "48px",
-        borderRadius: "14px",
-        background: "var(--block-bg)",
-        border: "1px solid var(--glass-border)",
+    <div
+      className="glass-content"
+      style={{
         display: "flex",
+        flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        marginBottom: "16px"
-      }}>
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: "var(--text-muted)" }}>
+        flex: 1,
+        padding: "48px 24px",
+        textAlign: "center",
+      }}
+    >
+      {/* Icon */}
+      <div
+        style={{
+          width: "48px",
+          height: "48px",
+          borderRadius: "14px",
+          background: "var(--block-bg)",
+          border: "1px solid var(--glass-border)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          marginBottom: "16px",
+        }}
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ color: "var(--text-muted)" }}
+        >
           <path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
         </svg>
       </div>
-      <h3 style={{ margin: "0 0 8px", fontSize: "14px", fontWeight: "600", color: "var(--text-secondary)" }}>
+      <h3
+        style={{
+          margin: "0 0 8px",
+          fontSize: "14px",
+          fontWeight: "600",
+          color: "var(--text-secondary)",
+        }}
+      >
         Waiting to observe
       </h3>
-      <p style={{ margin: 0, fontSize: "12px", color: "var(--text-muted)", lineHeight: "1.45", maxWidth: "260px" }}>
-        When you start a checkout, the AI agent will evaluate the context and make real-time decisions here.
+      <p
+        style={{
+          margin: 0,
+          fontSize: "12px",
+          color: "var(--text-muted)",
+          lineHeight: "1.45",
+          maxWidth: "260px",
+        }}
+      >
+        When you start a checkout, the AI agent will evaluate the context and make real-time
+        decisions here.
       </p>
     </div>
   );
@@ -89,9 +128,24 @@ function ActiveAgentActivity() {
   return (
     <div className="glass-content">
       {/* Title Section */}
-      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "12px", marginBottom: "12px" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          gap: "12px",
+          marginBottom: "12px",
+        }}
+      >
         <div>
-          <h2 style={{ margin: 0, fontSize: "16px", letterSpacing: "0.2px", color: "var(--text-primary)" }}>
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "16px",
+              letterSpacing: "0.2px",
+              color: "var(--text-primary)",
+            }}
+          >
             Autonomous Decisions
           </h2>
         </div>
@@ -130,8 +184,16 @@ function ActiveAgentActivity() {
                     ? `${getHumanReadableAction(event.decision.action)} for ${event.inputSignals.productName}`
                     : `Processed ${event.inputSignals.productName}`}
               </div>
-              <div className={`glass-tag ${event.status === "success" ? "green" : event.status === "error" ? "" : "yellow"}`}>
-                {event.status === "pending" ? "EVALUATING" : event.status === "success" ? "DECIDED" : event.status === "error" ? "ERROR" : "SKIPPED"}
+              <div
+                className={`glass-tag ${event.status === "success" ? "green" : event.status === "error" ? "" : "yellow"}`}
+              >
+                {event.status === "pending"
+                  ? "EVALUATING"
+                  : event.status === "success"
+                    ? "DECIDED"
+                    : event.status === "error"
+                      ? "ERROR"
+                      : "SKIPPED"}
               </div>
             </div>
           ))}
@@ -151,7 +213,10 @@ export function AgentActivityPanel() {
   const hasEvents = state.events.length > 0;
 
   return (
-    <section className="glass-panel flex-1 flex flex-col h-full overflow-hidden" aria-label="Agent Activity Panel">
+    <section
+      className="glass-panel flex-1 flex flex-col h-full overflow-hidden"
+      aria-label="Agent Activity Panel"
+    >
       {/* Glass Panel Header */}
       <div className="glass-panel-header">
         <div className={`glass-badge ${hasEvents ? "green" : "gray"}`}>


### PR DESCRIPTION
## Summary
- Replace hardcoded "WHY THIS HAPPENED" observations with actual LLM reasoning from the promotion agent
- Add human-readable action labels in the agent timeline (e.g., "Applied 10% discount" instead of "DISCOUNT_10_PCT")
- Remove hardcoded confidence indicator since it's not coming from the agent
- Hide "Time to decide" field when duration data is unavailable

## Test plan
- [x] Verify "Why this happened" section shows the actual LLM reasoning text
- [x] Verify timeline shows human-readable actions (e.g., "Applied 10% discount for Vintage Tee")
- [x] Verify confidence indicator is no longer displayed
- [x] Verify Details panel shows reason codes and technical data
- [x] Run `pnpm test:run` - AgentActivityItem tests should pass