### PR TITLE
[agents] Add Phoenix telemetry and ARAG ultrafast config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,8 @@ src/
 │   └── configs/        # Agent workflow configurations
 │       ├── promotion.yml        # Promotion strategy arbiter (port 8002)
 │       ├── post-purchase.yml    # Multilingual shipping messages (port 8003)
-│       └── recommendation.yml   # ARAG multi-agent recommendations (port 8004)
+│       ├── recommendation.yml   # ARAG multi-agent recommendations (full version)
+│       └── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
 │
 ├── apps_sdk/           # Apps SDK MCP Server (port 2091)
 │   ├── main.py         # FastAPI + MCP server entry point
@@ -237,7 +238,7 @@ NAT Agents (from `src/agents/`):
 - Install: `uv pip install -e ".[dev]" --prerelease=allow`
 - Start Promotion Agent: `nat serve --config_file configs/promotion.yml --port 8002`
 - Start Post-Purchase Agent: `nat serve --config_file configs/post-purchase.yml --port 8003`
-- Start Recommendation Agent (ARAG): `nat serve --config_file configs/recommendation.yml --port 8004`
+- Start Recommendation Agent (ARAG): `nat serve --config_file configs/recommendation-ultrafast.yml --port 8004`
 - Test Promotion: `nat run --config_file configs/promotion.yml --input '{...}'`
 - Test Post-Purchase: `nat run --config_file configs/post-purchase.yml --input '{...}'`
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cd src/agents
 uv pip install -e ".[dev]" --prerelease=allow
 nat serve --config_file configs/promotion.yml --port 8002      # Promotion Agent
 nat serve --config_file configs/post-purchase.yml --port 8003  # Post-Purchase Agent
-nat serve --config_file configs/recommendation.yml --port 8004 # Recommendation Agent (requires Milvus)
+nat serve --config_file configs/recommendation-ultrafast.yml --port 8004 # Recommendation Agent (requires Milvus)
 
 # Frontend UI (port 3000)
 cd src/ui
@@ -88,23 +88,29 @@ pnpm dev  # Runs on http://localhost:3001
 
 See [src/apps_sdk/README.md](src/apps_sdk/README.md) for full documentation.
 
-### Milvus Setup (for Recommendation Agent)
+### Infrastructure (Docker)
 
-The Recommendation Agent uses Milvus for vector similarity search. Start Milvus and seed the product catalog:
+The Recommendation Agent requires Milvus (vector search) and Phoenix (observability). Start both with Docker Compose:
 
 ```bash
-# Start Milvus (Docker required)
+# Start infrastructure
 docker compose up -d
 
-# Wait for health check
-curl -s http://localhost:9091/healthz
+# Verify services
+curl -s http://localhost:9091/healthz  # Milvus
+curl -s http://localhost:6006/healthz  # Phoenix
 
-# Seed product catalog embeddings (from src/agents/)
+# Seed product catalog (from src/agents/)
 cd src/agents
 uv run python scripts/seed_milvus.py
 ```
 
-Data persists across restarts. To start fresh:
+| Service | URL | Purpose |
+|---------|-----|---------|
+| Milvus | localhost:19530 | Vector similarity search |
+| Phoenix | http://localhost:6006 | LLM observability UI |
+
+Data persists across restarts. To reset: `docker compose down -v`
 
 ### Verify
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,5 @@
-# Docker Compose for Milvus Vector Database
-# ==========================================
-# Required for ARAG Recommendation Agent
-# Milvus provides vector similarity search for product catalog embeddings.
-#
-# Usage:
-#   docker compose up -d                    # Start Milvus in background
-#   docker compose down                     # Stop Milvus
-#   docker compose down -v                  # Stop and remove volumes
-#   curl -s http://localhost:9091/healthz   # Health check
+# Infrastructure for ARAG Recommendation Agent
+# See src/agents/README.md for full documentation
 
 services:
   # etcd - Metadata storage for Milvus
@@ -76,6 +68,25 @@ services:
     networks:
       - milvus-network
 
