### PR TITLE
[frontend] Add payment form and fix customer name in post-purchase messages

### DIFF
--- a/.cursor/skills/validation/SKILL.md
+++ b/.cursor/skills/validation/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: validation
+description: Validate ACP services and UI using Chrome MCP for browser testing, Kaizen UI MCP for NVIDIA styling, and curl for API endpoints. Use when starting development, testing changes, running health checks, or validating the checkout flow.
+---
+
+# ACP Validation
+
+Validates all Agentic Commerce Protocol services and UI before development or after changes.
+
+## Service Ports Reference
+
+| Service | Port | Health Endpoint |
+|---------|------|-----------------|
+| UI (Next.js) | 3000 | http://localhost:3000 |
+| Merchant API | 8000 | http://localhost:8000/health |
+| Payment (PSP) | 8001 | http://localhost:8001/health |
+| Promotion Agent | 8002 | http://localhost:8002/health |
+| Post-Purchase Agent | 8003 | http://localhost:8003/health |
+
+## Phase 1: Service Health Checks
+
+Run these curl commands to verify all backend services are operational.
+
+### Merchant API (port 8000)
+
+```bash
+curl -s http://localhost:8000/health | jq
+```
+
+Expected response:
+```json
+{"status": "healthy"}
+```
+
+### Payment Service (port 8001)
+
+```bash
+curl -s http://localhost:8001/health | jq
+```
+
+Expected response:
+```json
+{"status": "healthy"}
+```
+
+### Promotion Agent (port 8002)
+
+```bash
+curl -s http://localhost:8002/health | jq
+```
+
+Expected: 200 OK or agent-specific health response.
+
+### Post-Purchase Agent (port 8003)
+
+```bash
+curl -s http://localhost:8003/health | jq
+```
+
+Expected: 200 OK or agent-specific health response.
+
+### Quick Health Check (All Services)
+
+```bash
+echo "Merchant API (8000):" && curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health
+echo "\nPayment PSP (8001):" && curl -s -o /dev/null -w "%{http_code}" http://localhost:8001/health
+echo "\nPromotion Agent (8002):" && curl -s -o /dev/null -w "%{http_code}" http://localhost:8002/health
+echo "\nPost-Purchase Agent (8003):" && curl -s -o /dev/null -w "%{http_code}" http://localhost:8003/health
+echo "\nUI (3000):" && curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
+```
+
+All should return `200`.
+
+## Phase 2: API Endpoint Validation
+
+### Create Checkout Session
+
+```bash
+curl -X POST http://localhost:8000/checkout_sessions \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: your-api-key" \
+  -H "Idempotency-Key: test-$(date +%s)" \
+  -d '{
+    "line_items": [{"product_id": "prod_001", "quantity": 1}],
+    "buyer": {"id": "buyer_123", "email": "test@example.com"},
+    "fulfillment_address": {
+      "line1": "123 Test St",
+      "city": "San Francisco",
+      "state": "CA",
+      "postal_code": "94102",
+      "country": "US"
+    }
+  }' | jq
+```
+
+Expected: 201 with session ID and `status: "not_ready_for_payment"`.
+
+### Get Checkout Session
+
+```bash
+curl -s http://localhost:8000/checkout_sessions/{session_id} \
+  -H "X-API-Key: your-api-key" | jq
+```
+
+### Delegate Payment (PSP)
+
+```bash
+curl -X POST http://localhost:8001/agentic_commerce/delegate_payment \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: psp-api-key-12345" \
+  -H "Idempotency-Key: delegate-$(date +%s)" \
+  -d '{
+    "payment_method": {
+      "type": "card",
+      "card": {
+        "number": "4242424242424242",
+        "exp_month": 12,
+        "exp_year": 2030,
+        "cvc": "123"
+      }
+    },
+    "allowance": {
+      "amount": 10000,
+      "currency": "USD"
+    }
+  }' | jq
+```
+
+Expected: 201 with `vault_token` and `status: "active"`.
+
+## Phase 3: Browser UI Validation (Chrome MCP)
+
+Use the Chrome MCP server (`cursor-browser-extension` or `cursor-ide-browser`) for UI validation.
+
+### Validation Workflow
+
+1. **List existing tabs** to check browser state:
+   ```
+   browser_tabs action: "list"
+   ```
+
+2. **Navigate to UI**:
+   ```
+   browser_navigate url: "http://localhost:3000"
+   ```
+
+3. **Lock browser** for interactions:
+   ```
+   browser_lock
+   ```
+
+4. **Take snapshot** to verify page loaded:
+   ```
+   browser_snapshot
+   ```
+
+5. **Check console** for JavaScript errors:
+   ```
+   browser_console_messages level: "error"
+   ```
+
+6. **Unlock browser** when done:
+   ```
+   browser_unlock
+   ```
+
+### UI Elements to Verify
+
+After taking a snapshot, verify these elements exist:
+
+- **Navbar**: Logo, navigation links
+- **Three-Panel Layout**:
+  - Client Agent Panel (left) - Blue badge
+  - Merchant Server Panel (center) - Yellow badge  
+  - Agent Activity Panel (right) - Green badge
+- **Product Grid**: Product cards with images, names, prices
+- **Checkout Button**: Visible and clickable
+
+### Interaction Testing
+
+Test the checkout flow:
+
+```
+1. browser_snapshot → Find product card
+2. browser_click on "Add to Cart" or product
+3. browser_snapshot → Verify checkout modal appears
+4. browser_fill_form → Enter shipping details
+5. browser_click on "Continue" or "Checkout"
+6. browser_snapshot → Verify state progression
+7. browser_console_messages → Check for errors
+```
+
+## Phase 4: Kaizen UI Style Validation
+
+Use the Kaizen UI MCP server for NVIDIA design system compliance.
+
+### Style Checklist
+
+When validating UI components, verify:
+
+- **Colors**: Using NVIDIA brand colors (green #76B900, black #1A1A1A)
+- **Typography**: Proper font hierarchy and sizing
+- **Spacing**: Consistent padding/margins per design tokens
+- **Components**: Following Kaizen/Nebula component patterns
+- **Accessibility**: Proper contrast ratios, focus states
+
+### Component Reference
+
+Query the Kaizen UI MCP for component specifications:
+- Buttons: Primary, secondary, ghost variants
+- Cards: Elevation, border radius, padding
+- Forms: Input styling, validation states
+- Layout: Grid system, responsive breakpoints
+
+## Phase 5: E2E Checkout Flow
+
+Complete end-to-end validation of the checkout process.
+
+### Flow Steps
+
+1. **Product Selection**
+   - Navigate to http://localhost:3000
+   - Verify products load from Merchant API
+   - Click on a product to select
+
+2. **Checkout Session Creation**
+   - Verify session created via Merchant API (port 8000)
+   - Check Agent Activity panel for promotion decision
+
+3. **Shipping Selection**
+   - Enter/select shipping address
+   - Verify session updates to `ready_for_payment`
+
+4. **Payment Delegation**
+   - Verify PSP integration (port 8001)
+   - Vault token created and returned
+
+5. **Order Completion**
+   - Complete checkout
+   - Verify session status: `completed`
+   - Check for post-purchase agent activity
+
+### Validation Checklist
+
+Copy and track progress:
+
+```
+E2E Checkout Validation:
+- [ ] All services healthy (Phase 1)
+- [ ] API endpoints responding (Phase 2)
+- [ ] UI loads without errors (Phase 3)
+- [ ] Three-panel layout renders
+- [ ] Product grid displays products
+- [ ] Checkout modal opens
+- [ ] Shipping form submits
+- [ ] Payment delegation works
+- [ ] Order completes successfully
+- [ ] No console errors
+- [ ] Kaizen UI styles applied (Phase 4)
+```
+
+## Troubleshooting
+
+### Service Not Running
+
+If a health check fails:
+
+```bash
+# Check if port is in use
+lsof -i :8000  # Merchant
+lsof -i :8001  # PSP
+lsof -i :8002  # Promotion Agent
+lsof -i :8003  # Post-Purchase Agent
+lsof -i :3000  # UI
+```
+
+### Start Services
+
+```bash
+# Terminal 1: Merchant API
+uvicorn src.merchant.main:app --reload
+
+# Terminal 2: Payment PSP
+uvicorn src.payment.main:app --reload --port 8001
+
+# Terminal 3: Promotion Agent (from src/agents/)
+nat serve --config_file configs/promotion.yml --port 8002
+
+# Terminal 4: Post-Purchase Agent (from src/agents/)
+nat serve --config_file configs/post-purchase.yml --port 8003
+
+# Terminal 5: UI (from src/ui/)
+pnpm run dev
+```
+
+### Browser MCP Not Available
+
+If Chrome MCP tools are unavailable:
+1. Verify the MCP server is configured in Cursor settings
+2. Check the browser extension is installed and connected
+3. Manually test the UI in a browser window
+
+### API Authentication Errors
+
+Ensure environment variables are set:
+```bash
+export API_KEY=your-api-key
+export PSP_API_KEY=psp-api-key-12345
+```
+
+Or check `src/ui/.env.local`:
+```env
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_PSP_URL=http://localhost:8001
+NEXT_PUBLIC_API_KEY=your-api-key
+NEXT_PUBLIC_PSP_API_KEY=psp-api-key-12345
+```

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -384,8 +384,7 @@ export function AgentPanel() {
     showCheckoutModal && context.checkoutStep === "summary" && context.state === "checkout";
 
   // Show payment form step (second step - with Pay Now button)
-  const showPaymentFormStep =
-    showCheckoutModal && context.checkoutStep === "payment";
+  const showPaymentFormStep = showCheckoutModal && context.checkoutStep === "payment";
 
   // Show confirmation in modal
   const showConfirmationModal =

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -7,13 +7,20 @@ import { ProductGrid } from "./ProductGrid";
 import { CheckoutCard } from "./CheckoutCard";
 import { ConfirmationCard } from "./ConfirmationCard";
 import { StreamingText } from "./StreamingText";
+import { PaymentShippingForm } from "./PaymentShippingForm";
 import { useCheckoutFlow } from "@/hooks/useCheckoutFlow";
 import { useACPLog } from "@/hooks/useACPLog";
 import { useAgentActivityLog } from "@/hooks/useAgentActivityLog";
 import { mockProducts, mockChatMessages } from "@/data/mock-data";
 import { getErrorMessage, getSuggestedAction } from "@/lib/errors";
 import { Close } from "@/components/icons";
-import type { ChatMessage as ChatMessageType, FulfillmentOption, Product } from "@/types";
+import type {
+  ChatMessage as ChatMessageType,
+  FulfillmentOption,
+  Product,
+  PaymentFormData,
+  BillingAddressFormData,
+} from "@/types";
 
 /**
  * Payment Modal Component
@@ -232,6 +239,10 @@ export function AgentPanel() {
     submitPayment,
     reset,
     clearError,
+    setPaymentInfo,
+    setBillingAddress,
+    proceedToPayment,
+    backToSummary,
   } = useCheckoutFlow(acpLog, agentActivityLog);
 
   // Handle product selection - opens modal
@@ -249,11 +260,6 @@ export function AgentPanel() {
     // Reset checkout flow when closing modal
     reset();
   }, [reset]);
-
-  // Handle pay button click
-  const handlePay = useCallback(() => {
-    submitPayment();
-  }, [submitPayment]);
 
   // Handle shipping change
   const handleShippingChange = useCallback(
@@ -286,6 +292,27 @@ export function AgentPanel() {
   const handleTextComplete = useCallback(() => {
     setShowProducts(true);
   }, []);
+
+  // Handle continue from summary to payment form
+  const handleContinueToPayment = useCallback(() => {
+    proceedToPayment();
+  }, [proceedToPayment]);
+
+  // Handle back to summary from payment form
+  const handleBackToSummary = useCallback(() => {
+    backToSummary();
+  }, [backToSummary]);
+
+  // Handle payment form submission - actually process payment
+  // Pass payment info directly to submitPayment to avoid async state update issues
+  const handlePaymentFormSubmit = useCallback(
+    (paymentInfo: PaymentFormData, billingAddress: BillingAddressFormData) => {
+      setPaymentInfo(paymentInfo);
+      setBillingAddress(billingAddress);
+      submitPayment(paymentInfo, billingAddress);
+    },
+    [setPaymentInfo, setBillingAddress, submitPayment]
+  );
 
   // Get fulfillment options from session
   const fulfillmentOptions = context.session
@@ -351,6 +378,14 @@ export function AgentPanel() {
     !context.error &&
     checkoutData !== null &&
     context.selectedProduct !== null;
+
+  // Show checkout summary step (first step - with Continue button)
+  const showCheckoutSummaryStep =
+    showCheckoutModal && context.checkoutStep === "summary" && context.state === "checkout";
+
+  // Show payment form step (second step - with Pay Now button)
+  const showPaymentFormStep =
+    showCheckoutModal && context.checkoutStep === "payment";
 
   // Show confirmation in modal
   const showConfirmationModal =
@@ -424,17 +459,28 @@ export function AgentPanel() {
         {/* Loading state */}
         {context.isLoading && !checkoutData && <CheckoutSkeleton />}
 
-        {/* Checkout state */}
-        {showCheckoutModal && checkoutData && context.selectedProduct && (
+        {/* Checkout Summary step (first step - with Continue button) */}
+        {showCheckoutSummaryStep && checkoutData && context.selectedProduct && (
           <CheckoutCard
             checkout={checkoutData}
             product={context.selectedProduct}
             quantity={context.quantity}
-            isProcessing={context.state === "processing" || context.isLoading}
+            isProcessing={context.isLoading}
             isReadyForPayment={isReadyForPayment}
-            onPay={handlePay}
+            onContinue={handleContinueToPayment}
             onQuantityChange={handleQuantityChange}
             onShippingChange={handleShippingChange}
+          />
+        )}
+
+        {/* Payment Form step (second step - with Pay Now button) */}
+        {showPaymentFormStep && (
+          <PaymentShippingForm
+            onSubmit={handlePaymentFormSubmit}
+            onBack={handleBackToSummary}
+            isProcessing={context.state === "processing" || context.isLoading}
+            initialPaymentInfo={context.paymentInfo}
+            initialBillingAddress={context.billingAddress}
           />
         )}
 

--- a/src/ui/components/agent/CheckoutCard.test.tsx
+++ b/src/ui/components/agent/CheckoutCard.test.tsx
@@ -102,18 +102,18 @@ describe("CheckoutCard", () => {
     expect(screen.getByText("$5.00")).toBeInTheDocument();
   });
 
-  it("renders pay button with card info", () => {
+  it("renders continue button", () => {
     render(<CheckoutCard checkout={mockCheckout} />);
-    expect(screen.getByRole("button", { name: /pay with saved card/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue to payment/i })).toBeInTheDocument();
   });
 
-  it("calls onPay when pay button is clicked", () => {
-    const onPay = vi.fn();
-    render(<CheckoutCard checkout={mockCheckout} onPay={onPay} />);
+  it("calls onContinue when continue button is clicked", () => {
+    const onContinue = vi.fn();
+    render(<CheckoutCard checkout={mockCheckout} onContinue={onContinue} />);
 
-    screen.getByRole("button", { name: /pay with saved card/i }).click();
+    screen.getByRole("button", { name: /continue to payment/i }).click();
 
-    expect(onPay).toHaveBeenCalled();
+    expect(onContinue).toHaveBeenCalled();
   });
 
   describe("quantity controls", () => {
@@ -167,10 +167,10 @@ describe("CheckoutCard", () => {
       expect(screen.getByText("Processing...")).toBeInTheDocument();
     });
 
-    it("disables pay button when processing", () => {
+    it("disables continue button when processing", () => {
       render(<CheckoutCard checkout={mockCheckout} isProcessing={true} />);
 
-      expect(screen.getByRole("button", { name: /processing payment/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /processing/i })).toBeDisabled();
     });
 
     it("disables quantity controls when processing", () => {
@@ -237,21 +237,21 @@ describe("CheckoutCard", () => {
     it("shows correct button text when not ready for payment", () => {
       render(<CheckoutCard checkout={mockCheckout} isReadyForPayment={false} />);
 
-      expect(screen.getByText("Complete details to pay")).toBeInTheDocument();
+      expect(screen.getByText("Complete details to continue")).toBeInTheDocument();
     });
 
-    it("disables pay button when not ready for payment", () => {
+    it("disables continue button when not ready for payment", () => {
       render(<CheckoutCard checkout={mockCheckout} isReadyForPayment={false} />);
 
-      const payButton = screen.getByRole("button", { name: /pay with saved card/i });
-      expect(payButton).toBeDisabled();
+      const continueButton = screen.getByRole("button", { name: /continue to payment/i });
+      expect(continueButton).toBeDisabled();
     });
 
-    it("enables pay button when ready for payment", () => {
+    it("enables continue button when ready for payment", () => {
       render(<CheckoutCard checkout={mockCheckout} isReadyForPayment={true} />);
 
-      const payButton = screen.getByRole("button", { name: /pay with saved card/i });
-      expect(payButton).not.toBeDisabled();
+      const continueButton = screen.getByRole("button", { name: /continue to payment/i });
+      expect(continueButton).not.toBeDisabled();
     });
 
     it("shows processing indicator when isProcessing is true", () => {
@@ -260,18 +260,12 @@ describe("CheckoutCard", () => {
       expect(screen.getByText("Processing")).toBeInTheDocument();
     });
 
-    it("does not show card info when not ready for payment", () => {
-      render(<CheckoutCard checkout={mockCheckout} isReadyForPayment={false} />);
-
-      expect(screen.queryByText("4242")).not.toBeInTheDocument();
-    });
-
-    it("shows card info when ready for payment and not processing", () => {
+    it("shows continue button text when ready", () => {
       render(
         <CheckoutCard checkout={mockCheckout} isReadyForPayment={true} isProcessing={false} />
       );
 
-      expect(screen.getByText("4242")).toBeInTheDocument();
+      expect(screen.getByText("Continue")).toBeInTheDocument();
     });
   });
 });

--- a/src/ui/components/agent/CheckoutCard.tsx
+++ b/src/ui/components/agent/CheckoutCard.tsx
@@ -61,7 +61,7 @@ interface CheckoutCardProps {
   quantity?: number;
   isProcessing?: boolean;
   isReadyForPayment?: boolean;
-  onPay?: () => void;
+  onContinue?: () => void;
   onQuantityChange?: (quantity: number) => void;
   onShippingChange?: (optionId: string) => void;
 }
@@ -75,7 +75,7 @@ export function CheckoutCard({
   quantity = 1,
   isProcessing = false,
   isReadyForPayment = true,
-  onPay,
+  onContinue,
   onQuantityChange,
   onShippingChange,
 }: CheckoutCardProps) {
@@ -103,8 +103,8 @@ export function CheckoutCard({
   const buttonText = isProcessing
     ? "Processing..."
     : !isReadyForPayment
-      ? "Complete details to pay"
-      : "Pay Now";
+      ? "Complete details to continue"
+      : "Continue";
 
   const handleDecrement = () => {
     if (quantity > 1 && onQuantityChange) {
@@ -308,36 +308,23 @@ export function CheckoutCard({
           )}
         </Stack>
 
-        {/* Pay button */}
+        {/* Continue button */}
         <Button
           kind="primary"
           color="neutral"
           className="w-full"
-          onClick={onPay}
+          onClick={onContinue}
           disabled={isButtonDisabled}
-          aria-label={isProcessing ? "Processing payment" : "Pay with saved card"}
+          aria-label={isProcessing ? "Processing" : "Continue to payment"}
         >
-          <Flex align="center" justify="center" gap="3" className="w-full">
-            {isProcessing ? (
-              <Flex align="center" gap="2">
-                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                <span>Processing...</span>
-              </Flex>
-            ) : (
-              <>
-                <span>{buttonText}</span>
-                {isReadyForPayment && (
-                  <>
-                    <span className="opacity-30">|</span>
-                    <Flex align="center" gap="1">
-                      <CreditCard className="w-4 h-4" />
-                      <span>4242</span>
-                    </Flex>
-                  </>
-                )}
-              </>
-            )}
-          </Flex>
+          {isProcessing ? (
+            <Flex align="center" justify="center" gap="2">
+              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <span>Processing...</span>
+            </Flex>
+          ) : (
+            buttonText
+          )}
         </Button>
       </Stack>
     </Card>

--- a/src/ui/components/agent/PaymentShippingForm.test.tsx
+++ b/src/ui/components/agent/PaymentShippingForm.test.tsx
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PaymentShippingForm } from "./PaymentShippingForm";
+import type { PaymentFormData, BillingAddressFormData } from "@/types";
+
+describe("PaymentShippingForm", () => {
+  const mockOnSubmit = vi.fn();
+  const mockOnBack = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("renders the form header", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      expect(screen.getByText("Add payment method")).toBeInTheDocument();
+    });
+
+    it("renders the card section label", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      expect(screen.getByText("Card")).toBeInTheDocument();
+    });
+
+    it("renders the billing address section label", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      expect(screen.getByText("Billing address")).toBeInTheDocument();
+    });
+
+    it("renders the pay now button", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      expect(screen.getByRole("button", { name: /pay now/i })).toBeInTheDocument();
+    });
+
+
+    it("renders back button when onBack is provided", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} onBack={mockOnBack} />);
+      expect(screen.getByRole("button", { name: /go back/i })).toBeInTheDocument();
+    });
+
+    it("does not render back button when onBack is not provided", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      expect(screen.queryByRole("button", { name: /go back/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("default values", () => {
+    it("renders with default card number", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      expect(cardInput).toHaveValue("4242 4242 4242 4242");
+    });
+
+    it("renders with default expiration date", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const expirationInput = screen.getByLabelText(/expiration date/i);
+      expect(expirationInput).toHaveValue("12/28");
+    });
+
+    it("renders with default security code", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const securityInput = screen.getByLabelText(/security code/i);
+      expect(securityInput).toHaveValue("123");
+    });
+
+    it("renders with default full name", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const nameInput = screen.getByLabelText(/full name/i);
+      expect(nameInput).toHaveValue("John Doe");
+    });
+
+    it("renders with default address", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const addressInput = screen.getByLabelText(/^address$/i);
+      expect(addressInput).toHaveValue("123 Main St, San Francisco, CA 94102");
+    });
+  });
+
+  describe("initial values", () => {
+    const initialPaymentInfo: PaymentFormData = {
+      cardNumber: "5555555555554444",
+      expirationDate: "06/30",
+      securityCode: "456",
+    };
+
+    const initialBillingAddress: BillingAddressFormData = {
+      fullName: "Jane Smith",
+      address: "456 Oak Ave, Los Angeles, CA 90001",
+    };
+
+    it("uses initial payment info when provided", () => {
+      render(
+        <PaymentShippingForm
+          onSubmit={mockOnSubmit}
+          initialPaymentInfo={initialPaymentInfo}
+        />
+      );
+      const cardInput = screen.getByLabelText(/card number/i);
+      expect(cardInput).toHaveValue("5555 5555 5555 4444");
+    });
+
+    it("uses initial billing address when provided", () => {
+      render(
+        <PaymentShippingForm
+          onSubmit={mockOnSubmit}
+          initialBillingAddress={initialBillingAddress}
+        />
+      );
+      const nameInput = screen.getByLabelText(/full name/i);
+      expect(nameInput).toHaveValue("Jane Smith");
+    });
+  });
+
+  describe("card number formatting", () => {
+    it("formats card number with spaces every 4 digits", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      
+      fireEvent.change(cardInput, { target: { value: "1234567890123456" } });
+      expect(cardInput).toHaveValue("1234 5678 9012 3456");
+    });
+
+    it("limits card number to 16 digits", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      
+      fireEvent.change(cardInput, { target: { value: "12345678901234567890" } });
+      expect(cardInput).toHaveValue("1234 5678 9012 3456");
+    });
+
+    it("removes non-numeric characters from card number", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      
+      fireEvent.change(cardInput, { target: { value: "1234-5678-9012-3456" } });
+      expect(cardInput).toHaveValue("1234 5678 9012 3456");
+    });
+  });
+
+  describe("expiration date formatting", () => {
+    it("formats expiration date as MM/YY", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const expirationInput = screen.getByLabelText(/expiration date/i);
+      
+      fireEvent.change(expirationInput, { target: { value: "1230" } });
+      expect(expirationInput).toHaveValue("12/30");
+    });
+
+    it("limits expiration date to 4 digits", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const expirationInput = screen.getByLabelText(/expiration date/i);
+      
+      fireEvent.change(expirationInput, { target: { value: "123456" } });
+      expect(expirationInput).toHaveValue("12/34");
+    });
+  });
+
+  describe("security code", () => {
+    it("limits security code to 4 digits", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const securityInput = screen.getByLabelText(/security code/i);
+      
+      fireEvent.change(securityInput, { target: { value: "12345" } });
+      expect(securityInput).toHaveValue("1234");
+    });
+
+    it("removes non-numeric characters from security code", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const securityInput = screen.getByLabelText(/security code/i);
+      
+      fireEvent.change(securityInput, { target: { value: "abc123" } });
+      expect(securityInput).toHaveValue("123");
+    });
+  });
+
+  describe("form validation", () => {
+    it("enables pay now button with valid form data", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      expect(payButton).not.toBeDisabled();
+    });
+
+    it("disables pay now button when card number is incomplete", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      
+      fireEvent.change(cardInput, { target: { value: "1234" } });
+      expect(payButton).toBeDisabled();
+    });
+
+    it("disables pay now button when expiration date is incomplete", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const expirationInput = screen.getByLabelText(/expiration date/i);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      
+      fireEvent.change(expirationInput, { target: { value: "12" } });
+      expect(payButton).toBeDisabled();
+    });
+
+    it("disables pay now button when security code is too short", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const securityInput = screen.getByLabelText(/security code/i);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      
+      fireEvent.change(securityInput, { target: { value: "12" } });
+      expect(payButton).toBeDisabled();
+    });
+
+    it("disables pay now button when full name is empty", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const nameInput = screen.getByLabelText(/full name/i);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      
+      fireEvent.change(nameInput, { target: { value: "" } });
+      expect(payButton).toBeDisabled();
+    });
+
+    it("disables pay now button when address is empty", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const addressInput = screen.getByLabelText(/^address$/i);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      
+      fireEvent.change(addressInput, { target: { value: "" } });
+      expect(payButton).toBeDisabled();
+    });
+  });
+
+  describe("form submission", () => {
+    it("calls onSubmit with payment info and billing address when clicking pay now", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      
+      fireEvent.click(payButton);
+      
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        {
+          cardNumber: "4242424242424242",
+          expirationDate: "12/28",
+          securityCode: "123",
+        },
+        {
+          fullName: "John Doe",
+          address: "123 Main St, San Francisco, CA 94102",
+        }
+      );
+    });
+
+    it("does not call onSubmit when form is invalid", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      const payButton = screen.getByRole("button", { name: /pay now/i });
+      
+      fireEvent.change(cardInput, { target: { value: "1234" } });
+      fireEvent.click(payButton);
+      
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it("calls onBack when back button is clicked", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} onBack={mockOnBack} />);
+      const backButton = screen.getByRole("button", { name: /go back/i });
+      
+      fireEvent.click(backButton);
+      
+      expect(mockOnBack).toHaveBeenCalled();
+    });
+  });
+
+  describe("processing state", () => {
+    it("shows processing text when isProcessing is true", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} isProcessing={true} />);
+      expect(screen.getByText("Processing...")).toBeInTheDocument();
+    });
+
+    it("disables pay button when processing", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} isProcessing={true} />);
+      const payButton = screen.getByRole("button", { name: /processing/i });
+      expect(payButton).toBeDisabled();
+    });
+
+    it("disables all inputs when processing", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} isProcessing={true} />);
+      
+      expect(screen.getByLabelText(/card number/i)).toBeDisabled();
+      expect(screen.getByLabelText(/expiration date/i)).toBeDisabled();
+      expect(screen.getByLabelText(/security code/i)).toBeDisabled();
+      expect(screen.getByLabelText(/full name/i)).toBeDisabled();
+      expect(screen.getByLabelText(/^address$/i)).toBeDisabled();
+    });
+  });
+
+  describe("card number input", () => {
+    it("accepts Visa card numbers", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      
+      // Default is Visa (4242...)
+      expect(cardInput).toHaveValue("4242 4242 4242 4242");
+    });
+
+    it("accepts Mastercard numbers", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      
+      fireEvent.change(cardInput, { target: { value: "5555555555554444" } });
+      expect(cardInput).toHaveValue("5555 5555 5555 4444");
+    });
+
+    it("accepts Amex numbers", () => {
+      render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
+      const cardInput = screen.getByLabelText(/card number/i);
+      
+      fireEvent.change(cardInput, { target: { value: "3782822463100005" } });
+      expect(cardInput).toHaveValue("3782 8224 6310 0005");
+    });
+  });
+});