+  # Phoenix - LLM Observability and Tracing
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    container_name: phoenix
+    ports:
+      - "6006:6006"   # Phoenix UI and OTLP HTTP collector
+      - "4317:4317"   # OTLP gRPC collector
+    environment:
+      - PHOENIX_WORKING_DIR=/mnt/data
+    volumes:
+      - phoenix_data:/mnt/data
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:6006/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - milvus-network
+
 networks:
   milvus-network:
     driver: bridge
@@ -84,3 +95,4 @@ volumes:
   etcd_data:
   minio_data:
   milvus_data:
+  phoenix_data:

--- a/env.example
+++ b/env.example
@@ -31,3 +31,15 @@ PROMOTION_AGENT_TIMEOUT=10.0
 # Post-Purchase Agent Configuration
 POST_PURCHASE_AGENT_URL=http://localhost:8003
 POST_PURCHASE_AGENT_TIMEOUT=15.0
+
+# Recommendation Agent Configuration
+RECOMMENDATION_AGENT_URL=http://localhost:8004
+RECOMMENDATION_AGENT_TIMEOUT=15.0
+
+# Phoenix Observability (for Recommendation Agent tracing)
+# Start Phoenix: docker compose up -d
+# View traces: http://localhost:6006
+PHOENIX_ENDPOINT=http://localhost:6006/v1/traces
+
+# Milvus Vector Database (for Recommendation Agent)
+MILVUS_URI=http://localhost:19530

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -50,7 +50,7 @@ All ACP agents follow a **3-layer hybrid architecture** that combines determinis
 |-------|--------|------|---------|
 | Promotion Agent | `configs/promotion.yml` | 8002 | Strategy arbiter for dynamic pricing |
 | Post-Purchase Agent | `configs/post-purchase.yml` | 8003 | Multilingual shipping message generator |
-| Recommendation Agent (ARAG) | `configs/recommendation.yml` | 8004 | Multi-agent personalized recommendations |
+| Recommendation Agent (ARAG) | `configs/recommendation-ultrafast.yml` | 8004 | Multi-agent personalized recommendations |
 
 ### ARAG Recommendation Agent Architecture
 
@@ -300,7 +300,7 @@ nat run --config_file configs/post-purchase.yml --input '{
 | `out_for_delivery` | Package arriving today |
 | `delivered` | Package delivered |
 
-### Recommendation Agent (`configs/recommendation.yml`)
+### Recommendation Agent (`configs/recommendation-ultrafast.yml`)
 
 **Workflow Type:** `react_agent` (multi-agent orchestration)
 
@@ -388,15 +388,47 @@ The Recommendation Agent uses an ARAG (Agentic RAG) architecture with 4 speciali
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+**Infrastructure (Docker Compose):**
+
+The Recommendation Agent requires Milvus for vector search and Phoenix for observability. Both are defined in `docker-compose.yml` at the project root.
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| Milvus | 19530 | Vector similarity search for product embeddings |
+| Phoenix | 6006 | LLM observability UI and trace collection |
+| MinIO | 9001 | Object storage for Milvus (console optional) |
+
+```bash
+# Start infrastructure
+docker compose up -d
+
+# Stop infrastructure
+docker compose down
+
+# Stop and remove all data
+docker compose down -v
+```
+
+| Health Check | Command |
+|--------------|---------|
+| Milvus | `curl -s http://localhost:9091/healthz` |
+| Phoenix | `curl -s http://localhost:6006/healthz` |
+
+| UI | URL |
+|----|-----|
+| Phoenix (traces, LLM calls) | http://localhost:6006 |
+| MinIO Console (optional) | http://localhost:9001 |
+
 **Prerequisites:**
 
-1. **Start Milvus Vector Database:**
+1. **Start Infrastructure (Milvus + Phoenix):**
    ```bash
    # From project root
    docker compose up -d
    
-   # Verify Milvus is running
-   curl -s http://localhost:9091/healthz  # Should return "OK"
+   # Verify services are running
+   curl -s http://localhost:9091/healthz  # Milvus - Should return "OK"
+   curl -s http://localhost:6006/healthz  # Phoenix - Should return "OK"
    ```
 
 2. **Seed Product Catalog with Embeddings:**
@@ -415,7 +447,7 @@ The Recommendation Agent uses an ARAG (Agentic RAG) architecture with 4 speciali
 
 ```bash
 # Start as REST endpoint
-nat serve --config_file configs/recommendation.yml --port 8004
+nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
 
 # Test with curl
 curl -X POST http://localhost:8004/generate \
@@ -562,7 +594,8 @@ src/agents/
 └── configs/
     ├── promotion.yml        # Promotion strategy arbiter (port 8002)
     ├── post-purchase.yml    # Multilingual shipping messages (port 8003)
-    └── recommendation.yml   # ARAG multi-agent recommendations (port 8004, planned)
+    ├── recommendation.yml   # ARAG multi-agent recommendations (full version)
+    └── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
 ```
 
 ## Development
@@ -646,7 +679,7 @@ Traditional RAG retrieves documents based on embedding similarity alone. ARAG in
 | **Context Summary (CSA)** | Synthesize signals | UUA output, NLI scores | Focused context JSON |
 | **Item Ranker (IRA)** | Final ranking | User summary, context | Ranked recommendations |
 
-### Complete NAT Configuration (`configs/recommendation.yml`)
+### Complete NAT Configuration (`configs/recommendation-ultrafast.yml`)
 
 All ARAG agents are orchestrated in a **single YAML file** using NAT's multi-agent pattern.
 
@@ -654,10 +687,10 @@ All ARAG agents are orchestrated in a **single YAML file** using NAT's multi-age
 
 ```bash
 # Start as REST endpoint (single command for all agents)
-nat serve --config_file configs/recommendation.yml --port 8004
+nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
 
 # Test with direct input
-nat run --config_file configs/recommendation.yml --input '{
+nat run --config_file configs/recommendation-ultrafast.yml --input '{
   "cart_items": [
     {"product_id": "prod_1", "name": "Classic Tee", "category": "tops", "price": 2500}
   ],
@@ -701,6 +734,7 @@ nat run --config_file configs/recommendation.yml --input '{
 |----------|-------------|---------|
 | `NVIDIA_API_KEY` | API key for NVIDIA NIM | Required |
 | `MILVUS_URI` | Milvus vector database URI | `http://localhost:19530` |
+| `PHOENIX_ENDPOINT` | Phoenix observability endpoint | `http://localhost:6006` |
 
 ### Architecture Benefits
 
@@ -711,6 +745,76 @@ Using NAT's multi-agent orchestration provides:
 3. **Flexible LLM Assignment**: Different models for different tasks (fast for scoring, reasoning for ranking)
 4. **Built-in Tracing**: Phoenix integration for debugging the multi-agent workflow
 5. **Tool Composition**: Coordinator can call specialized agents as tools
+
+### Observability with Phoenix
+
+The Recommendation Agent includes built-in observability using [Arize Phoenix](https://docs.arize.com/phoenix/), providing distributed tracing and LLM call visualization for debugging the multi-agent pipeline.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    ARAG Agent Pipeline                           │
+│  (Coordinator → UUA → NLI → CSA → IRA)                          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ OTLP traces (port 6006)
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Phoenix (Docker Container)                    │
+├─────────────────────────────────────────────────────────────────┤
+│  - Trace visualization for multi-agent workflow                  │
+│  - LLM call details (prompts, completions, tokens)              │
+│  - Latency breakdown per agent                                   │
+│  - Token usage and cost tracking                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Starting Phoenix:**
+
+```bash
+# Start Phoenix alongside Milvus (from project root)
+docker compose up -d
+
+# Verify Phoenix is running
+curl -s http://localhost:6006/healthz  # Should return "OK"
+```
+
+**Accessing the Phoenix UI:**
+
+Open http://localhost:6006 in your browser to view:
+- **Traces**: End-to-end request traces showing all agent calls
+- **Spans**: Individual LLM calls with prompts, completions, and token counts
+- **Latency**: Time breakdown for each step in the pipeline
+- **Errors**: Failed calls and error details
+
+**Configuration:**
+
+Phoenix tracing is configured in `configs/recommendation-ultrafast.yml`:
+
+```yaml
+general:
+  telemetry:
+    tracing:
+      phoenix:
+        _type: phoenix
+        project_name: "arag-recommendations"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006}
+```
+
+**Installation:**
+
+To enable Phoenix tracing, install the Phoenix telemetry package:
+
+```bash
+pip install "nvidia-nat[phoenix]"
+```
+
+**Troubleshooting Phoenix:**
+
+| Issue | Solution |
+|-------|----------|
+| No traces appearing | Verify Phoenix is running: `curl http://localhost:6006/healthz` |
+| Connection refused | Check `PHOENIX_ENDPOINT` env var matches your Phoenix URL |
+| Traces missing spans | Ensure `nvidia-nat[phoenix]` is installed |
 
 ### Service Integration
 

--- a/src/agents/configs/post-purchase.yml
+++ b/src/agents/configs/post-purchase.yml
@@ -10,6 +10,16 @@
 
 general:
   use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: info
+    tracing:
+      phoenix:
+        _type: phoenix
+        project: "post-purchase-agent"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006/v1/traces}
 
 # LLM configuration
 llms:

--- a/src/agents/configs/promotion.yml
+++ b/src/agents/configs/promotion.yml
@@ -8,6 +8,16 @@
 
 general:
   use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: info
+    tracing:
+      phoenix:
+        _type: phoenix
+        project: "promotion-agent"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006/v1/traces}
 
 # LLM configuration
 llms:

--- a/src/agents/configs/recommendation-ultrafast.yml
+++ b/src/agents/configs/recommendation-ultrafast.yml
@@ -1,0 +1,178 @@
+# ARAG Recommendation Agent - ULTRAFAST Version
+# ==============================================
+# Maximum speed version: Single LLM call with full ARAG methodology.
+#
+# Architecture: tool_calling_agent with embedded ARAG reasoning
+# - No ReAct parsing overhead
+# - Single coordinated tool call + recommendation generation
+# - Full 4-step ARAG methodology (UUA + NLI + CSA + Ranker) in one prompt
+#
+# Trade-off: Faster than react_agent while maintaining ARAG quality
+#
+# Usage:
+#   nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+#   nat run --config_file configs/recommendation-ultrafast.yml --input '{"cart_items": [...], "session_context": {}}'
+
+general:
+  use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: info
+    tracing:
+      phoenix:
+        _type: phoenix
+        project: "arag-recommendations-ultrafast"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006/v1/traces}
+
+# =============================================================================
+# EMBEDDERS - Semantic embeddings for product search
+# =============================================================================
+embedders:
+  product_embedder:
+    _type: nim
+    model_name: nvidia/nv-embedqa-e5-v5
+    truncate: "END"
+
+# =============================================================================
+# RETRIEVERS - Vector search for candidate products
+# =============================================================================
+retrievers:
+  product_retriever:
+    _type: milvus_retriever
+    uri: ${MILVUS_URI:-http://localhost:19530}
+    collection_name: "product_catalog"
+    embedding_model: product_embedder
+    top_k: 10
+
+# =============================================================================
+# FUNCTIONS - Product search tool
+# =============================================================================
+functions:
+  product_search:
+    _type: nat_retriever
+    retriever: product_retriever
+    topic: Search product catalog for items matching the shopping context
+
+# =============================================================================
+# LLM PROVIDERS
+# =============================================================================
+llms:
+  fast_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-nano-30b-a3b
+    temperature: 0.3
+    max_tokens: 512
+    chat_template_kwargs:
+      enable_thinking: false
+
+# =============================================================================
+# MAIN WORKFLOW - Tool-calling agent (more efficient than ReAct)
+# =============================================================================
+workflow:
+  _type: tool_calling_agent
+  name: ultrafast_arag_recommendation
+  workflow_alias: recommendation_agent
+  llm_name: fast_llm
+  tool_names:
+    - product_search
+  verbose: true
+  max_iterations: 2
+  system_prompt: |
+    You are an expert e-commerce recommendation engine using ARAG (Agentic RAG) methodology.
+    
+    IMPORTANT - PRICE FORMAT:
+    =========================
+    All prices are in CENTS, not dollars.
+    - price: 2500 means $25.00
+    - price: 5900 means $59.00
+    - price_range_viewed: [2000, 5000] means $20-$50
+    - price_cents: 4900 means $49.00
+    Always divide by 100 to get dollar values when reasoning about prices.
+    
+    MANDATORY FIRST STEP - YOU MUST DO THIS:
+    =========================================
+    You MUST call the product_search tool FIRST before doing anything else.
+    DO NOT generate any response until you have search results.
+    DO NOT skip the tool call. The search is REQUIRED.
+    
+    Search query should describe complementary items for the cart contents.
+    Example: if cart has "Bomber Jacket", search for "casual pants accessories footwear to pair with jacket"
+    
+    AFTER RECEIVING SEARCH RESULTS - APPLY ARAG METHODOLOGY:
+    =========================================================
+    Perform this 4-step analysis (internally, do not output intermediate steps):
+    
+    1. USER UNDERSTANDING (UUA):
+       - Infer shopping intent from cart items
+       - Determine price sensitivity (low/medium/high) from price_range_viewed
+       - Identify style preferences from browse history
+       - Find complementary category opportunities
+    
+    2. NLI ALIGNMENT SCORING:
+       For each candidate product, score semantic alignment with user intent:
+       - SUPPORTS (0.8-1.0): Directly matches or complements intent
+       - NEUTRAL (0.4-0.7): Tangentially related
+       - CONTRADICTS (0.0-0.3): Doesn't fit (duplicate category, wrong style)
+    
+    3. CONTEXT SYNTHESIS (CSA):
+       - Filter to products with alignment score > 0.7
+       - Prioritize by: cross-sell fit > price match > diversity
+       - Exclude items already in cart or same subcategory as cart items
+    
+    4. FINAL RANKING (IRA):
+       - Select top 3 diverse recommendations
+       - Ensure variety (don't recommend 3 similar items)
+       - Provide clear reasoning for each selection
+    
+    OUTPUT FORMAT (return ONLY this JSON after analysis):
+    {{
+      "recommendations": [
+        {{
+          "product_id": "prod_X",
+          "product_name": "exact name from search",
+          "rank": 1,
+          "reasoning": "2-3 sentence explanation of why this recommendation fits"
+        }},
+        {{
+          "product_id": "prod_Y",
+          "product_name": "exact name from search",
+          "rank": 2,
+          "reasoning": "2-3 sentence explanation"
+        }},
+        {{
+          "product_id": "prod_Z",
+          "product_name": "exact name from search",
+          "rank": 3,
+          "reasoning": "2-3 sentence explanation"
+        }}
+      ],
+      "user_intent": "1 sentence summary of inferred shopping intent (use dollar amounts, not cents)",
+      "pipeline_trace": {{
+        "candidates_received": <actual count from search>,
+        "after_alignment_filter": <count with alignment score > 0.7>,
+        "final_ranked": 3
+      }}
+    }}
+    
+    CRITICAL RULES:
+    - ALWAYS call product_search first - this is mandatory
+    - Use EXACT product_id and product_name from search results
+    - NEVER recommend items already in cart
+    - NEVER skip the search step
+    - NEVER invent product names or IDs
+    - Ensure diversity: avoid 3 items from same subcategory
+    - Remember: all prices are in CENTS (divide by 100 for dollars)
+    
+    If no suitable recommendations exist after ARAG filtering:
+    {{
+      "recommendations": [],
+      "user_intent": "description of inferred intent",
+      "pipeline_trace": {{
+        "candidates_received": <count>,
+        "after_alignment_filter": 0,
+        "final_ranked": 0
+      }},
+      "message": "No suitable cross-sell recommendations for current cart"
+    }}

--- a/src/agents/configs/recommendation.yml
+++ b/src/agents/configs/recommendation.yml
@@ -22,6 +22,11 @@ general:
       console:
         _type: console
         level: info
+    tracing:
+      phoenix:
+        _type: phoenix
+        project: "arag-recommendations"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006/v1/traces}
 
 # =============================================================================
 # EMBEDDERS - Semantic embeddings for product search
@@ -110,12 +115,16 @@ functions:
       
       INPUT: You will receive:
       - User intent summary (from User Understanding Agent)
-      - List of candidate products with their metadata
+      - List of candidate products with their metadata (including product IDs like prod_7, prod_2)
+      
+      CRITICAL: You MUST use the EXACT product_id values from the input (e.g., "prod_7", "prod_2").
+      NEVER invent, generate, or modify product IDs. If input says "prod_7 (Cargo Shorts)",
+      your output must use "prod_7" as the product_id, NOT "Cargo Shorts" or any other made-up ID.
       
       OUTPUT: Return ONLY valid JSON array with this exact structure:
       [
         {{
-          "product_id": "string",
+          "product_id": "prod_X (EXACT ID from input)",
           "alignment": "supports|neutral|contradicts",
           "relevance_score": 0.0-1.0,
           "reasoning": "brief explanation"
@@ -146,12 +155,16 @@ functions:
       - Key matching attributes for each
       - Cross-sell rationale explaining why each fits
       
+      CRITICAL: You MUST use the EXACT product_id values from the input (e.g., "prod_7", "prod_2").
+      NEVER invent, generate, or modify product IDs. If input says "prod_7 (Cargo Shorts)",
+      your output must use "prod_7" as the product_id
+      
       OUTPUT: Return ONLY valid JSON with this exact structure:
       {{
         "summary": "brief context for ranker describing user needs",
         "top_candidates": [
           {{
-            "product_id": "prod_X",
+            "product_id": "prod_X (EXACT ID from input, e.g. prod_7)",
             "product_name": "exact name from catalog",
             "match_reasons": ["reason1", "reason2"],
             "cross_sell_fit": "brief explanation"
@@ -181,11 +194,15 @@ functions:
       4. Value proposition for the customer
       5. Diversity (don't recommend 3 similar items)
       
+      CRITICAL: You MUST use the EXACT product_id values from the input (e.g., "prod_7", "prod_2").
+      NEVER invent, generate, or modify product IDs. If input says "prod_7 (Cargo Shorts)",
+      your output must use "prod_7" as the product_id.
+      
       OUTPUT: Return EXACTLY 3 recommendations in valid JSON:
       {{
         "recommendations": [
           {{
-            "product_id": "prod_X",
+            "product_id": "prod_X (EXACT ID from input, e.g. prod_7)",
             "product_name": "exact name from list above",
             "rank": 1,
             "reasoning": "why this recommendation makes sense for the user"
@@ -211,7 +228,7 @@ llms:
     _type: nim
     model_name: nvidia/llama-3.3-nemotron-super-49b-v1.5
     thinking: false
-    temperature: 0.3
+    temperature: 0.9
     max_tokens: 512
 
 # =============================================================================
@@ -223,7 +240,7 @@ workflow:
   workflow_alias: recommendation_agent
   llm_name: coordinator_llm
   verbose: true
-  parse_agent_response_max_retries: 2
+  parse_agent_response_max_retries: 3
   tool_names:
     - product_search
     - user_understanding_agent
@@ -234,7 +251,7 @@ workflow:
     ARAG Recommendation Coordinator - orchestrates multi-agent pipeline for
     personalized cross-sell recommendations based on cart items and session context.
   system_prompt: |
-    /no_think You are the ARAG Recommendation Coordinator for an e-commerce platform.
+    You are the ARAG Recommendation Coordinator for an e-commerce platform.
     
     Your task: Given a user's cart items and optional session context, produce
     3 personalized cross-sell recommendations using your specialized agents.
@@ -251,18 +268,22 @@ workflow:
     
     1. RETRIEVE CANDIDATES: Use `product_search` with a text query.
        Example: "bottoms to pair with tees" or "casual summer accessories"
+       NOTE: This returns products with REAL IDs like "prod_7", "prod_2". Save these IDs!
     
     2. UNDERSTAND USER: Call `user_understanding_agent` with a text summary.
        Example: "User has Classic Tee in cart, browsing casual wear, price range 2000-4000"
     
     3. SCORE ALIGNMENT: Call `nli_alignment_agent` with a text summary.
-       Example: "Score products joggers shorts jeans against user wanting casual summer wear"
+       Example: "Score products prod_7 (Cargo Shorts), prod_5 (Joggers) against user wanting casual summer wear"
+       CRITICAL: Always include the actual product IDs (prod_X) in your input!
     
     4. SYNTHESIZE CONTEXT: Call `context_summary_agent` with a text summary.
-       Example: "Summarize context for casual summer shopper, top products: shorts, sneakers"
+       Example: "Summarize context for casual summer shopper, top products: prod_7 (Cargo Shorts), prod_9 (Canvas Sneakers)"
+       CRITICAL: Always include the actual product IDs (prod_X) in your input!
     
     5. RANK ITEMS: Call `item_ranker_agent` with a text summary.
-       Example: "Rank shorts sneakers sunglasses for casual summer shopper"
+       Example: "Rank prod_7 (Cargo Shorts), prod_9 (Canvas Sneakers), prod_11 (Sunglasses) for casual summer shopper"
+       CRITICAL: Always include the actual product IDs (prod_X) in your input!
     
     Use this format for your responses:
     
@@ -287,9 +308,9 @@ workflow:
       ],
       "user_intent": "summary of inferred user intent",
       "pipeline_trace": {{
-        "candidates_found": 20,
-        "after_nli_filter": 8,
-        "final_ranked": 3
+        "candidates_found": "<ACTUAL count from product_search>",
+        "after_nli_filter": "<ACTUAL count after NLI filtering>",
+        "final_ranked": "<ACTUAL count of final recommendations>"
       }}
     }}
     
@@ -297,17 +318,20 @@ workflow:
     - CRITICAL: Only recommend products that were ACTUALLY returned by product_search
     - Use the EXACT product_id and product_name from the retrieved results (e.g., "prod_7", "Cargo Shorts")
     - NEVER invent or hallucinate product names or IDs
+    - NEVER invent or hallucinate counts - use ACTUAL numbers from tool outputs
+    - The pipeline_trace counts MUST reflect real values: count the actual results array length
     - Never recommend items already in the cart
     - Only recommend in-stock items
     - Ensure diversity in recommendations
+    - When calling sub-agents, ALWAYS include the real product IDs (prod_X format) in your text input
     
     If you cannot find suitable recommendations, return:
     {{
       "recommendations": [],
       "user_intent": "description of what was inferred",
       "pipeline_trace": {{
-        "candidates_found": 0,
-        "after_nli_filter": 0,
+        "candidates_found": "<ACTUAL count - may be 0 or more>",
+        "after_nli_filter": "<ACTUAL count after filtering>",
         "final_ranked": 0
       }},
       "message": "No suitable recommendations found for the current cart"

--- a/src/agents/pyproject.toml
+++ b/src/agents/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     # NAT with ingestion (Milvus retriever) and langchain extras
-    "nvidia-nat[ingestion,langchain]~=1.4.0rc3",
+    "nvidia-nat[ingestion,langchain,phoenix]~=1.4.0rc3",
     "httpx>=0.27.0",
 ]
 


### PR DESCRIPTION
## Summary

- Add **Phoenix observability** service to docker-compose for LLM tracing and debugging
- Configure Phoenix tracing endpoints in all NAT agent configs (promotion, post-purchase, recommendation)
- Add **recommendation-ultrafast.yml** with full 4-step ARAG methodology optimized for `nemotron-nano-30b`
- Fix product_id handling to enforce exact IDs from search results

## Changes

### Phoenix Integration
- New Phoenix service in `docker-compose.yml` (ports 6006 for UI, 4317 for OTLP gRPC)
- All agent configs now include Phoenix tracing configuration
- `PHOENIX_ENDPOINT` added to `env.example`

### ARAG Ultrafast Config
New `recommendation-ultrafast.yml` that combines speed with quality:
- Uses `tool_calling_agent` workflow (faster than ReAct)
- Embeds full ARAG methodology in single prompt:
  1. **User Understanding (UUA)** - Intent inference, price sensitivity
  2. **NLI Alignment Scoring** - Semantic relevance 0.0-1.0
  3. **Context Synthesis (CSA)** - Filtering and prioritization
  4. **Final Ranking (IRA)** - Diverse top-3 selection

### Bug Fixes
- Improved product_id enforcement in recommendation.yml prompts to prevent hallucinated IDs

## Test Plan

- [x] Start Phoenix: `docker compose up phoenix -d`
- [x] Verify Phoenix UI at http://localhost:6006
- [x] Test ultrafast agent: `nat serve --config_file configs/recommendation-ultrafast.yml --port 8004`
- [x] Verify traces appear in Phoenix dashboard


Made with [Cursor](https://cursor.com)