--- a/src/ui/components/agent/PaymentShippingForm.test.tsx
+++ b/src/ui/components/agent/PaymentShippingForm.test.tsx
@@ -32,7 +32,6 @@ describe("PaymentShippingForm", () => {
       expect(screen.getByRole("button", { name: /pay now/i })).toBeInTheDocument();
     });
 
-
     it("renders back button when onBack is provided", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} onBack={mockOnBack} />);
       expect(screen.getByRole("button", { name: /go back/i })).toBeInTheDocument();
@@ -90,10 +89,7 @@ describe("PaymentShippingForm", () => {
 
     it("uses initial payment info when provided", () => {
       render(
-        <PaymentShippingForm
-          onSubmit={mockOnSubmit}
-          initialPaymentInfo={initialPaymentInfo}
-        />
+        <PaymentShippingForm onSubmit={mockOnSubmit} initialPaymentInfo={initialPaymentInfo} />
       );
       const cardInput = screen.getByLabelText(/card number/i);
       expect(cardInput).toHaveValue("5555 5555 5555 4444");
@@ -115,7 +111,7 @@ describe("PaymentShippingForm", () => {
     it("formats card number with spaces every 4 digits", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
-      
+
       fireEvent.change(cardInput, { target: { value: "1234567890123456" } });
       expect(cardInput).toHaveValue("1234 5678 9012 3456");
     });
@@ -123,7 +119,7 @@ describe("PaymentShippingForm", () => {
     it("limits card number to 16 digits", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
-      
+
       fireEvent.change(cardInput, { target: { value: "12345678901234567890" } });
       expect(cardInput).toHaveValue("1234 5678 9012 3456");
     });
@@ -131,7 +127,7 @@ describe("PaymentShippingForm", () => {
     it("removes non-numeric characters from card number", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
-      
+
       fireEvent.change(cardInput, { target: { value: "1234-5678-9012-3456" } });
       expect(cardInput).toHaveValue("1234 5678 9012 3456");
     });
@@ -141,7 +137,7 @@ describe("PaymentShippingForm", () => {
     it("formats expiration date as MM/YY", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const expirationInput = screen.getByLabelText(/expiration date/i);
-      
+
       fireEvent.change(expirationInput, { target: { value: "1230" } });
       expect(expirationInput).toHaveValue("12/30");
     });
@@ -149,7 +145,7 @@ describe("PaymentShippingForm", () => {
     it("limits expiration date to 4 digits", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const expirationInput = screen.getByLabelText(/expiration date/i);
-      
+
       fireEvent.change(expirationInput, { target: { value: "123456" } });
       expect(expirationInput).toHaveValue("12/34");
     });
@@ -159,7 +155,7 @@ describe("PaymentShippingForm", () => {
     it("limits security code to 4 digits", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const securityInput = screen.getByLabelText(/security code/i);
-      
+
       fireEvent.change(securityInput, { target: { value: "12345" } });
       expect(securityInput).toHaveValue("1234");
     });
@@ -167,7 +163,7 @@ describe("PaymentShippingForm", () => {
     it("removes non-numeric characters from security code", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const securityInput = screen.getByLabelText(/security code/i);
-      
+
       fireEvent.change(securityInput, { target: { value: "abc123" } });
       expect(securityInput).toHaveValue("123");
     });
@@ -184,7 +180,7 @@ describe("PaymentShippingForm", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
       const payButton = screen.getByRole("button", { name: /pay now/i });
-      
+
       fireEvent.change(cardInput, { target: { value: "1234" } });
       expect(payButton).toBeDisabled();
     });
@@ -193,7 +189,7 @@ describe("PaymentShippingForm", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const expirationInput = screen.getByLabelText(/expiration date/i);
       const payButton = screen.getByRole("button", { name: /pay now/i });
-      
+
       fireEvent.change(expirationInput, { target: { value: "12" } });
       expect(payButton).toBeDisabled();
     });
@@ -202,7 +198,7 @@ describe("PaymentShippingForm", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const securityInput = screen.getByLabelText(/security code/i);
       const payButton = screen.getByRole("button", { name: /pay now/i });
-      
+
       fireEvent.change(securityInput, { target: { value: "12" } });
       expect(payButton).toBeDisabled();
     });
@@ -211,7 +207,7 @@ describe("PaymentShippingForm", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const nameInput = screen.getByLabelText(/full name/i);
       const payButton = screen.getByRole("button", { name: /pay now/i });
-      
+
       fireEvent.change(nameInput, { target: { value: "" } });
       expect(payButton).toBeDisabled();
     });
@@ -220,7 +216,7 @@ describe("PaymentShippingForm", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const addressInput = screen.getByLabelText(/^address$/i);
       const payButton = screen.getByRole("button", { name: /pay now/i });
-      
+
       fireEvent.change(addressInput, { target: { value: "" } });
       expect(payButton).toBeDisabled();
     });
@@ -230,9 +226,9 @@ describe("PaymentShippingForm", () => {
     it("calls onSubmit with payment info and billing address when clicking pay now", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const payButton = screen.getByRole("button", { name: /pay now/i });
-      
+
       fireEvent.click(payButton);
-      
+
       expect(mockOnSubmit).toHaveBeenCalledWith(
         {
           cardNumber: "4242424242424242",
@@ -250,19 +246,19 @@ describe("PaymentShippingForm", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
       const payButton = screen.getByRole("button", { name: /pay now/i });
-      
+
       fireEvent.change(cardInput, { target: { value: "1234" } });
       fireEvent.click(payButton);
-      
+
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
 
     it("calls onBack when back button is clicked", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} onBack={mockOnBack} />);
       const backButton = screen.getByRole("button", { name: /go back/i });
-      
+
       fireEvent.click(backButton);
-      
+
       expect(mockOnBack).toHaveBeenCalled();
     });
   });
@@ -281,7 +277,7 @@ describe("PaymentShippingForm", () => {
 
     it("disables all inputs when processing", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} isProcessing={true} />);
-      
+
       expect(screen.getByLabelText(/card number/i)).toBeDisabled();
       expect(screen.getByLabelText(/expiration date/i)).toBeDisabled();
       expect(screen.getByLabelText(/security code/i)).toBeDisabled();
@@ -294,7 +290,7 @@ describe("PaymentShippingForm", () => {
     it("accepts Visa card numbers", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
-      
+
       // Default is Visa (4242...)
       expect(cardInput).toHaveValue("4242 4242 4242 4242");
     });
@@ -302,7 +298,7 @@ describe("PaymentShippingForm", () => {
     it("accepts Mastercard numbers", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
-      
+
       fireEvent.change(cardInput, { target: { value: "5555555555554444" } });
       expect(cardInput).toHaveValue("5555 5555 5555 4444");
     });
@@ -310,7 +306,7 @@ describe("PaymentShippingForm", () => {
     it("accepts Amex numbers", () => {
       render(<PaymentShippingForm onSubmit={mockOnSubmit} />);
       const cardInput = screen.getByLabelText(/card number/i);
-      
+
       fireEvent.change(cardInput, { target: { value: "3782822463100005" } });
       expect(cardInput).toHaveValue("3782 8224 6310 0005");
     });

--- a/src/ui/components/agent/PaymentShippingForm.tsx
+++ b/src/ui/components/agent/PaymentShippingForm.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { Card, Text, Button, Stack, Flex, Divider } from "@kui/foundations-react-external";
+import { CreditCard, ChevronLeft } from "@/components/icons";
+import type { PaymentFormData, BillingAddressFormData } from "@/types";
+import {
+  DEFAULT_PAYMENT_FORM,
+  DEFAULT_BILLING_ADDRESS,
+} from "@/types";
+
+/**
+ * Styled input component using NVIDIA KUI native classes
+ * Uses nv-input and nv-text-input classes for proper styling
+ */
+type StyledInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+function StyledInput({ style, ...props }: StyledInputProps) {
+  return (
+    <div 
+      data-testid="nv-text-input-root" 
+      className="nv-input nv-text-input-root"
+      style={style}
+    >
+      <input
+        {...props}
+        data-testid="nv-text-input-element"
+        className="nv-text-input-element"
+      />
+    </div>
+  );
+}
+
+interface PaymentShippingFormProps {
+  onSubmit: (paymentInfo: PaymentFormData, billingAddress: BillingAddressFormData) => void;
+  onBack?: () => void;
+  isProcessing?: boolean;
+  initialPaymentInfo?: PaymentFormData | null;
+  initialBillingAddress?: BillingAddressFormData | null;
+}
+
+/**
+ * Format card number with spaces every 4 digits
+ */
+function formatCardNumber(value: string): string {
+  const cleaned = value.replace(/\D/g, "").slice(0, 16);
+  const groups = cleaned.match(/.{1,4}/g);
+  return groups ? groups.join(" ") : cleaned;
+}
+
+/**
+ * Format expiration date as MM/YY
+ */
+function formatExpirationDate(value: string): string {
+  const cleaned = value.replace(/\D/g, "").slice(0, 4);
+  if (cleaned.length >= 2) {
+    return `${cleaned.slice(0, 2)}/${cleaned.slice(2)}`;
+  }
+  return cleaned;
+}
+
+/**
+ * CVV security icon using KUI theme colors
+ */
+function SecurityIcon() {
+  return (
+    <div className="w-6 h-4 border border-base rounded text-[8px] flex items-center justify-center text-subtle">
+      123
+    </div>
+  );
+}
+
+/**
+ * Payment and Shipping Information Form
+ * Collects card details and billing address before checkout
+ */
+export function PaymentShippingForm({
+  onSubmit,
+  onBack,
+  isProcessing = false,
+  initialPaymentInfo,
+  initialBillingAddress,
+}: PaymentShippingFormProps) {
+  // Form state with defaults
+  const [cardNumber, setCardNumber] = useState(
+    initialPaymentInfo?.cardNumber
+      ? formatCardNumber(initialPaymentInfo.cardNumber)
+      : formatCardNumber(DEFAULT_PAYMENT_FORM.cardNumber)
+  );
+  const [expirationDate, setExpirationDate] = useState(
+    initialPaymentInfo?.expirationDate ?? DEFAULT_PAYMENT_FORM.expirationDate
+  );
+  const [securityCode, setSecurityCode] = useState(
+    initialPaymentInfo?.securityCode ?? DEFAULT_PAYMENT_FORM.securityCode
+  );
+  const [fullName, setFullName] = useState(
+    initialBillingAddress?.fullName ?? DEFAULT_BILLING_ADDRESS.fullName
+  );
+  const [address, setAddress] = useState(
+    initialBillingAddress?.address ?? DEFAULT_BILLING_ADDRESS.address
+  );
+
+  // Form validation
+  const isValid = useMemo(() => {
+    const cleanCardNumber = cardNumber.replace(/\s/g, "");
+    const cleanExpiration = expirationDate.replace(/\//g, "");
+    return (
+      cleanCardNumber.length === 16 &&
+      cleanExpiration.length === 4 &&
+      securityCode.length >= 3 &&
+      fullName.trim().length > 0 &&
+      address.trim().length > 0
+    );
+  }, [cardNumber, expirationDate, securityCode, fullName, address]);
+
+  // Handle form submission
+  const handleSubmit = useCallback(() => {
+    if (!isValid) return;
+
+    const paymentInfo: PaymentFormData = {
+      cardNumber: cardNumber.replace(/\s/g, ""),
+      expirationDate,
+      securityCode,
+    };
+
+    const billingAddress: BillingAddressFormData = {
+      fullName,
+      address,
+    };
+
+    onSubmit(paymentInfo, billingAddress);
+  }, [isValid, cardNumber, expirationDate, securityCode, fullName, address, onSubmit]);
+
+  return (
+    <Card className="w-full max-w-md fade-in">
+      <Stack gap="4">
+        {/* Header */}
+        <Flex align="center" gap="2">
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="p-1 hover:bg-surface-sunken rounded transition-colors"
+              aria-label="Go back"
+            >
+              <ChevronLeft className="w-5 h-5 text-secondary" />
+            </button>
+          )}
+          <Text kind="label/bold/md">
+            Add payment method
+          </Text>
+        </Flex>
+
+        {/* Card Section */}
+        <Stack gap="2">
+          <Flex align="center" gap="2">
+            <CreditCard className="w-4 h-4 text-secondary" />
+            <Text kind="label/semibold/sm">
+              Card
+            </Text>
+          </Flex>
+
+          {/* Card Number */}
+          <StyledInput
+            type="text"
+            value={cardNumber}
+            onChange={(e) => {
+              const formatted = formatCardNumber(e.target.value);
+              setCardNumber(formatted);
+            }}
+            placeholder="Card number"
+            disabled={isProcessing}
+            aria-label="Card number"
+            inputMode="numeric"
+          />
+
+          {/* Expiration and CVV */}
+          <Flex gap="3">
+            <StyledInput
+              type="text"
+              value={expirationDate}
+              onChange={(e) => {
+                const formatted = formatExpirationDate(e.target.value);
+                setExpirationDate(formatted);
+              }}
+              placeholder="MM/YY"
+              disabled={isProcessing}
+              aria-label="Expiration date"
+              inputMode="numeric"
+              style={{ flex: 1 }}
+            />
+            <Flex align="center" gap="2" className="flex-1">
+              <StyledInput
+                type="text"
+                value={securityCode}
+                onChange={(e) => {
+                  const cleaned = e.target.value.replace(/\D/g, "").slice(0, 4);
+                  setSecurityCode(cleaned);
+                }}
+                placeholder="CVV"
+                disabled={isProcessing}
+                aria-label="Security code"
+                inputMode="numeric"
+                style={{ flex: 1 }}
+              />
+              <SecurityIcon />
+            </Flex>
+          </Flex>
+        </Stack>
+
+        {/* Billing Address Section */}
+        <Stack gap="2">
+          <Text kind="label/semibold/sm">
+            Billing address
+          </Text>
+          {/* Full Name */}
+          <StyledInput
+            type="text"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            placeholder="Full name"
+            disabled={isProcessing}
+            aria-label="Full name"
+          />
+          {/* Address */}
+          <StyledInput
+            type="text"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            placeholder="Address"
+            disabled={isProcessing}
+            aria-label="Address"
+          />
+        </Stack>
+
+
+
+        <Divider />
+
+        {/* Pay Now Button */}
+        <Button
+          kind="primary"
+          color="neutral"
+          className="w-full"
+          onClick={handleSubmit}
+          disabled={!isValid || isProcessing}
+          aria-label={isProcessing ? "Processing payment" : "Pay now"}
+        >
+          {isProcessing ? (
+            <Flex align="center" justify="center" gap="2">
+              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <span>Processing...</span>
+            </Flex>
+          ) : (
+            "Pay Now"
+          )}
+        </Button>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/ui/components/agent/PaymentShippingForm.tsx
+++ b/src/ui/components/agent/PaymentShippingForm.tsx
@@ -4,10 +4,7 @@ import { useState, useMemo, useCallback } from "react";
 import { Card, Text, Button, Stack, Flex, Divider } from "@kui/foundations-react-external";
 import { CreditCard, ChevronLeft } from "@/components/icons";
 import type { PaymentFormData, BillingAddressFormData } from "@/types";
-import {
-  DEFAULT_PAYMENT_FORM,
-  DEFAULT_BILLING_ADDRESS,
-} from "@/types";
+import { DEFAULT_PAYMENT_FORM, DEFAULT_BILLING_ADDRESS } from "@/types";
 
 /**
  * Styled input component using NVIDIA KUI native classes
@@ -17,16 +14,8 @@ type StyledInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 function StyledInput({ style, ...props }: StyledInputProps) {
   return (
-    <div 
-      data-testid="nv-text-input-root" 
-      className="nv-input nv-text-input-root"
-      style={style}
-    >
-      <input
-        {...props}
-        data-testid="nv-text-input-element"
-        className="nv-text-input-element"
-      />
+    <div data-testid="nv-text-input-root" className="nv-input nv-text-input-root" style={style}>
+      <input {...props} data-testid="nv-text-input-element" className="nv-text-input-element" />
     </div>
   );
 }
@@ -145,18 +134,14 @@ export function PaymentShippingForm({
               <ChevronLeft className="w-5 h-5 text-secondary" />
             </button>
           )}
-          <Text kind="label/bold/md">
-            Add payment method
-          </Text>
+          <Text kind="label/bold/md">Add payment method</Text>
         </Flex>
 
         {/* Card Section */}
         <Stack gap="2">
           <Flex align="center" gap="2">
             <CreditCard className="w-4 h-4 text-secondary" />
-            <Text kind="label/semibold/sm">
-              Card
-            </Text>
+            <Text kind="label/semibold/sm">Card</Text>
           </Flex>
 
           {/* Card Number */}
@@ -209,9 +194,7 @@ export function PaymentShippingForm({
 
         {/* Billing Address Section */}
         <Stack gap="2">
-          <Text kind="label/semibold/sm">
-            Billing address
-          </Text>
+          <Text kind="label/semibold/sm">Billing address</Text>
           {/* Full Name */}
           <StyledInput
             type="text"
@@ -231,8 +214,6 @@ export function PaymentShippingForm({
             aria-label="Address"
           />
         </Stack>
-
-
 
         <Divider />
 

--- a/src/ui/components/agent/index.ts
+++ b/src/ui/components/agent/index.ts
@@ -5,3 +5,4 @@ export { CheckoutCard } from "./CheckoutCard";
 export { ProductGrid } from "./ProductGrid";
 export { ConfirmationCard } from "./ConfirmationCard";
 export { StreamingText } from "./StreamingText";
+export { PaymentShippingForm } from "./PaymentShippingForm";

--- a/src/ui/components/icons/index.tsx
+++ b/src/ui/components/icons/index.tsx
@@ -51,6 +51,28 @@ export function CreditCard({ className, ...props }: IconProps) {
 }
 
 /**
+ * Chevron left icon
+ */
+export function ChevronLeft({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+/**
  * Chevron down icon
  */
 export function ChevronDown({ className, ...props }: IconProps) {

--- a/src/ui/hooks/useCheckoutFlow.test.ts
+++ b/src/ui/hooks/useCheckoutFlow.test.ts
@@ -10,6 +10,8 @@ vi.mock("@/lib/api-client", () => ({
   updateCheckoutSession: vi.fn(),
   completeCheckout: vi.fn(),
   delegatePayment: vi.fn(),
+  generatePostPurchaseMessage: vi.fn(),
+  postWebhookShippingUpdate: vi.fn(),
 }));
 
 describe("useCheckoutFlow", () => {
@@ -334,6 +336,18 @@ describe("useCheckoutFlow", () => {
     });
   });
 
+  // Mock payment and billing data for tests
+  const mockPaymentInfo = {
+    cardNumber: "4242424242424242",
+    expirationDate: "12/28",
+    securityCode: "123",
+  };
+
+  const mockBillingAddress = {
+    fullName: "John Doe",
+    address: "123 Main St, San Francisco, CA 94102",
+  };
+
   describe("submitPayment - happy path", () => {
     it("transitions to processing state", async () => {
       vi.mocked(apiClient.createCheckoutSession).mockResolvedValueOnce(mockSession);
@@ -349,6 +363,12 @@ describe("useCheckoutFlow", () => {
 
       await waitFor(() => {
         expect(result.current.context.state).toBe("checkout");
+      });
+
+      // Set payment info and billing address (required for submitPayment)
+      act(() => {
+        result.current.setPaymentInfo(mockPaymentInfo);
+        result.current.setBillingAddress(mockBillingAddress);
       });
 
       act(() => {
@@ -372,6 +392,12 @@ describe("useCheckoutFlow", () => {
 
       await waitFor(() => {
         expect(result.current.context.state).toBe("checkout");
+      });
+
+      // Set payment info and billing address (required for submitPayment)
+      act(() => {
+        result.current.setPaymentInfo(mockPaymentInfo);
+        result.current.setBillingAddress(mockBillingAddress);
       });
 
       await act(async () => {
@@ -404,6 +430,12 @@ describe("useCheckoutFlow", () => {
         expect(result.current.context.state).toBe("checkout");
       });
 
+      // Set payment info and billing address (required for submitPayment)
+      act(() => {
+        result.current.setPaymentInfo(mockPaymentInfo);
+        result.current.setBillingAddress(mockBillingAddress);
+      });
+
       await act(async () => {
         await result.current.submitPayment();
       });
@@ -434,6 +466,12 @@ describe("useCheckoutFlow", () => {
         expect(result.current.context.state).toBe("checkout");
       });
 
+      // Set payment info and billing address (required for submitPayment)
+      act(() => {
+        result.current.setPaymentInfo(mockPaymentInfo);
+        result.current.setBillingAddress(mockBillingAddress);
+      });
+
       await act(async () => {
         await result.current.submitPayment();
       });
@@ -461,6 +499,12 @@ describe("useCheckoutFlow", () => {
 
       await waitFor(() => {
         expect(result.current.context.state).toBe("checkout");
+      });
+
+      // Set payment info and billing address (required for submitPayment)
+      act(() => {
+        result.current.setPaymentInfo(mockPaymentInfo);
+        result.current.setBillingAddress(mockBillingAddress);
       });
 
       await act(async () => {

--- a/src/ui/hooks/useCheckoutFlow.ts
+++ b/src/ui/hooks/useCheckoutFlow.ts
@@ -8,6 +8,8 @@ import type {
   Product,
   CheckoutSessionResponse,
   UpdateCheckoutRequest,
+  PaymentFormData,
+  BillingAddressFormData,
 } from "@/types";
 import {
   createCheckoutSession,
@@ -170,6 +172,9 @@ const initialContext: CheckoutFlowContext = {
   vaultToken: null,
   isLoading: false,
   error: null,
+  checkoutStep: "summary",
+  paymentInfo: null,
+  billingAddress: null,
 };
 
 /**
@@ -335,6 +340,40 @@ function checkoutFlowReducer(
 
     case "RESET": {
       return initialContext;
+    }
+
+    case "SET_PAYMENT_INFO": {
+      return {
+        ...context,
+        paymentInfo: action.paymentInfo,
+      };
+    }
+
+    case "SET_BILLING_ADDRESS": {
+      return {
+        ...context,
+        billingAddress: action.billingAddress,
+      };
+    }
+
+    case "PROCEED_TO_PAYMENT": {
+      if (context.state !== "checkout") {
+        return context;
+      }
+      return {
+        ...context,
+        checkoutStep: "payment",
+      };
+    }
+
+    case "BACK_TO_SUMMARY": {
+      if (context.state !== "checkout") {
+        return context;
+      }
+      return {
+        ...context,
+        checkoutStep: "summary",
+      };
     }
 
     default:
@@ -631,17 +670,47 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
 
   /**
    * Submit payment - delegates to PSP and completes checkout
+   * Accepts optional payment info and billing address to support immediate submission
+   * without waiting for context state to update
    */
-  const submitPayment = useCallback(async () => {
-    if (!context.sessionId || !context.session) {
-      return;
-    }
+  const submitPayment = useCallback(
+    async (
+      paymentInfoParam?: PaymentFormData,
+      billingAddressParam?: BillingAddressFormData
+    ) => {
+      // Use provided params or fall back to context
+      const paymentInfo = paymentInfoParam ?? context.paymentInfo;
+      const billingAddress = billingAddressParam ?? context.billingAddress;
 
-    dispatch({ type: "SUBMIT_PAYMENT" });
+      if (!context.sessionId || !context.session || !paymentInfo || !billingAddress) {
+        return;
+      }
 
-    // Step 1: Get vault token from PSP
-    const totalAmount = getTotalFromSession(context.session);
-    const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+      dispatch({ type: "SUBMIT_PAYMENT" });
+
+      // Step 1: Get vault token from PSP
+      const totalAmount = getTotalFromSession(context.session);
+      const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+
+      // Parse payment info from form
+      const cardNumber = paymentInfo.cardNumber;
+      const expirationParts = paymentInfo.expirationDate.split("/");
+      const expMonth = expirationParts[0] ?? "12";
+      const expYear = expirationParts[1] ?? "28";
+      const fullExpYear = expYear.length === 2 ? `20${expYear}` : expYear;
+      const last4 = cardNumber.slice(-4);
+
+      // Build billing address from form
+      // Parse the address string to extract components
+      const addressParts = billingAddress.address.split(",").map((s) => s.trim());
+      const billingAddressData = {
+        name: billingAddress.fullName,
+        line_one: addressParts[0] || "123 Main St",
+        city: addressParts[1] || "San Francisco",
+        state: addressParts[2]?.split(" ")[0] || "CA",
+        country: "US",
+        postal_code: addressParts[2]?.split(" ")[1] || "94102",
+      };
 
     const delegateEventId = loggerRef.current?.logEvent(
       "delegate_payment",
@@ -656,11 +725,11 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
           type: "card",
           card_number_type: "fpan",
           virtual: false,
-          number: "4242424242424242",
-          exp_month: "12",
-          exp_year: "2027",
+          number: cardNumber,
+          exp_month: expMonth,
+          exp_year: fullExpYear,
           display_card_funding_type: "credit",
-          display_last4: "4242",
+          display_last4: last4,
         },
         allowance: {
           reason: "one_time",
@@ -676,7 +745,7 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
             action: "authorized",
           },
         ],
-        billing_address: DEFAULT_FULFILLMENT_ADDRESS,
+        billing_address: billingAddressData,
       });
 
       if (delegateEventId) {
@@ -702,7 +771,7 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
         payment_data: {
           token: delegateResponse.id,
           provider: "stripe",
-          billing_address: DEFAULT_FULFILLMENT_ADDRESS,
+          billing_address: billingAddressData,
         },
       });
 
@@ -748,12 +817,14 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
             dispatch({ type: "PAYMENT_COMPLETE", session: finalSession });
 
             // Trigger Post-Purchase Agent after successful payment
+            // Extract first name from billing address (use full name if no space)
+            const customerFirstName = billingAddress?.fullName?.split(" ")[0] ?? DEFAULT_BUYER.first_name;
             if (finalSession.order?.id && context.selectedProduct && context.sessionId) {
               triggerPostPurchaseAgent(
                 finalSession.order.id,
                 context.selectedProduct.name,
                 context.sessionId,
-                DEFAULT_BUYER.first_name
+                customerFirstName
               );
             }
           } catch (error) {
@@ -775,12 +846,14 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
         dispatch({ type: "PAYMENT_COMPLETE", session: completedSession });
 
         // Trigger Post-Purchase Agent after successful payment
+        // Extract first name from billing address (use full name if no space)
+        const customerName = billingAddress?.fullName?.split(" ")[0] ?? DEFAULT_BUYER.first_name;
         if (completedSession.order?.id && context.selectedProduct && context.sessionId) {
           triggerPostPurchaseAgent(
             completedSession.order.id,
             context.selectedProduct.name,
             context.sessionId,
-            DEFAULT_BUYER.first_name
+            customerName
           );
         }
       } else {
@@ -801,7 +874,9 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
       }
       dispatch({ type: "SET_ERROR", error: createAPIError(error) });
     }
-  }, [context.sessionId, context.session, context.selectedProduct, triggerPostPurchaseAgent]);
+    },
+    [context.sessionId, context.session, context.selectedProduct, context.paymentInfo, context.billingAddress, triggerPostPurchaseAgent]
+  );
 
   /**
    * Reset to initial state
@@ -819,6 +894,34 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
     dispatch({ type: "CLEAR_ERROR" });
   }, []);
 
+  /**
+   * Set payment info from form
+   */
+  const setPaymentInfo = useCallback((paymentInfo: PaymentFormData) => {
+    dispatch({ type: "SET_PAYMENT_INFO", paymentInfo });
+  }, []);
+
+  /**
+   * Set billing address from form
+   */
+  const setBillingAddress = useCallback((billingAddress: BillingAddressFormData) => {
+    dispatch({ type: "SET_BILLING_ADDRESS", billingAddress });
+  }, []);
+
+  /**
+   * Proceed from summary to payment form
+   */
+  const proceedToPayment = useCallback(() => {
+    dispatch({ type: "PROCEED_TO_PAYMENT" });
+  }, []);
+
+  /**
+   * Go back from payment form to summary
+   */
+  const backToSummary = useCallback(() => {
+    dispatch({ type: "BACK_TO_SUMMARY" });
+  }, []);
+
   return {
     context,
     dispatch,
@@ -828,5 +931,9 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
     submitPayment,
     reset,
     clearError,
+    setPaymentInfo,
+    setBillingAddress,
+    proceedToPayment,
+    backToSummary,
   };
 }

--- a/src/ui/hooks/useCheckoutFlow.ts
+++ b/src/ui/hooks/useCheckoutFlow.ts
@@ -674,10 +674,7 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
    * without waiting for context state to update
    */
   const submitPayment = useCallback(
-    async (
-      paymentInfoParam?: PaymentFormData,
-      billingAddressParam?: BillingAddressFormData
-    ) => {
+    async (paymentInfoParam?: PaymentFormData, billingAddressParam?: BillingAddressFormData) => {
       // Use provided params or fall back to context
       const paymentInfo = paymentInfoParam ?? context.paymentInfo;
       const billingAddress = billingAddressParam ?? context.billingAddress;
@@ -712,170 +709,178 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
         postal_code: addressParts[2]?.split(" ")[1] || "94102",
       };
 
-    const delegateEventId = loggerRef.current?.logEvent(
-      "delegate_payment",
-      "POST",
-      "/agentic_commerce/delegate_payment",
-      `Delegate $${(totalAmount / 100).toFixed(2)}`
-    );
-
-    try {
-      const delegateResponse = await delegatePayment({
-        payment_method: {
-          type: "card",
-          card_number_type: "fpan",
-          virtual: false,
-          number: cardNumber,
-          exp_month: expMonth,
-          exp_year: fullExpYear,
-          display_card_funding_type: "credit",
-          display_last4: last4,
-        },
-        allowance: {
-          reason: "one_time",
-          max_amount: totalAmount,
-          currency: context.session.currency,
-          checkout_session_id: context.sessionId,
-          merchant_id: "merchant_nvshop",
-          expires_at: expiresAt,
-        },
-        risk_signals: [
-          {
-            type: "card_testing",
-            action: "authorized",
-          },
-        ],
-        billing_address: billingAddressData,
-      });
-
-      if (delegateEventId) {
-        loggerRef.current?.completeEvent(
-          delegateEventId,
-          "success",
-          `Vault token: ${delegateResponse.id.slice(0, 10)}...`,
-          201
-        );
-      }
-
-      dispatch({ type: "PAYMENT_DELEGATED", vaultToken: delegateResponse.id });
-
-      // Step 2: Complete checkout with vault token
-      const completeEventId = loggerRef.current?.logEvent(
-        "session_complete",
+      const delegateEventId = loggerRef.current?.logEvent(
+        "delegate_payment",
         "POST",
-        `/checkout_sessions/${truncateId(context.sessionId)}/complete`,
-        "Process payment"
+        "/agentic_commerce/delegate_payment",
+        `Delegate $${(totalAmount / 100).toFixed(2)}`
       );
 
-      const completedSession = await completeCheckout(context.sessionId, {
-        payment_data: {
-          token: delegateResponse.id,
-          provider: "stripe",
+      try {
+        const delegateResponse = await delegatePayment({
+          payment_method: {
+            type: "card",
+            card_number_type: "fpan",
+            virtual: false,
+            number: cardNumber,
+            exp_month: expMonth,
+            exp_year: fullExpYear,
+            display_card_funding_type: "credit",
+            display_last4: last4,
+          },
+          allowance: {
+            reason: "one_time",
+            max_amount: totalAmount,
+            currency: context.session.currency,
+            checkout_session_id: context.sessionId,
+            merchant_id: "merchant_nvshop",
+            expires_at: expiresAt,
+          },
+          risk_signals: [
+            {
+              type: "card_testing",
+              action: "authorized",
+            },
+          ],
           billing_address: billingAddressData,
-        },
-      });
+        });
 
-      // Check if 3DS is required
-      if (completedSession.status === "authentication_required") {
-        if (completeEventId) {
-          loggerRef.current?.completeEvent(completeEventId, "success", "3DS required", 200);
-        }
-        dispatch({ type: "AUTHENTICATION_REQUIRED", session: completedSession });
-        // For now, we'll simulate 3DS completion after a delay
-        // In production, this would redirect to the 3DS URL
-        setTimeout(async () => {
-          const authEventId = loggerRef.current?.logEvent(
-            "session_complete",
-            "POST",
-            `/checkout_sessions/${truncateId(context.sessionId!)}/complete`,
-            "3DS authentication"
+        if (delegateEventId) {
+          loggerRef.current?.completeEvent(
+            delegateEventId,
+            "success",
+            `Vault token: ${delegateResponse.id.slice(0, 10)}...`,
+            201
           );
-          try {
-            const finalSession = await completeCheckout(context.sessionId!, {
-              payment_data: {
-                token: delegateResponse.id,
-                provider: "stripe",
-              },
-              authentication_result: {
-                outcome: "authenticated",
-                outcome_details: {
-                  three_ds_cryptogram: "AAIBBYNoEQAAAAAAg4PyBhdAEQs=",
-                  electronic_commerce_indicator: "05",
-                  transaction_id: crypto.randomUUID(),
-                  version: "2.2.0",
-                },
-              },
-            });
-            if (authEventId) {
-              loggerRef.current?.completeEvent(
-                authEventId,
-                "success",
-                `Order: ${finalSession.order?.id.slice(0, 10)}...`,
-                200
-              );
-            }
-            dispatch({ type: "PAYMENT_COMPLETE", session: finalSession });
+        }
 
-            // Trigger Post-Purchase Agent after successful payment
-            // Extract first name from billing address (use full name if no space)
-            const customerFirstName = billingAddress?.fullName?.split(" ")[0] ?? DEFAULT_BUYER.first_name;
-            if (finalSession.order?.id && context.selectedProduct && context.sessionId) {
-              triggerPostPurchaseAgent(
-                finalSession.order.id,
-                context.selectedProduct.name,
-                context.sessionId,
-                customerFirstName
-              );
-            }
-          } catch (error) {
-            if (authEventId) {
-              loggerRef.current?.completeEvent(authEventId, "error", "Payment failed", 400);
-            }
-            dispatch({ type: "SET_ERROR", error: createAPIError(error) });
+        dispatch({ type: "PAYMENT_DELEGATED", vaultToken: delegateResponse.id });
+
+        // Step 2: Complete checkout with vault token
+        const completeEventId = loggerRef.current?.logEvent(
+          "session_complete",
+          "POST",
+          `/checkout_sessions/${truncateId(context.sessionId)}/complete`,
+          "Process payment"
+        );
+
+        const completedSession = await completeCheckout(context.sessionId, {
+          payment_data: {
+            token: delegateResponse.id,
+            provider: "stripe",
+            billing_address: billingAddressData,
+          },
+        });
+
+        // Check if 3DS is required
+        if (completedSession.status === "authentication_required") {
+          if (completeEventId) {
+            loggerRef.current?.completeEvent(completeEventId, "success", "3DS required", 200);
           }
-        }, 2000);
-      } else if (completedSession.status === "completed") {
-        if (completeEventId) {
-          loggerRef.current?.completeEvent(
-            completeEventId,
-            "success",
-            `Order: ${completedSession.order?.id.slice(0, 10)}...`,
-            200
-          );
-        }
-        dispatch({ type: "PAYMENT_COMPLETE", session: completedSession });
+          dispatch({ type: "AUTHENTICATION_REQUIRED", session: completedSession });
+          // For now, we'll simulate 3DS completion after a delay
+          // In production, this would redirect to the 3DS URL
+          setTimeout(async () => {
+            const authEventId = loggerRef.current?.logEvent(
+              "session_complete",
+              "POST",
+              `/checkout_sessions/${truncateId(context.sessionId!)}/complete`,
+              "3DS authentication"
+            );
+            try {
+              const finalSession = await completeCheckout(context.sessionId!, {
+                payment_data: {
+                  token: delegateResponse.id,
+                  provider: "stripe",
+                },
+                authentication_result: {
+                  outcome: "authenticated",
+                  outcome_details: {
+                    three_ds_cryptogram: "AAIBBYNoEQAAAAAAg4PyBhdAEQs=",
+                    electronic_commerce_indicator: "05",
+                    transaction_id: crypto.randomUUID(),
+                    version: "2.2.0",
+                  },
+                },
+              });
+              if (authEventId) {
+                loggerRef.current?.completeEvent(
+                  authEventId,
+                  "success",
+                  `Order: ${finalSession.order?.id.slice(0, 10)}...`,
+                  200
+                );
+              }
+              dispatch({ type: "PAYMENT_COMPLETE", session: finalSession });
 
-        // Trigger Post-Purchase Agent after successful payment
-        // Extract first name from billing address (use full name if no space)
-        const customerName = billingAddress?.fullName?.split(" ")[0] ?? DEFAULT_BUYER.first_name;
-        if (completedSession.order?.id && context.selectedProduct && context.sessionId) {
-          triggerPostPurchaseAgent(
-            completedSession.order.id,
-            context.selectedProduct.name,
-            context.sessionId,
-            customerName
-          );
+              // Trigger Post-Purchase Agent after successful payment
+              // Extract first name from billing address (use full name if no space)
+              const customerFirstName =
+                billingAddress?.fullName?.split(" ")[0] ?? DEFAULT_BUYER.first_name;
+              if (finalSession.order?.id && context.selectedProduct && context.sessionId) {
+                triggerPostPurchaseAgent(
+                  finalSession.order.id,
+                  context.selectedProduct.name,
+                  context.sessionId,
+                  customerFirstName
+                );
+              }
+            } catch (error) {
+              if (authEventId) {
+                loggerRef.current?.completeEvent(authEventId, "error", "Payment failed", 400);
+              }
+              dispatch({ type: "SET_ERROR", error: createAPIError(error) });
+            }
+          }, 2000);
+        } else if (completedSession.status === "completed") {
+          if (completeEventId) {
+            loggerRef.current?.completeEvent(
+              completeEventId,
+              "success",
+              `Order: ${completedSession.order?.id.slice(0, 10)}...`,
+              200
+            );
+          }
+          dispatch({ type: "PAYMENT_COMPLETE", session: completedSession });
+
+          // Trigger Post-Purchase Agent after successful payment
+          // Extract first name from billing address (use full name if no space)
+          const customerName = billingAddress?.fullName?.split(" ")[0] ?? DEFAULT_BUYER.first_name;
+          if (completedSession.order?.id && context.selectedProduct && context.sessionId) {
+            triggerPostPurchaseAgent(
+              completedSession.order.id,
+              context.selectedProduct.name,
+              context.sessionId,
+              customerName
+            );
+          }
+        } else {
+          if (completeEventId) {
+            loggerRef.current?.completeEvent(
+              completeEventId,
+              "success",
+              `Status: ${completedSession.status}`,
+              200
+            );
+          }
+          // Handle other statuses
+          dispatch({ type: "SESSION_UPDATED", session: completedSession });
         }
-      } else {
-        if (completeEventId) {
-          loggerRef.current?.completeEvent(
-            completeEventId,
-            "success",
-            `Status: ${completedSession.status}`,
-            200
-          );
+      } catch (error) {
+        if (delegateEventId) {
+          loggerRef.current?.completeEvent(delegateEventId, "error", "Payment failed", 400);
         }
-        // Handle other statuses
-        dispatch({ type: "SESSION_UPDATED", session: completedSession });
+        dispatch({ type: "SET_ERROR", error: createAPIError(error) });
       }
-    } catch (error) {
-      if (delegateEventId) {
-        loggerRef.current?.completeEvent(delegateEventId, "error", "Payment failed", 400);
-      }
-      dispatch({ type: "SET_ERROR", error: createAPIError(error) });
-    }
     },
-    [context.sessionId, context.session, context.selectedProduct, context.paymentInfo, context.billingAddress, triggerPostPurchaseAgent]
+    [
+      context.sessionId,
+      context.session,
+      context.selectedProduct,
+      context.paymentInfo,
+      context.billingAddress,
+      triggerPostPurchaseAgent,
+    ]
   );
 
   /**

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -743,6 +743,9 @@ export interface CheckoutFlowContext {
   vaultToken: string | null;
   isLoading: boolean;
   error: APIError | null;
+  checkoutStep: CheckoutStep;
+  paymentInfo: PaymentFormData | null;
+  billingAddress: BillingAddressFormData | null;
 }
 
 /**
@@ -761,4 +764,53 @@ export type CheckoutFlowAction =
   | { type: "SET_LOADING"; isLoading: boolean }
   | { type: "SET_ERROR"; error: APIError }
   | { type: "CLEAR_ERROR" }
-  | { type: "RESET" };
+  | { type: "RESET" }
+  | { type: "SET_PAYMENT_INFO"; paymentInfo: PaymentFormData }
+  | { type: "SET_BILLING_ADDRESS"; billingAddress: BillingAddressFormData }
+  | { type: "PROCEED_TO_PAYMENT" }
+  | { type: "BACK_TO_SUMMARY" };
+
+// =============================================================================
+// Payment Form Types (Feature 14)
+// =============================================================================
+
+/**
+ * Checkout step in the modal flow
+ * - "summary": Shows order summary with Continue button (first step)
+ * - "payment": Shows payment form with Pay Now button (second step)
+ */
+export type CheckoutStep = "summary" | "payment";
+
+/**
+ * Payment form data for card information
+ */
+export interface PaymentFormData {
+  cardNumber: string;
+  expirationDate: string;
+  securityCode: string;
+}
+
+/**
+ * Billing address form data
+ */
+export interface BillingAddressFormData {
+  fullName: string;
+  address: string;
+}
+
+/**
+ * Default payment form values for demo
+ */
+export const DEFAULT_PAYMENT_FORM: PaymentFormData = {
+  cardNumber: "4242424242424242",
+  expirationDate: "12/28",
+  securityCode: "123",
+};
+
+/**
+ * Default billing address values for demo
+ */
+export const DEFAULT_BILLING_ADDRESS: BillingAddressFormData = {
+  fullName: "John Doe",
+  address: "123 Main St, San Francisco, CA 94102",
+};


### PR DESCRIPTION
## Summary

- Adds `PaymentShippingForm` component for collecting card details and billing address
- Integrates payment form into checkout modal with two-step flow (summary → payment)
- Fixes post-purchase messages to use actual customer name from billing address instead of hardcoded "John"

## Test plan

- [x] All 155 UI tests pass (`pnpm test:run`)
- [x] Lint passes (`pnpm lint`)
- [x] TypeScript check passes (`pnpm typecheck`)
- [x] Manual testing: Enter different name in billing form, verify post-purchase message shows entered name
- [x] Manual testing: Complete full checkout flow with payment form

## Changes

| File | Change |
|------|--------|
| `PaymentShippingForm.tsx` | New component for payment/billing input |
| `PaymentShippingForm.test.tsx` | 35 tests for the new component |
| `useCheckoutFlow.ts` | Payment state management, fix customer name passing |
| `useCheckoutFlow.test.ts` | Added missing mocks for post-purchase functions |
| `types/index.ts` | `PaymentFormData`, `BillingAddressFormData` types |
| `AgentPanel.tsx` | Integration of payment form in checkout flow |
| `CheckoutCard.tsx` | Updated to support two-step checkout |
| `icons/index.tsx` | Added `ChevronLeft`, `CreditCard` icons |