### PR TITLE
[apps-sdk][frontend] Widget improvements and backend-driven totals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,3 +305,144 @@ curl -s -w "\nHTTP_CODE:%{http_code}" -X POST http://localhost:2091/acp/sessions
 - **No log output**: Code path not executed
 
 **DO NOT** just read code and say "this should work" - always test and show evidence.
+
+## Critical Verification Diligence (MUST READ)
+
+**Passing static checks (TypeScript, linting, tests, code review) does NOT mean code works correctly.**
+
+Many bugs are invisible to static analysis. You MUST verify actual runtime behavior through real testing, not just reading code and assuming it works.
+
+### Verification Blind Spots
+
+These pass all static checks but contain bugs:
+
+| Blind Spot | What You See | Reality |
+|------------|--------------|---------|
+| **Mock/Hardcoded Data** | Code calls a function that "returns data" | Function returns hardcoded values, not real API calls |
+| **Fire-and-Forget Async** | `fetchData()` is called | Call is made but result is never awaited or used |
+| **Stale State Display** | UI updates when state changes | UI shows OLD data while waiting for NEW data |
+| **Unused Results** | Backend call is made | Response is ignored; UI uses local calculation instead |
+| **Dead Code Paths** | Function exists and looks correct | Function is never actually called in the flow |
+| **Wrong Data Source** | Display shows correct-looking values | Values come from local state, not backend response |
+
+### Questions to Ask Before Claiming "It Works"
+
+1. **Is this REAL or MOCK?**
+   - Trace the data from UI back to source
+   - Is there an actual HTTP call? Check network tab or server logs
+   - Are there hardcoded values, default fallbacks, or mock returns?
+
+2. **Is this USED or IGNORED?**
+   - If backend returns data, is that data actually used in the UI?
+   - Or does the UI calculate/derive values locally and ignore the response?
+
+3. **What happens DURING async operations?**
+   - What does user see while waiting for response?
+   - Is stale data shown without indication?
+   - Can mismatched data appear (e.g., new quantity but old total)?
+
+4. **What happens on FAILURE?**
+   - If the backend call fails, does the UI handle it?
+   - Are optimistic updates rolled back?
+
+5. **Is the CODE PATH actually executed?**
+   - Just because code exists doesn't mean it runs
+   - Add console.log or check server logs to confirm execution
+
+### Verification Methods (In Order of Reliability)
+
+1. **Server Logs** - Most reliable. Shows actual HTTP calls made.
+   ```bash
+   # Check terminal for: "POST /endpoint HTTP/1.1 200 OK"
+   ```
+
+2. **Network Tab** - Shows real requests from browser/client.
+
+3. **Console Logs** - Add logging at key points to trace execution.
+
+4. **Manual User Testing** - Actually use the UI as a user would.
+
+5. **curl/HTTP Tests** - Verify endpoints respond correctly.
+
+6. **Code Reading** - LEAST reliable alone. Must be combined with above.
+
+### Common Deceptive Patterns
+
+**Pattern 1: Looks like API call, is actually local**
+```tsx
+// DECEPTIVE: Looks like it uses backend data
+const total = calculateTotal(items);  // Actually local calculation!
+
+// CORRECT: Actually uses backend response
+const total = backendResponse.totals.find(t => t.type === 'total').amount;
+```
+
+**Pattern 2: Backend called but result ignored**
+```tsx
+// DECEPTIVE: Makes call but ignores result
+await updateBackend(newItems);
+setDisplayTotal(localCalculation(newItems));  // BUG: should use response!
+
+// CORRECT: Uses backend result
+const response = await updateBackend(newItems);
+setDisplayTotal(response.total);
+```
+
+**Pattern 3: Async without proper waiting**
+```tsx
+// DECEPTIVE: Looks correct but has timing bug
+setItems(newItems);           // UI updates immediately
+notifyBackend(newItems);      // Async fires (no await)
+// BUG: UI shows new items but old totals until backend responds!
+
+// CORRECT: Track pending state
+setItems(newItems);
+setIsPending(true);
+await notifyBackend(newItems);
+setIsPending(false);
+```
+
+**Pattern 4: Default/fallback hides missing data**
+```tsx
+// DECEPTIVE: Fallback masks the bug
+const price = response.price ?? calculateLocally(item);  // Fallback used!
+
+// CORRECT: Fail explicitly if data missing
+const price = response.price;
+if (price === undefined) throw new Error("Backend did not return price");
+```
+
+### Verification Checklist
+
+Before saying code is correct, verify these with EVIDENCE:
+
+- [ ] **Server logs show HTTP calls** were actually made
+- [ ] **Response data is used** in the UI (not local calculations)
+- [ ] **No hardcoded/mock data** in the actual code path
+- [ ] **Loading states shown** during async operations
+- [ ] **Error handling works** when backend fails
+- [ ] **User sees correct data** through manual testing
+
+### When Static Analysis is INSUFFICIENT
+
+You MUST do runtime verification when:
+- Code involves HTTP/API calls
+- Multiple components share or sync state
+- Async operations affect UI display
+- Data flows from backend to frontend
+- User actions trigger calculations that should happen server-side
+
+For these cases, **reading code is not enough** - you must observe actual behavior through logs, network inspection, or manual testing.
+
+### Key Principle
+
+**Never claim code works based solely on:**
+- "The function exists and looks correct"
+- "TypeScript/linting passes"
+- "The logic seems right"
+
+**Always verify with evidence:**
+- Server logs showing actual calls
+- Network tab showing request/response
+- Manual testing showing correct behavior
+- Console logs confirming code path execution

--- a/README.md
+++ b/README.md
@@ -1,166 +1,271 @@
 # NVIDIA AI Blueprint: Retail Agentic Commerce
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![Node.js 18+](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org/)
+
+A reference implementation of the **Agentic Commerce Protocol (ACP)**: a retailer-operated checkout system that enables agentic negotiation while maintaining merchant control.
+
 <div align="center">
 
 ![NVIDIA Logo](https://avatars.githubusercontent.com/u/178940881?s=200&v=4)
 
 </div>
 
-A **reference implementation** of the **Agentic Commerce Protocol (ACP)**: a retailer-operated checkout system that enables agentic negotiation while maintaining merchant control.
+## What is ACP?
 
-> **Third-Party Software Notice**
-> This project may download and install additional third-party open source software projects.
-> Please review the license terms of these open source projects before use.
+ACP lets AI agents negotiate with merchants on behalf of users. The merchant stays in control while agents can:
+
+- Request promotions and discounts
+- Get personalized recommendations
+- Complete checkout with delegated payments
+- Receive multilingual post-purchase updates
 
 ## Quick Start
 
 ### Prerequisites
 
 - Python 3.12+
-- Node.js 18+ (for UI)
-- [uv](https://docs.astral.sh/uv/) (recommended) or pip
-- Docker (for Milvus vector database)
+- Node.js 18+
+- [uv](https://docs.astral.sh/uv/) package manager
+- Docker (optional, for Recommendation Agent)
 
-### Installation
+### 1. Clone and Configure
 
 ```bash
 git clone https://github.com/NVIDIA/Retail-Agentic-Commerce.git
 cd Retail-Agentic-Commerce
 cp env.example .env
+```
+
+Edit `.env` and add your NVIDIA API key ([get one here](https://build.nvidia.com/settings/api-keys)):
+
+```env
+NVIDIA_API_KEY=nvapi-xxx
+```
+
+### 2. Backend Services (Merchant, PSP, Apps SDK)
+
+Create and activate a virtual environment, then start the services in separate terminals:
+
+```bash
+# Setup (run once)
+uv venv
+source .venv/bin/activate
 uv sync
 ```
 
-### Environment Variables
-
-Copy `env.example` to `.env`. Most variables have sensible defaults and work out of the box:
-
-```env
-# Required - get your key from https://build.nvidia.com/settings/api-keys
-NVIDIA_API_KEY=nvapi-xxx   # For agents to call Nemotron Nano v3
-
-# Optional - these have working defaults
-API_KEY=your-api-key                        # Merchant API auth
-PSP_API_KEY=psp-api-key-12345               # PSP service auth
-PROMOTION_AGENT_URL=http://localhost:8002
-POST_PURCHASE_AGENT_URL=http://localhost:8003
-```
-
-> **Note**: `NVIDIA_API_KEY` is the only variable you must set. It enables the NAT agents (Promotion and Post-Purchase) to communicate with the nemontron-nano-v3 public endpoint.
-
-### Run the Services
-
 ```bash
-# Merchant API (port 8000)
+# Terminal 1: Merchant API (port 8000)
+source .venv/bin/activate
 uvicorn src.merchant.main:app --reload
-
-# PSP Service (port 8001)
-uvicorn src.payment.main:app --reload --port 8001
-
-# Apps SDK MCP Server (port 2091)
-uvicorn src.apps_sdk.main:app --reload --port 2091
-
-# NAT Agents (from src/agents/)
-cd src/agents
-uv pip install -e ".[dev]" --prerelease=allow
-nat serve --config_file configs/promotion.yml --port 8002      # Promotion Agent
-nat serve --config_file configs/post-purchase.yml --port 8003  # Post-Purchase Agent
-nat serve --config_file configs/recommendation-ultrafast.yml --port 8004 # Recommendation Agent (requires Milvus)
-
-# Frontend UI (port 3000)
-cd src/ui
-cp env.example .env.local  # Configure API endpoints
-pnpm install && pnpm run dev
 ```
 
-### Apps SDK Widget
-
-The Apps SDK provides a ChatGPT-compatible merchant widget. Build and serve it:
+```bash
+# Terminal 2: PSP Service (port 8001)
+source .venv/bin/activate
+uvicorn src.payment.main:app --reload --port 8001
+```
 
 ```bash
-# Build the widget (outputs to src/apps_sdk/dist/)
+# Terminal 3: Apps SDK MCP Server (port 2091)
+source .venv/bin/activate
+uvicorn src.apps_sdk.main:app --reload --port 2091
+```
+
+### 3. NAT Agents (Separate Environment)
+
+The agents use their own virtual environment:
+
+```bash
+# Setup (run once)
+cd src/agents
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]" --prerelease=allow
+```
+
+```bash
+# Terminal 4: Promotion Agent (port 8002)
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/promotion.yml --port 8002
+```
+
+```bash
+# Terminal 5: Post-Purchase Agent (port 8003)
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/post-purchase.yml --port 8003
+```
+
+```bash
+# Terminal 6: Recommendation Agent (port 8004) - requires Docker
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+```
+
+> **Note**: The Recommendation Agent requires Milvus. See [Optional: Milvus Setup](#optional-milvus-setup) below.
+
+### 4. Frontend
+
+```bash
+# Terminal 7: Demo UI (port 3000)
+cd src/ui
+pnpm install
+pnpm dev
+```
+
+```bash
+# Terminal 8: Apps SDK Widget (port 3001) - for development
 cd src/apps_sdk/web
 pnpm install
-pnpm build
-
-# For development with hot reload
-pnpm dev  # Runs on http://localhost:3001
+pnpm dev
 ```
 
-See [src/apps_sdk/README.md](src/apps_sdk/README.md) for full documentation.
-
-### Infrastructure (Docker)
-
-The Recommendation Agent requires Milvus (vector search) and Phoenix (observability). Start both with Docker Compose:
-
-```bash
-# Start infrastructure
-docker compose up -d
-
-# Verify services
-curl -s http://localhost:9091/healthz  # Milvus
-curl -s http://localhost:6006/healthz  # Phoenix
-
-# Seed product catalog (from src/agents/)
-cd src/agents
-uv run python scripts/seed_milvus.py
-```
-
-| Service | URL | Purpose |
-|---------|-----|---------|
-| Milvus | localhost:19530 | Vector similarity search |
-| Phoenix | http://localhost:6006 | LLM observability UI |
-
-Data persists across restarts. To reset: `docker compose down -v`
-
-### Verify
+### 5. Verify
 
 ```bash
 curl http://localhost:8000/health  # Merchant API
 curl http://localhost:8001/health  # PSP Service
-curl http://localhost:2091/health  # Apps SDK MCP Server
-# Visit http://localhost:3000 for the UI
+curl http://localhost:2091/health  # Apps SDK
 ```
 
-## UI Integration
+Visit **http://localhost:3000** to see the demo UI.
 
-The frontend connects to both the Merchant API and PSP Service for end-to-end checkout:
+## Architecture
 
-1. **Product Selection** - User selects a product from the grid
-2. **Session Creation** - UI calls `POST /checkout_sessions` to create a checkout session
-3. **Shipping Selection** - UI calls `POST /checkout_sessions/{id}` to update shipping
-4. **Payment Delegation** - UI calls PSP `POST /agentic_commerce/delegate_payment` to get a vault token
-5. **Checkout Completion** - UI calls `POST /checkout_sessions/{id}/complete` with the vault token
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Client Agent                             │
+│                    (ChatGPT, Claude, etc.)                      │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     Apps SDK MCP Server                         │
+│                        (Port 2091)                              │
+│   ┌─────────────┬─────────────────┬────────────────────────┐    │
+│   │ get-recs    │ add-to-cart     │ checkout               │    │
+│   └─────────────┴─────────────────┴────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      Merchant API                               │
+│                        (Port 8000)                              │
+│   ┌─────────────┬─────────────────┬────────────────────────┐    │
+│   │ Products    │ Checkout        │ Orders                 │    │
+│   │ Sessions    │ Promotions      │ Recommendations        │    │
+│   └─────────────┴─────────────────┴────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+          │                    │                    │
+          ▼                    ▼                    ▼
+   ┌────────────┐       ┌────────────┐       ┌────────────┐
+   │ Promotion  │       │ Post-      │       │ Recommend  │
+   │ Agent      │       │ Purchase   │       │ Agent      │
+   │ (8002)     │       │ (8003)     │       │ (8004)     │
+   └────────────┘       └────────────┘       └────────────┘
+```
 
-### Environment Variables (UI)
-
-The UI has its own environment file at `src/ui/.env.local`. Copy from `src/ui/env.example` - the defaults work out of the box for local development.
-
-## Backend Services
+## Services
 
 | Service | Port | Description |
 |---------|------|-------------|
-| **Merchant API** | 8000 | Core ACP checkout sessions, products, and order management |
-| **PSP Service** | 8001 | Payment delegation, vault tokens, and payment intents |
-| **Apps SDK MCP Server** | 2091 | ChatGPT-compatible MCP server with merchant widget |
-| **Promotion Agent** | 8002 | NAT agent for promotion strategy arbitration |
-| **Post-Purchase Agent** | 8003 | NAT agent for multilingual shipping messages |
-| **Recommendation Agent** | 8004 | ARAG multi-agent for personalized recommendations (requires Milvus) |
+| Merchant API | 8000 | ACP checkout, products, orders |
+| PSP Service | 8001 | Payment delegation, vault tokens |
+| Apps SDK | 2091 | MCP server for AI agents |
+| Promotion Agent | 8002 | Discount strategy (NAT) |
+| Post-Purchase Agent | 8003 | Multilingual messages (NAT) |
+| Recommendation Agent | 8004 | Personalized recs (requires Docker) |
 
-## API Documentation
+## API Docs
+
+Interactive docs available when services are running:
 
 - **Merchant API**: http://localhost:8000/docs
 - **PSP Service**: http://localhost:8001/docs
-- **Apps SDK MCP Server**: http://localhost:2091/docs
+- **Apps SDK**: http://localhost:2091/docs
+
+## Project Structure
+
+```
+src/
+├── merchant/          # Merchant API (FastAPI)
+├── payment/           # PSP Service (FastAPI)
+├── apps_sdk/          # MCP Server + Widget
+├── agents/            # NAT Agent configs
+└── ui/                # Demo UI (Next.js)
+
+docs/
+├── architecture.md    # System design
+├── features.md        # Feature status
+└── specs/             # Protocol specs
+```
+
+## Optional: Milvus Setup
+
+The Recommendation Agent requires Milvus for vector search. Start it before running the agent:
+
+```bash
+# Start Milvus (from project root)
+docker compose up -d
+
+# Verify Milvus is running
+curl -s http://localhost:9091/healthz
+
+# Seed the product catalog (from agents env)
+cd src/agents
+source .venv/bin/activate
+uv run python scripts/seed_milvus.py
+```
+
+## Contributing
+
+We welcome contributions! Here's how to get started:
+
+1. **Fork** the repository
+2. **Create a branch** for your feature (`git checkout -b feature/amazing-feature`)
+3. **Make your changes** following our code standards
+4. **Run tests** to ensure nothing is broken
+5. **Submit a Pull Request**
+
+### Code Standards
+
+```bash
+# Backend (Python)
+ruff check src/ tests/
+ruff format src/ tests/
+pyright src/
+pytest tests/ -v
+
+# Frontend (TypeScript)
+cd src/ui
+pnpm lint
+pnpm typecheck
+pnpm test:run
+```
+
+See [AGENTS.md](AGENTS.md) for detailed development guidelines.
 
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
-| `docs/PRD.md` | Product requirements |
-| `docs/architecture.md` | System architecture |
-| `docs/acp-spec.md` | ACP protocol specification |
-| `docs/features.md` | Feature breakdown and status |
-| `src/agents/README.md` | NAT Agents documentation |
-| `src/apps_sdk/README.md` | Apps SDK MCP Server documentation |
-| `CLAUDE.md` | Development guide for AI assistants |
-| `AGENTS.md` | Quick reference for contributors |
+| [Architecture](docs/architecture.md) | System design and data flow |
+| [Features](docs/features.md) | Feature breakdown and status |
+| [ACP Spec](docs/specs/acp-spec.md) | Protocol specification |
+| [Apps SDK](src/apps_sdk/README.md) | MCP server documentation |
+| [NAT Agents](src/agents/README.md) | Agent configuration guide |
+
+## Getting Help
+
+- **Issues**: [Open an issue](https://github.com/NVIDIA/Retail-Agentic-Commerce/issues) for bugs or feature requests
+- **Security**: See [SECURITY.md](SECURITY.md) for reporting vulnerabilities
+
+## License
+
+This project is licensed under Apache 2.0 - see [LICENSE](LICENSE) for details.
+
+> **Third-Party Software Notice**: This project may download and install additional third-party open source software projects. Review the license terms of these projects before use.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     volumes:
       - phoenix_data:/mnt/data
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:6006/healthz"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:6006/')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/features/feature-16-apps-sdk.md
+++ b/docs/features/feature-16-apps-sdk.md
@@ -665,12 +665,6 @@ async def checkout(cart_id: str) -> dict:
 - [ ] Test complete flow in real ChatGPT
 - [ ] Capture screenshots/recordings for documentation
 
-**Phase 8: Polish & Production Prep**
-- [ ] Add smooth transitions between modes
-- [ ] Ensure consistent styling with native mode
-- [ ] Add deployment scripts for Vercel
-- [ ] Create deployment documentation
-
 ## Acceptance Criteria
 
 **Tab Switcher** ✅:

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -971,6 +971,7 @@ def emit_checkout_event(
     status_code: int | None = None,
     session_id: str | None = None,
     order_id: str | None = None,
+    event_id: str | None = None,
 ) -> None:
     """Emit a checkout event to all SSE subscribers.
 
@@ -983,9 +984,10 @@ def emit_checkout_event(
         status_code: HTTP status code
         session_id: Checkout session ID
         order_id: Order ID (for completed checkouts)
+        event_id: Optional stable event ID for matching pending/complete events
     """
     event = {
-        "id": f"evt_{datetime.now().timestamp()}",
+        "id": event_id or f"evt_{datetime.now().timestamp()}",
         "type": event_type,
         "endpoint": endpoint,
         "method": method,
@@ -1004,19 +1006,67 @@ def emit_checkout_event(
             queue.put_nowait(event)
 
 
+def emit_agent_activity_event(
+    agent_type: str,
+    product_id: str,
+    product_name: str,
+    action: str,
+    discount_amount: int,
+    reason_codes: list[str],
+    reasoning: str,
+    stock_count: int = 0,
+    base_price: int = 0,
+) -> None:
+    """Emit an agent activity event to all SSE subscribers.
+
+    Args:
+        agent_type: Type of agent (promotion, recommendation, post_purchase)
+        product_id: Product ID
+        product_name: Product name
+        action: Agent action (e.g., DISCOUNT_10_PCT, NO_PROMO)
+        discount_amount: Discount in cents
+        reason_codes: List of reason codes
+        reasoning: Agent's reasoning
+        stock_count: Product stock count
+        base_price: Product base price in cents
+    """
+    event = {
+        "id": f"agent_{datetime.now().timestamp()}",
+        "agentType": agent_type,
+        "productId": product_id,
+        "productName": product_name,
+        "action": action,
+        "discountAmount": discount_amount,
+        "reasonCodes": reason_codes,
+        "reasoning": reasoning,
+        "stockCount": stock_count,
+        "basePrice": base_price,
+        "timestamp": datetime.now().isoformat(),
+    }
+    checkout_events.append(event)
+
+    # Notify all subscribers
+    for queue in event_subscribers:
+        with contextlib.suppress(asyncio.QueueFull):
+            queue.put_nowait(event)
+
+
 async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
-    """Generator that yields SSE events."""
+    """Generator that yields SSE events.
+    
+    Note: We intentionally do NOT send historical events on connect.
+    The Protocol Inspector should start fresh on page load/refresh.
+    Events are stored in checkout_events deque for debugging purposes only.
+    """
     queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=50)
     event_subscribers.append(queue)
     try:
-        # Send recent events on connect
-        for event in list(checkout_events)[-10:]:
-            yield {"event": "checkout", "data": json.dumps(event)}
-
-        # Stream new events
+        # Stream new events only - no historical events on connect
+        # This ensures Protocol Inspector starts fresh on page refresh
         while True:
             event = await queue.get()
-            yield {"event": "checkout", "data": json.dumps(event)}
+            event_type = "agent_activity" if "agentType" in event else "checkout"
+            yield {"event": event_type, "data": json.dumps(event)}
     finally:
         event_subscribers.remove(queue)
 
@@ -1294,6 +1344,10 @@ async def acp_create_session(request: ACPCreateSessionRequest) -> dict[str, Any]
     Returns:
         Checkout session response from merchant API.
     """
+    # Clear previous session events - new session means fresh protocol trace
+    # This prevents stale events from appearing in Protocol Inspector on fresh start
+    checkout_events.clear()
+    
     settings = get_apps_sdk_settings()
     merchant_api_url = settings.merchant_api_url
     api_key = settings.api_key
@@ -1330,6 +1384,28 @@ async def acp_create_session(request: ACPCreateSessionRequest) -> dict[str, Any]
                     status_code=201,
                     session_id=session_id,
                 )
+
+                # Emit agent activity events for promotion decisions (session create only)
+                line_items = data.get("line_items", [])
+                for line_item in line_items:
+                    promotion = line_item.get("promotion")
+                    if promotion:
+                        item_info = line_item.get("item", {})
+                        product_id = item_info.get("id", "unknown")
+                        product_name = line_item.get("name") or product_id
+                        stock_count = promotion.get("stock_count", 0)
+
+                        emit_agent_activity_event(
+                            agent_type="promotion",
+                            product_id=product_id,
+                            product_name=product_name,
+                            action=promotion.get("action", "NO_PROMO"),
+                            discount_amount=line_item.get("discount", 0),
+                            reason_codes=promotion.get("reason_codes", []),
+                            reasoning=promotion.get("reasoning", ""),
+                            stock_count=stock_count,
+                            base_price=line_item.get("base_amount", 0),
+                        )
 
                 return data
             else:
@@ -1418,6 +1494,9 @@ async def acp_update_session(
                     status_code=200,
                     session_id=session_id,
                 )
+
+                # Note: Agent activity events are only emitted on session CREATE
+                # to match Native ACP behavior (no duplicates on updates)
 
                 return data
             else:

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -1053,7 +1053,7 @@ def emit_agent_activity_event(
 
 async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
     """Generator that yields SSE events.
-    
+
     Note: We intentionally do NOT send historical events on connect.
     The Protocol Inspector should start fresh on page load/refresh.
     Events are stored in checkout_events deque for debugging purposes only.
@@ -1347,7 +1347,7 @@ async def acp_create_session(request: ACPCreateSessionRequest) -> dict[str, Any]
     # Clear previous session events - new session means fresh protocol trace
     # This prevents stale events from appearing in Protocol Inspector on fresh start
     checkout_events.clear()
-    
+
     settings = get_apps_sdk_settings()
     merchant_api_url = settings.merchant_api_url
     api_key = settings.api_key

--- a/src/apps_sdk/tools/checkout.py
+++ b/src/apps_sdk/tools/checkout.py
@@ -32,10 +32,15 @@ def _emit_event(
     status_code: int | None = None,
     session_id: str | None = None,
     order_id: str | None = None,
+    event_id: str | None = None,
 ) -> None:
     """Emit checkout event to SSE subscribers.
 
     Lazy import to avoid circular dependency.
+
+    Args:
+        event_id: Stable event ID for matching pending/complete events.
+                  Must be the same for both pending and success/error events.
     """
     try:
         from src.apps_sdk.main import emit_checkout_event
@@ -49,6 +54,7 @@ def _emit_event(
             status_code=status_code,
             session_id=session_id,
             order_id=order_id,
+            event_id=event_id,
         )
     except ImportError:
         # Module not loaded yet, skip event emission
@@ -104,11 +110,14 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
         async with httpx.AsyncClient(timeout=15.0) as client:
             # Step 1: Create checkout session on merchant API
             logger.info(f"Creating checkout session for cart {cart_id}")
+            # Generate stable event ID for matching pending/complete events
+            session_create_event_id = f"evt_session_create_{uuid4().hex[:12]}"
             _emit_event(
                 "session_create",
                 "/checkout_sessions",
                 status="pending",
                 summary=f"Creating session for {item_count} item(s)",
+                event_id=session_create_event_id,
             )
             session_response = await client.post(
                 f"{merchant_api_url}/checkout_sessions",
@@ -150,6 +159,7 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
                 summary=f"Session {session_id} created",
                 status_code=201,
                 session_id=session_id,
+                event_id=session_create_event_id,
             )
 
             # Get the first available fulfillment option
@@ -187,12 +197,15 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
 
             # Step 3: Delegate payment to PSP to get vault token (need session total)
             logger.info(f"Delegating payment to PSP for session {session_id}")
+            # Generate stable event ID for matching pending/complete events
+            delegate_payment_event_id = f"evt_delegate_payment_{uuid4().hex[:12]}"
             _emit_event(
                 "delegate_payment",
                 "/agentic_commerce/delegate_payment",
                 status="pending",
                 summary="Delegating payment to PSP...",
                 session_id=session_id,
+                event_id=delegate_payment_event_id,
             )
             idempotency_key = f"checkout_{cart_id}_{uuid4().hex[:8]}"
             expires_at = datetime.now(UTC) + timedelta(hours=1)
@@ -256,16 +269,20 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
                 summary=f"Vault token {vault_token_id} received",
                 status_code=201,
                 session_id=session_id,
+                event_id=delegate_payment_event_id,
             )
 
             # Step 4: Complete checkout with vault token
             logger.info(f"Completing checkout session {session_id} with vault token")
+            # Generate stable event ID for matching pending/complete events
+            session_complete_event_id = f"evt_session_complete_{uuid4().hex[:12]}"
             _emit_event(
                 "session_complete",
                 f"/checkout_sessions/{session_id}/complete",
                 status="pending",
                 summary="Completing checkout...",
                 session_id=session_id,
+                event_id=session_complete_event_id,
             )
             complete_response = await client.post(
                 f"{merchant_api_url}/checkout_sessions/{session_id}/complete",
@@ -306,6 +323,7 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
                     status_code=200,
                     session_id=session_id,
                     order_id=order_id,
+                    event_id=session_complete_event_id,
                 )
                 return {
                     "success": True,
@@ -327,6 +345,7 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
                     summary=f"Checkout failed: {complete_response.status_code}",
                     status_code=complete_response.status_code,
                     session_id=session_id,
+                    event_id=session_complete_event_id,
                 )
                 return {
                     "success": False,

--- a/src/apps_sdk/web/src/App.tsx
+++ b/src/apps_sdk/web/src/App.tsx
@@ -11,8 +11,9 @@ import type {
   CartItem,
   CartState,
   CheckoutResult,
+  ACPSessionResponse,
 } from "@/types";
-import { calculateCartTotals } from "@/types";
+import { cartStateFromSession, EMPTY_CART_STATE } from "@/types";
 
 /**
  * Widget page state for navigation
@@ -89,11 +90,11 @@ export function App() {
   const [checkoutRecommendations, setCheckoutRecommendations] = useState<Product[]>([]);
   const [isLoadingCheckoutRecommendations, setIsLoadingCheckoutRecommendations] = useState(false);
 
-  // Cart state
+  // Cart state - totals come from backend ACP session
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
-  const [cartState, setCartState] = useState<CartState>(() =>
-    calculateCartTotals("", [])
-  );
+  const [cartState, setCartState] = useState<CartState>(EMPTY_CART_STATE);
+  // Track pending backend updates to show loading state
+  const [isPendingCartUpdate, setIsPendingCartUpdate] = useState(false);
 
   // Checkout state
   const [isCheckingOut, setIsCheckingOut] = useState(false);
@@ -103,6 +104,7 @@ export function App() {
 
   // ACP session state
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [acpSession, setAcpSession] = useState<ACPSessionResponse | null>(null);
 
   // API base URL - relative in production, localhost in dev
   const getApiBaseUrl = useCallback(() => {
@@ -112,10 +114,10 @@ export function App() {
 
   // Create or update ACP checkout session
   const syncCheckoutSession = useCallback(
-    async (items: CartItem[], currentSessionId: string | null): Promise<string | null> => {
+    async (items: CartItem[], currentSessionId: string | null): Promise<{sessionId: string | null; sessionData: ACPSessionResponse | null}> => {
       if (items.length === 0) {
         // No items, no session needed
-        return null;
+        return { sessionId: null, sessionData: null };
       }
 
       const apiBaseUrl = getApiBaseUrl();
@@ -138,8 +140,9 @@ export function App() {
           });
 
           if (response.ok) {
-            const data = await response.json();
-            return data.id || currentSessionId;
+            const data = await response.json() as ACPSessionResponse;
+            console.log("[Widget] ACP session updated with promotion data:", data.line_items?.map(li => li.promotion));
+            return { sessionId: data.id || currentSessionId, sessionData: data };
           } else {
             // Session might be invalid, create a new one
             console.warn("[Widget] Session update failed, creating new session");
@@ -170,15 +173,16 @@ export function App() {
         });
 
         if (response.ok) {
-          const data = await response.json();
+          const data = await response.json() as ACPSessionResponse;
           console.log("[Widget] ACP session created:", data.id);
-          return data.id;
+          console.log("[Widget] Promotion data:", data.line_items?.map(li => li.promotion));
+          return { sessionId: data.id, sessionData: data };
         }
       } catch (error) {
         console.warn("[Widget] Failed to sync ACP session:", error);
       }
 
-      return currentSessionId;
+      return { sessionId: currentSessionId, sessionData: null };
     },
     [getApiBaseUrl]
   );
@@ -186,19 +190,67 @@ export function App() {
   // Notify server of cart updates via ACP
   const notifyCartUpdate = useCallback(
     async (items: CartItem[]) => {
-      const newSessionId = await syncCheckoutSession(items, sessionId);
-      if (newSessionId !== sessionId) {
-        setSessionId(newSessionId);
+      // Mark as pending to show loading state while backend calculates
+      setIsPendingCartUpdate(true);
+      try {
+        const { sessionId: newSessionId, sessionData } = await syncCheckoutSession(items, sessionId);
+        if (newSessionId !== sessionId) {
+          setSessionId(newSessionId);
+        }
+        if (sessionData) {
+          setAcpSession(sessionData);
+        }
+      } finally {
+        setIsPendingCartUpdate(false);
       }
     },
     [sessionId, syncCheckoutSession]
   );
 
-  // Update cart state when items change
+  // Update shipping option via ACP - backend recalculates totals
+  const handleShippingUpdate = useCallback(
+    async (fulfillmentOptionId: string) => {
+      if (!sessionId) {
+        console.warn("[Widget] No session ID for shipping update");
+        return;
+      }
+
+      const apiBaseUrl = getApiBaseUrl();
+      try {
+        console.log("[Widget] Updating shipping to:", fulfillmentOptionId);
+        const response = await fetch(`${apiBaseUrl}/acp/sessions/${sessionId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionId,
+            fulfillmentOptionId,
+          }),
+        });
+
+        if (response.ok) {
+          const data = await response.json() as ACPSessionResponse;
+          console.log("[Widget] Shipping updated, new totals:", data.totals);
+          setAcpSession(data);
+        } else {
+          console.error("[Widget] Shipping update failed:", response.status);
+        }
+      } catch (error) {
+        console.error("[Widget] Failed to update shipping:", error);
+        throw error;
+      }
+    },
+    [sessionId, getApiBaseUrl]
+  );
+
+  // Update cart state when ACP session changes - totals come from backend
   useEffect(() => {
-    const newCartState = calculateCartTotals(cartState.cartId || "", cartItems);
+    const newCartState = cartStateFromSession(acpSession, cartItems, sessionId || "");
+    // Override isCalculating if we're waiting for a backend update
+    if (isPendingCartUpdate) {
+      newCartState.isCalculating = true;
+    }
     setCartState(newCartState);
-  }, [cartItems, cartState.cartId]);
+  }, [acpSession, cartItems, sessionId, isPendingCartUpdate]);
 
   // Add item to cart
   const handleAddToCart = useCallback((product: Product) => {
@@ -463,7 +515,10 @@ export function App() {
       setCheckoutResult(result);
 
       if (result.success) {
+        // Clear cart and session state on successful checkout
         setCartItems([]);
+        setSessionId(null);
+        setAcpSession(null);
       }
     } catch (error) {
       console.error("[Checkout] Error:", error);
@@ -513,7 +568,6 @@ export function App() {
           isLoadingRecommendations={isLoadingCheckoutRecommendations}
           isProcessing={isCheckingOut}
           checkoutResult={checkoutResult}
-          sessionId={sessionId}
           onBack={handleBackToBrowse}
           onUpdateQuantity={handleUpdateQuantity}
           onRemoveItem={handleRemoveItem}
@@ -521,6 +575,7 @@ export function App() {
           onProductClick={handleProductClick}
           onQuickAdd={handleAddToCart}
           onClearResult={handleClearCart}
+          onShippingUpdate={handleShippingUpdate}
         />
       </div>
     );

--- a/src/apps_sdk/web/src/components/CheckoutPage.tsx
+++ b/src/apps_sdk/web/src/components/CheckoutPage.tsx
@@ -19,13 +19,16 @@ import { PaymentSheet } from "@/components/PaymentSheet";
 
 /**
  * Delivery option configuration
+ * Note: Prices are display-only references. Actual shipping costs
+ * are calculated by the backend when fulfillment option is selected.
  */
 interface DeliveryOption {
   id: string;
   name: string;
   description: string;
-  price: number;
+  displayPrice: number; // Display reference only - backend calculates actual
   icon: typeof Truck;
+  fulfillmentOptionId: string; // Maps to merchant API fulfillment option
 }
 
 const DELIVERY_OPTIONS: DeliveryOption[] = [
@@ -33,32 +36,28 @@ const DELIVERY_OPTIONS: DeliveryOption[] = [
     id: "standard",
     name: "Standard Delivery",
     description: "5-7 business days",
-    price: 0,
+    displayPrice: 599, // $5.99 - display only, backend calculates actual
     icon: Truck,
+    fulfillmentOptionId: "shipping_standard", // Matches backend ID
   },
   {
     id: "express",
     name: "Express Delivery",
-    description: "1-2 business days",
-    price: 999, // $9.99 in cents
+    description: "2-3 business days",
+    displayPrice: 1299, // $12.99 - display only, backend calculates actual
     icon: Zap,
+    fulfillmentOptionId: "shipping_express", // Matches backend ID
   },
 ];
 
-// Map delivery option IDs to merchant fulfillment option IDs
-const FULFILLMENT_OPTION_MAP: Record<string, string> = {
-  standard: "ship_standard",
-  express: "ship_express",
-};
-
 interface CheckoutPageProps {
   cartItems: CartItem[];
+  /** Cart state with totals from backend - isCalculating indicates pending update */
   cartState: CartState;
   recommendations: Product[];
   isLoadingRecommendations: boolean;
   isProcessing: boolean;
   checkoutResult: CheckoutResult | null;
-  sessionId: string | null;
   onBack: () => void;
   onUpdateQuantity: (productId: string, quantity: number) => void;
   onRemoveItem: (productId: string) => void;
@@ -66,6 +65,8 @@ interface CheckoutPageProps {
   onProductClick: (product: Product) => void;
   onQuickAdd: (product: Product) => void;
   onClearResult: () => void;
+  /** Called when shipping option changes - parent handles backend call */
+  onShippingUpdate: (fulfillmentOptionId: string) => Promise<void>;
 }
 
 /**
@@ -229,7 +230,6 @@ export function CheckoutPage({
   isLoadingRecommendations,
   isProcessing,
   checkoutResult,
-  sessionId,
   onBack,
   onUpdateQuantity,
   onRemoveItem,
@@ -237,62 +237,51 @@ export function CheckoutPage({
   onProductClick,
   onQuickAdd,
   onClearResult,
+  onShippingUpdate,
 }: CheckoutPageProps) {
   const isEmpty = cartItems.length === 0;
   const [selectedDelivery, setSelectedDelivery] = useState<string>("standard");
   const [isDeliveryOpen, setIsDeliveryOpen] = useState(false);
   const [isPaymentSheetOpen, setIsPaymentSheetOpen] = useState(false);
+  const [isUpdatingShipping, setIsUpdatingShipping] = useState(false);
 
   const currentDelivery = DELIVERY_OPTIONS.find((d) => d.id === selectedDelivery) || DELIVERY_OPTIONS[0];
-  const deliveryPrice = currentDelivery.price;
-  
-  // Calculate adjusted totals with selected delivery
-  const adjustedTotal = cartState.subtotal + cartState.tax + deliveryPrice;
 
-  // API base URL - relative in production, localhost in dev
-  const getApiBaseUrl = useCallback(() => {
-    const isViteDevServer = window.location.port === "3001" || window.location.port === "3002";
-    return isViteDevServer ? "http://localhost:2091" : "";
-  }, []);
+  // All totals come from backend (cartState is derived from ACP session)
+  // cartState.isCalculating indicates we're waiting for backend
+  const isCalculating = cartState.isCalculating || isUpdatingShipping;
 
-  // Notify server of shipping updates via real ACP endpoint
-  const notifyShippingUpdate = useCallback(
-    async (option: typeof currentDelivery) => {
-      if (!sessionId) {
-        console.warn("[Widget] No session ID for shipping update");
-        return;
-      }
+  // Use cartState values (which come from ACP session via cartStateFromSession)
+  const subtotal = cartState.subtotal;
+  const shipping = cartState.shipping;
+  const tax = cartState.tax;
+  const totalDiscount = cartState.discount;
+  const total = cartState.total;
 
-      const fulfillmentOptionId = FULFILLMENT_OPTION_MAP[option.id] || option.id;
-
-      try {
-        await fetch(`${getApiBaseUrl()}/acp/sessions/${sessionId}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            sessionId,
-            fulfillmentOptionId,
-          }),
-        });
-        console.log("[Widget] Shipping updated via ACP:", option.name);
-      } catch (error) {
-        console.warn("[Widget] Failed to update shipping via ACP:", error);
-      }
-    },
-    [sessionId, getApiBaseUrl]
-  );
-
-  // Handle delivery selection
+  // Handle delivery selection - calls parent to update backend
   const handleSelectDelivery = useCallback(
-    (optionId: string) => {
+    async (optionId: string) => {
       const option = DELIVERY_OPTIONS.find((d) => d.id === optionId);
       if (option) {
+        const previousSelection = selectedDelivery;
         setSelectedDelivery(optionId);
         setIsDeliveryOpen(false);
-        notifyShippingUpdate(option);
+        
+        // Show loading state while backend calculates new totals
+        setIsUpdatingShipping(true);
+        try {
+          // Parent handles the backend call and updates ACP session
+          await onShippingUpdate(option.fulfillmentOptionId);
+        } catch (error) {
+          console.warn("[Widget] Failed to update shipping, reverting selection:", error);
+          // Revert to previous selection on error
+          setSelectedDelivery(previousSelection);
+        } finally {
+          setIsUpdatingShipping(false);
+        }
       }
     },
-    [notifyShippingUpdate]
+    [onShippingUpdate, selectedDelivery]
   );
 
   // Open payment sheet
@@ -437,6 +426,7 @@ export function CheckoutPage({
                 ))}
               </div>
 
+
               {/* Order Summary Panel */}
               <div className="space-y-4 rounded-3xl border border-default bg-surface-elevated px-5 pb-5 pt-4 shadow-lg transition-colors dark:shadow-none">
                 {/* Delivery section */}
@@ -460,9 +450,13 @@ export function CheckoutPage({
                         </div>
                       </div>
                       <div className="flex items-center gap-2">
-                        <span className="text-sm font-semibold text-success">
-                          {deliveryPrice === 0 ? "Free" : formatPrice(deliveryPrice)}
-                        </span>
+                        {isUpdatingShipping ? (
+                          <span className="h-4 w-4 animate-spin rounded-full border-2 border-text-tertiary border-t-accent" />
+                        ) : (
+                          <span className="text-sm font-semibold text-success">
+                            {shipping === 0 ? "Free" : formatPrice(shipping)}
+                          </span>
+                        )}
                         <ChevronDown
                           className={`h-4 w-4 text-text-tertiary transition-transform ${isDeliveryOpen ? "rotate-180" : ""}`}
                           strokeWidth={2}
@@ -470,7 +464,7 @@ export function CheckoutPage({
                       </div>
                     </button>
 
-                    {/* Dropdown options */}
+                    {/* Dropdown options - shows displayPrice as preview, actual price comes from backend after selection */}
                     {isDeliveryOpen && (
                       <div
                         className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-xl border border-default bg-surface shadow-lg dark:shadow-none"
@@ -479,6 +473,8 @@ export function CheckoutPage({
                         {DELIVERY_OPTIONS.map((option) => {
                           const Icon = option.icon;
                           const isSelected = option.id === selectedDelivery;
+                          // For selected option, show actual backend price; for others, show expected price
+                          const priceToShow = isSelected ? shipping : option.displayPrice;
                           return (
                             <button
                               key={option.id}
@@ -505,7 +501,7 @@ export function CheckoutPage({
                                 </div>
                               </div>
                               <span className={`text-sm font-semibold ${isSelected ? "text-accent" : "text-success"}`}>
-                                {option.price === 0 ? "Free" : formatPrice(option.price)}
+                                {priceToShow === 0 ? "Free" : formatPrice(priceToShow)}
                               </span>
                             </button>
                           );
@@ -515,25 +511,47 @@ export function CheckoutPage({
                   </div>
                 </section>
 
-                {/* Order summary */}
+                {/* Order summary - all values from backend */}
                 <section className="space-y-2 border-t border-default/50 pt-3">
+                  {isCalculating && (
+                    <div className="flex items-center justify-center gap-2 py-2 text-sm text-text-secondary">
+                      <span className="h-4 w-4 animate-spin rounded-full border-2 border-text-tertiary border-t-accent" />
+                      <span>Calculating totals...</span>
+                    </div>
+                  )}
                   <div className="flex justify-between text-sm">
                     <span className="text-text-secondary">Subtotal</span>
-                    <span className="text-text">{formatPrice(cartState.subtotal)}</span>
+                    <span className={`text-text ${isCalculating ? "opacity-50" : ""}`}>
+                      {formatPrice(subtotal)}
+                    </span>
                   </div>
+                  {totalDiscount > 0 && (
+                    <div className="flex justify-between text-sm">
+                      <span className="text-emerald-600 dark:text-emerald-400">
+                        Discount
+                      </span>
+                      <span className={`font-medium text-emerald-600 dark:text-emerald-400 ${isCalculating ? "opacity-50" : ""}`}>
+                        −{formatPrice(totalDiscount)}
+                      </span>
+                    </div>
+                  )}
                   <div className="flex justify-between text-sm">
                     <span className="text-text-secondary">Shipping</span>
-                    <span className="text-text">
-                      {deliveryPrice === 0 ? "Free" : formatPrice(deliveryPrice)}
+                    <span className={`text-text ${isCalculating ? "opacity-50" : ""}`}>
+                      {shipping === 0 ? "Free" : formatPrice(shipping)}
                     </span>
                   </div>
                   <div className="flex justify-between text-sm">
                     <span className="text-text-secondary">Tax</span>
-                    <span className="text-text">{formatPrice(cartState.tax)}</span>
+                    <span className={`text-text ${isCalculating ? "opacity-50" : ""}`}>
+                      {formatPrice(tax)}
+                    </span>
                   </div>
                   <div className="flex justify-between pt-2 text-base font-semibold">
                     <span className="text-text">Total</span>
-                    <span className="text-text">{formatPrice(adjustedTotal)}</span>
+                    <span className={`text-text ${isCalculating ? "opacity-50" : ""}`}>
+                      {formatPrice(total)}
+                    </span>
                   </div>
                 </section>
               </div>
@@ -542,13 +560,14 @@ export function CheckoutPage({
             {/* Checkout Button */}
             <div className="py-5">
               <button
-                className="flex w-full items-center justify-center gap-2.5 rounded-full bg-primary px-6 py-4 text-base font-semibold text-white shadow-lg transition-all hover:bg-primary-hover active:scale-[0.98] dark:shadow-primary/20"
+                className="flex w-full items-center justify-center gap-2.5 rounded-full bg-primary px-6 py-4 text-base font-semibold text-white shadow-lg transition-all hover:bg-primary-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 dark:shadow-primary/20"
                 onClick={handleOpenPayment}
+                disabled={isCalculating}
               >
                 <Lock className="h-4 w-4" strokeWidth={2} />
                 <span className="flex-1 text-center">Complete Purchase</span>
                 <span className="rounded-full bg-white/20 px-3 py-1 text-sm font-medium">
-                  {formatPrice(adjustedTotal)}
+                  {isCalculating ? "..." : formatPrice(total)}
                 </span>
               </button>
             </div>
@@ -560,10 +579,6 @@ export function CheckoutPage({
 
         {/* Recommendations Section */}
         <div className="py-5">
-          <h3 className="mb-3 text-base font-semibold text-text">
-            {isEmpty ? "Recommended For You" : "You May Also Like"}
-          </h3>
-
           {/* Loading Skeleton */}
           {isLoadingRecommendations && <RecommendationSkeleton />}
 
@@ -592,7 +607,7 @@ export function CheckoutPage({
       <PaymentSheet
         isOpen={isPaymentSheetOpen}
         isProcessing={isProcessing}
-        total={adjustedTotal}
+        total={total}
         onClose={handleClosePayment}
         onPay={handlePay}
       />

--- a/src/apps_sdk/web/src/components/PaymentSheet.tsx
+++ b/src/apps_sdk/web/src/components/PaymentSheet.tsx
@@ -279,11 +279,6 @@ export function PaymentSheet({
               </>
             )}
           </button>
-
-          {/* Security note */}
-          <p className="mt-3 text-center text-xs text-text-tertiary">
-            Secured by Agentic Commerce Protocol
-          </p>
         </form>
       </div>
     </div>

--- a/src/apps_sdk/web/src/components/RecommendationCarousel.tsx
+++ b/src/apps_sdk/web/src/components/RecommendationCarousel.tsx
@@ -116,10 +116,6 @@ export function RecommendationCarousel({
 
   return (
     <section className="py-4">
-      <h2 className="mb-3 flex items-center gap-2 text-base font-semibold text-text">
-        <span>Recommended For You</span>
-      </h2>
-
       <div className="grid grid-cols-3 gap-3">
         {products.map((product) => (
           <ProductCard

--- a/src/apps_sdk/web/src/components/ShoppingCart.tsx
+++ b/src/apps_sdk/web/src/components/ShoppingCart.tsx
@@ -164,19 +164,39 @@ export function ShoppingCart({
           </div>
         </section>
 
-        {/* Order summary */}
+        {/* Order summary - all values from backend */}
         <section className="space-y-2 border-t border-default/50 pt-3">
+          {cartState.isCalculating && (
+            <div className="flex items-center justify-center gap-2 py-2 text-sm text-text-secondary">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-text-tertiary border-t-accent" />
+              <span>Calculating...</span>
+            </div>
+          )}
           <div className="flex justify-between text-sm">
             <span className="text-text-secondary">Subtotal</span>
-            <span className="text-text">{formatPrice(cartState.subtotal)}</span>
+            <span className={`text-text ${cartState.isCalculating ? "opacity-50" : ""}`}>
+              {formatPrice(cartState.subtotal)}
+            </span>
           </div>
+          {cartState.discount > 0 && (
+            <div className="flex justify-between text-sm">
+              <span className="text-emerald-600 dark:text-emerald-400">Discount</span>
+              <span className={`font-medium text-emerald-600 dark:text-emerald-400 ${cartState.isCalculating ? "opacity-50" : ""}`}>
+                −{formatPrice(cartState.discount)}
+              </span>
+            </div>
+          )}
           <div className="flex justify-between text-sm">
             <span className="text-text-secondary">Tax</span>
-            <span className="text-text">{formatPrice(cartState.tax)}</span>
+            <span className={`text-text ${cartState.isCalculating ? "opacity-50" : ""}`}>
+              {formatPrice(cartState.tax)}
+            </span>
           </div>
           <div className="flex justify-between pt-2 text-base font-semibold">
             <span className="text-text">Total</span>
-            <span className="text-text">{formatPrice(cartState.total)}</span>
+            <span className={`text-text ${cartState.isCalculating ? "opacity-50" : ""}`}>
+              {formatPrice(cartState.total)}
+            </span>
           </div>
         </section>
       </div>

--- a/src/apps_sdk/web/src/types/index.ts
+++ b/src/apps_sdk/web/src/types/index.ts
@@ -46,6 +46,10 @@ export interface CartItem {
   imageUrl?: string;
 }
 
+/**
+ * Cart state - totals should come from backend ACP session
+ * Frontend should not calculate these values
+ */
 export interface CartState {
   cartId: string;
   items: CartItem[];
@@ -54,13 +58,28 @@ export interface CartState {
   shipping: number;
   tax: number;
   total: number;
+  discount: number;
+  /** True when waiting for backend to return calculated totals */
+  isCalculating: boolean;
 }
 
-// Fee constants
-export const CART_FEES = {
-  SHIPPING_STANDARD: 500, // $5.00 in cents
-  TAX_RATE: 0.0875, // 8.75%
-} as const;
+/**
+ * Empty cart state - used for initialization
+ */
+export const EMPTY_CART_STATE: CartState = {
+  cartId: "",
+  items: [],
+  itemCount: 0,
+  subtotal: 0,
+  shipping: 0,
+  tax: 0,
+  total: 0,
+  discount: 0,
+  isCalculating: false,
+};
+
+// Note: All fee calculations happen on the backend.
+// No frontend constants needed - shipping rates come from merchant API.
 
 // =============================================================================
 // Widget State Types
@@ -86,6 +105,59 @@ export interface CheckoutResult {
   total?: number;
   itemCount?: number;
   orderUrl?: string;
+}
+
+// =============================================================================
+// ACP Session Types (Promotion Agent Integration)
+// =============================================================================
+
+/**
+ * Promotion metadata from the Promotion Agent
+ */
+export interface PromotionMetadata {
+  action: string; // e.g., "DISCOUNT_10_PCT", "NO_PROMO", "FREE_SHIPPING"
+  reason_codes: string[]; // e.g., ["HIGH_INVENTORY", "ABOVE_MARKET"]
+  reasoning: string; // LLM reasoning for the decision
+}
+
+/**
+ * ACP Line Item with promotion data
+ * Matches backend LineItem schema from merchant API
+ */
+export interface ACPLineItem {
+  id: string;
+  item: {
+    id: string;
+    quantity: number;
+  };
+  name?: string; // Product name (optional in backend)
+  base_amount: number;
+  discount: number;
+  subtotal: number;
+  tax: number;
+  total: number;
+  promotion?: PromotionMetadata;
+}
+
+/**
+ * ACP Total entry
+ */
+export interface ACPTotal {
+  type: string;
+  display_text: string;
+  amount: number;
+}
+
+/**
+ * ACP Session response from the Merchant API
+ */
+export interface ACPSessionResponse {
+  id: string;
+  status: string;
+  currency: string;
+  line_items: ACPLineItem[];
+  totals: ACPTotal[];
+  // Other fields we don't need for promotion display
 }
 
 // =============================================================================
@@ -151,28 +223,87 @@ export function formatPrice(cents: number): string {
 }
 
 /**
- * Calculate cart totals from items
+ * Create cart state from ACP session response
+ * All totals come from backend - no local calculations
+ */
+export function cartStateFromSession(
+  session: ACPSessionResponse | null,
+  items: CartItem[],
+  cartId: string = ""
+): CartState {
+  if (!session) {
+    // No session yet - return items with zero totals, mark as calculating
+    return {
+      cartId,
+      items,
+      itemCount: items.reduce((sum, item) => sum + item.quantity, 0),
+      subtotal: 0,
+      shipping: 0,
+      tax: 0,
+      total: 0,
+      discount: 0,
+      isCalculating: items.length > 0, // Calculating if we have items but no session
+    };
+  }
+
+  // Extract totals from ACP session
+  // Backend uses these total types:
+  // - items_base_amount: Original item prices before discounts
+  // - items_discount: Total discount amount  
+  // - subtotal: Items after discounts
+  // - tax: Tax amount
+  // - fulfillment: Shipping cost (called "fulfillment" in backend)
+  // - total: Grand total
+  const findTotal = (type: string): number =>
+    session.totals?.find((t) => t.type === type)?.amount ?? 0;
+
+  // Get all totals from backend - NO frontend calculations
+  const itemsBase = findTotal("items_base_amount");
+  const subtotalAfterDiscount = findTotal("subtotal");
+  const tax = findTotal("tax");
+  const shipping = findTotal("fulfillment");
+  const total = findTotal("total");
+
+  // Calculate discount from line items (sum of individual discounts)
+  const discount = session.line_items?.reduce(
+    (sum, li) => sum + (li.discount || 0),
+    0
+  ) ?? 0;
+
+  return {
+    cartId: session.id || cartId,
+    items,
+    itemCount: items.reduce((sum, item) => sum + item.quantity, 0),
+    // Display items_base_amount as subtotal (before discounts) for transparency
+    subtotal: itemsBase > 0 ? itemsBase : subtotalAfterDiscount,
+    shipping,
+    tax,
+    // Use backend total directly - never calculate on frontend
+    total,
+    discount,
+    isCalculating: false,
+  };
+}
+
+/**
+ * @deprecated Use cartStateFromSession instead - totals should come from backend
+ * This function is kept only for backwards compatibility during migration
  */
 export function calculateCartTotals(
   cartId: string,
   items: CartItem[]
 ): CartState {
-  const subtotal = items.reduce(
-    (sum, item) => sum + item.basePrice * item.quantity,
-    0
-  );
-  const shipping = items.length > 0 ? CART_FEES.SHIPPING_STANDARD : 0;
-  const tax = Math.round(subtotal * CART_FEES.TAX_RATE);
-  const total = subtotal + shipping + tax;
-
+  // Return state with isCalculating=true to indicate backend should be called
   return {
     cartId,
     items,
     itemCount: items.reduce((sum, item) => sum + item.quantity, 0),
-    subtotal,
-    shipping,
-    tax,
-    total,
+    subtotal: 0,
+    shipping: 0,
+    tax: 0,
+    total: 0,
+    discount: 0,
+    isCalculating: true, // Signal that we need backend data
   };
 }
 

--- a/src/merchant/api/schemas.py
+++ b/src/merchant/api/schemas.py
@@ -239,6 +239,9 @@ class PromotionMetadata(BaseModel):
         default_factory=list, description="Reason codes for the decision"
     )
     reasoning: str = Field(default="", description="LLM reasoning for the decision")
+    stock_count: int | None = Field(
+        default=None, description="Product stock count at time of decision"
+    )
 
 
 class LineItem(BaseModel):
@@ -246,6 +249,7 @@ class LineItem(BaseModel):
 
     id: str = Field(..., description="Line item ID")
     item: Item = Field(..., description="Item reference")
+    name: str | None = Field(default=None, description="Product name")
     base_amount: Annotated[
         int, Field(ge=0, description="Base price before adjustments")
     ]

--- a/src/merchant/db/database.py
+++ b/src/merchant/db/database.py
@@ -71,59 +71,248 @@ def seed_data(session: Session) -> None:
 
     session.commit()
 
+    # Competitor pricing data for all products
+    # Prices are strategically set to demonstrate promotion scenarios:
+    # - Some competitors are cheaper (triggers price match discounts)
+    # - Some competitors are same price (triggers small incentive discounts)
+    # - Some competitors are more expensive (no discount needed)
     competitor_prices = [
+        # --- Tops: T-Shirts (prod_1 to prod_4) ---
+        # prod_1: Classic Tee ($25.00) - Competitors cheaper, should trigger discount
         CompetitorPrice(
             product_id="prod_1",
             retailer_name="FashionMart",
-            price=2400,
+            price=2400,  # $24.00 - cheaper
             updated_at=datetime.now(UTC),
         ),
         CompetitorPrice(
             product_id="prod_1",
             retailer_name="StyleHub",
-            price=2600,
+            price=2350,  # $23.50 - cheapest
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_2: V-Neck Tee ($28.00) - One cheaper, one same
+        CompetitorPrice(
+            product_id="prod_2",
+            retailer_name="FashionMart",
+            price=2700,  # $27.00 - cheaper
             updated_at=datetime.now(UTC),
         ),
         CompetitorPrice(
             product_id="prod_2",
-            retailer_name="FashionMart",
-            price=2700,
-            updated_at=datetime.now(UTC),
-        ),
-        CompetitorPrice(
-            product_id="prod_2",
             retailer_name="TrendyWear",
-            price=2900,
+            price=2800,  # $28.00 - same price
             updated_at=datetime.now(UTC),
         ),
+        # prod_3: Graphic Tee ($32.00) - Competitors cheaper, good discount demo
         CompetitorPrice(
             product_id="prod_3",
             retailer_name="StyleHub",
-            price=3000,
+            price=3000,  # $30.00 - cheaper
             updated_at=datetime.now(UTC),
         ),
         CompetitorPrice(
             product_id="prod_3",
             retailer_name="FashionMart",
-            price=3100,
+            price=2950,  # $29.50 - cheapest
             updated_at=datetime.now(UTC),
         ),
         CompetitorPrice(
             product_id="prod_3",
             retailer_name="TrendyWear",
-            price=3300,
+            price=3100,  # $31.00 - cheaper
             updated_at=datetime.now(UTC),
         ),
+        # prod_4: Premium Tee ($45.00) - Mixed pricing
         CompetitorPrice(
             product_id="prod_4",
             retailer_name="StyleHub",
-            price=4300,
+            price=4300,  # $43.00 - cheaper
             updated_at=datetime.now(UTC),
         ),
         CompetitorPrice(
             product_id="prod_4",
             retailer_name="TrendyWear",
-            price=4600,
+            price=4600,  # $46.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        # --- Bottoms (prod_5 to prod_8) ---
+        # prod_5: Classic Denim Jeans ($59.00) - Competitors cheaper
+        CompetitorPrice(
+            product_id="prod_5",
+            retailer_name="DenimDirect",
+            price=5500,  # $55.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_5",
+            retailer_name="JeansWorld",
+            price=5700,  # $57.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_6: Khaki Chinos ($45.00) - Same and cheaper mix
+        CompetitorPrice(
+            product_id="prod_6",
+            retailer_name="FashionMart",
+            price=4400,  # $44.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_6",
+            retailer_name="StyleHub",
+            price=4500,  # $45.00 - same
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_7: Cargo Shorts ($35.00) - All more expensive (no discount)
+        CompetitorPrice(
+            product_id="prod_7",
+            retailer_name="FashionMart",
+            price=3700,  # $37.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_7",
+            retailer_name="OutdoorGear",
+            price=3900,  # $39.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_8: Athletic Joggers ($42.00) - Competitor cheaper
+        CompetitorPrice(
+            product_id="prod_8",
+            retailer_name="SportStyle",
+            price=3900,  # $39.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_8",
+            retailer_name="AthleticWear",
+            price=4100,  # $41.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        # --- Outerwear (prod_9 to prod_11) ---
+        # prod_9: Denim Jacket ($75.00) - Competitors cheaper
+        CompetitorPrice(
+            product_id="prod_9",
+            retailer_name="DenimDirect",
+            price=7200,  # $72.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_9",
+            retailer_name="JeansWorld",
+            price=7000,  # $70.00 - cheapest
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_10: Lightweight Hoodie ($55.00) - Mixed
+        CompetitorPrice(
+            product_id="prod_10",
+            retailer_name="StyleHub",
+            price=5200,  # $52.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_10",
+            retailer_name="FashionMart",
+            price=5600,  # $56.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_11: Bomber Jacket ($89.00) - All more expensive
+        CompetitorPrice(
+            product_id="prod_11",
+            retailer_name="StyleHub",
+            price=9200,  # $92.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_11",
+            retailer_name="TrendyWear",
+            price=9500,  # $95.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        # --- Accessories (prod_12 to prod_14) ---
+        # prod_12: Canvas Belt ($18.00) - Competitors cheaper
+        CompetitorPrice(
+            product_id="prod_12",
+            retailer_name="AccessoryZone",
+            price=1650,  # $16.50 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_12",
+            retailer_name="FashionMart",
+            price=1750,  # $17.50 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_13: Classic Sunglasses ($22.00) - Same price
+        CompetitorPrice(
+            product_id="prod_13",
+            retailer_name="ShadesPlus",
+            price=2200,  # $22.00 - same
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_13",
+            retailer_name="EyewearExpress",
+            price=2100,  # $21.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_14: Baseball Cap ($15.00) - More expensive competitors
+        CompetitorPrice(
+            product_id="prod_14",
+            retailer_name="CapCity",
+            price=1700,  # $17.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_14",
+            retailer_name="HeadwearHub",
+            price=1600,  # $16.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        # --- Footwear (prod_15 to prod_17) ---
+        # prod_15: Canvas Sneakers ($49.00) - Competitors cheaper
+        CompetitorPrice(
+            product_id="prod_15",
+            retailer_name="ShoeWarehouse",
+            price=4500,  # $45.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_15",
+            retailer_name="FootwearFactory",
+            price=4700,  # $47.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_16: Leather Loafers ($85.00) - Mixed pricing
+        CompetitorPrice(
+            product_id="prod_16",
+            retailer_name="ShoeWarehouse",
+            price=8200,  # $82.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_16",
+            retailer_name="FootwearFactory",
+            price=8800,  # $88.00 - more expensive
+            updated_at=datetime.now(UTC),
+        ),
+        # prod_17: Athletic Running Shoes ($95.00) - Competitor cheaper
+        CompetitorPrice(
+            product_id="prod_17",
+            retailer_name="SportStyle",
+            price=8900,  # $89.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_17",
+            retailer_name="AthleticWear",
+            price=9200,  # $92.00 - cheaper
+            updated_at=datetime.now(UTC),
+        ),
+        CompetitorPrice(
+            product_id="prod_17",
+            retailer_name="RunnersPro",
+            price=9400,  # $94.00 - cheaper
             updated_at=datetime.now(UTC),
         ),
     ]

--- a/src/merchant/services/checkout.py
+++ b/src/merchant/services/checkout.py
@@ -153,6 +153,7 @@ def _calculate_line_item(
             "id": product.id,
             "quantity": quantity,
         },
+        "name": product.name,
         "base_amount": base_amount,
         "discount": total_discount,
         "subtotal": subtotal,
@@ -160,12 +161,13 @@ def _calculate_line_item(
         "total": total,
     }
 
-    # Add promotion metadata if available
+    # Add promotion metadata if available (include stock_count for agent activity display)
     if promotion_info:
         line_item["promotion"] = {
             "action": promotion_info.get("action", "NO_PROMO"),
             "reason_codes": promotion_info.get("reason_codes", []),
             "reasoning": promotion_info.get("reasoning", ""),
+            "stock_count": product.stock_count,
         }
 
     return line_item
@@ -250,11 +252,13 @@ def _dict_to_line_item(data: dict[str, Any]) -> LineItem:
             action=data["promotion"].get("action", "NO_PROMO"),
             reason_codes=data["promotion"].get("reason_codes", []),
             reasoning=data["promotion"].get("reasoning", ""),
+            stock_count=data["promotion"].get("stock_count"),
         )
 
     return LineItem(
         id=data["id"],
         item=Item(id=data["item"]["id"], quantity=data["item"]["quantity"]),
+        name=data.get("name"),
         base_amount=data["base_amount"],
         discount=data["discount"],
         subtotal=data["subtotal"],

--- a/src/ui/app/globals.css
+++ b/src/ui/app/globals.css
@@ -782,6 +782,8 @@ body {
 }
 
 .glass-event .msg {
+  flex: 1;
+  min-width: 0;
   font-size: 12.5px;
   color: var(--text-secondary);
   line-height: 1.35;

--- a/src/ui/components/agent-activity/AgentActivityItem.test.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.test.tsx
@@ -32,9 +32,9 @@ describe("AgentActivityItem", () => {
     expect(screen.getByText("Classic T-Shirt")).toBeInTheDocument();
   });
 
-  it("renders the Promotion Decision kicker", () => {
+  it("renders the Promotion Agent kicker", () => {
     render(<AgentActivityItem event={baseEvent} isLast={false} />);
-    expect(screen.getByText("Promotion Decision")).toBeInTheDocument();
+    expect(screen.getByText("Promotion Agent")).toBeInTheDocument();
   });
 
   it("renders Applied status pill for positive outcomes", () => {

--- a/src/ui/components/agent-activity/AgentActivityItem.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { Bot } from "@/components/icons";
 import type {
   AgentActivityEvent,
-  AgentType,
   PromotionInputSignals,
   PromotionDecision,
   PostPurchaseInputSignals,
@@ -34,23 +34,6 @@ function isRecommendationEvent(event: AgentActivityEvent): event is AgentActivit
   decision?: RecommendationDecision;
 } {
   return event.agentType === "recommendation";
-}
-
-/**
- * Get display info for agent types
- */
-function getAgentTypeInfo(type: AgentType): {
-  label: string;
-  icon: string;
-} {
-  switch (type) {
-    case "promotion":
-      return { label: "Promotion", icon: "%" };
-    case "recommendation":
-      return { label: "Recommendation", icon: "★" };
-    case "post_purchase":
-      return { label: "Post-Purchase", icon: "✉" };
-  }
 }
 
 /**
@@ -150,7 +133,6 @@ function PostPurchaseCard({
   isLast: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const typeInfo = getAgentTypeInfo(event.agentType);
   const isPending = event.status === "pending";
   const isError = event.status === "error";
   const isSuccess = event.status === "success" && event.decision;
@@ -160,7 +142,7 @@ function PostPurchaseCard({
   return (
     <div style={{ marginBottom: isLast ? 0 : "12px" }}>
       <div className={`glass-decision ${isSuccess ? "highlight" : ""}`}>
-        {/* Header row */}
+        {/* Header row with AI icon */}
         <div
           style={{
             display: "flex",
@@ -169,26 +151,37 @@ function PostPurchaseCard({
             gap: "12px",
           }}
         >
-          <div className="glass-kicker">
+          <div className="glass-kicker" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            {/* AI Agent Icon Badge */}
             <span
               style={{
-                width: "8px",
-                height: "8px",
-                borderRadius: "50%",
+                width: "24px",
+                height: "24px",
+                borderRadius: "6px",
                 background: isPending
-                  ? "rgba(255, 255, 255, 0.4)"
+                  ? "rgba(255, 255, 255, 0.08)"
                   : isError
-                    ? "#FF6B6B"
-                    : "rgba(118, 185, 0, 0.9)",
-                boxShadow: isPending
-                  ? "none"
-                  : isError
-                    ? "0 0 0 4px rgba(255, 107, 107, 0.12)"
-                    : "0 0 0 4px rgba(118, 185, 0, 0.12)",
-                display: "inline-block",
+                    ? "rgba(255, 107, 107, 0.15)"
+                    : "rgba(118, 185, 0, 0.15)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
               }}
-            ></span>
-            {typeInfo.label} Message
+            >
+              <Bot
+                style={{
+                  width: "14px",
+                  height: "14px",
+                  color: isPending
+                    ? "rgba(255, 255, 255, 0.5)"
+                    : isError
+                      ? "#FF6B6B"
+                      : "rgba(118, 185, 0, 0.9)",
+                }}
+              />
+            </span>
+            Post-Purchase Agent
           </div>
           <div className={`glass-pill ${isPending ? "yellow" : isError ? "" : "green"}`}>
             {isPending ? "Generating" : isError ? "Error" : "Sent"}
@@ -331,7 +324,6 @@ function RecommendationCard({
   };
   isLast: boolean;
 }) {
-  const typeInfo = getAgentTypeInfo(event.agentType);
   const isPending = event.status === "pending";
   const isError = event.status === "error";
   const isSuccess = event.status === "success" && event.decision;
@@ -341,7 +333,7 @@ function RecommendationCard({
   return (
     <div style={{ marginBottom: isLast ? 0 : "12px" }}>
       <div className={`glass-decision ${isSuccess ? "highlight" : ""}`}>
-        {/* Header row */}
+        {/* Header row with AI icon */}
         <div
           style={{
             display: "flex",
@@ -350,26 +342,37 @@ function RecommendationCard({
             gap: "12px",
           }}
         >
-          <div className="glass-kicker">
+          <div className="glass-kicker" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            {/* AI Agent Icon Badge */}
             <span
               style={{
-                width: "8px",
-                height: "8px",
-                borderRadius: "50%",
+                width: "24px",
+                height: "24px",
+                borderRadius: "6px",
                 background: isPending
-                  ? "rgba(255, 255, 255, 0.4)"
+                  ? "rgba(255, 255, 255, 0.08)"
                   : isError
-                    ? "#FF6B6B"
-                    : "rgba(118, 185, 0, 0.9)",
-                boxShadow: isPending
-                  ? "none"
-                  : isError
-                    ? "0 0 0 4px rgba(255, 107, 107, 0.12)"
-                    : "0 0 0 4px rgba(118, 185, 0, 0.12)",
-                display: "inline-block",
+                    ? "rgba(255, 107, 107, 0.15)"
+                    : "rgba(118, 185, 0, 0.15)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
               }}
-            ></span>
-            {typeInfo.label} Agent
+            >
+              <Bot
+                style={{
+                  width: "14px",
+                  height: "14px",
+                  color: isPending
+                    ? "rgba(255, 255, 255, 0.5)"
+                    : isError
+                      ? "#FF6B6B"
+                      : "rgba(118, 185, 0, 0.9)",
+                }}
+              />
+            </span>
+            Recommendation Agent
           </div>
           <div className={`glass-pill ${isPending ? "yellow" : isError ? "" : "green"}`}>
             {isPending ? "Generating" : isError ? "Error" : `${recommendationCount} items`}
@@ -486,7 +489,6 @@ function RecommendationCard({
  */
 export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const typeInfo = getAgentTypeInfo(event.agentType);
   const isPending = event.status === "pending";
   const isError = event.status === "error";
 
@@ -522,7 +524,7 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
     <div style={{ marginBottom: isLast ? 0 : "12px" }}>
       {/* Decision Card */}
       <div className={`glass-decision ${isHighlight ? "highlight" : ""}`}>
-        {/* Header row */}
+        {/* Header row with AI icon */}
         <div
           style={{
             display: "flex",
@@ -531,26 +533,37 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
             gap: "12px",
           }}
         >
-          <div className="glass-kicker">
+          <div className="glass-kicker" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            {/* AI Agent Icon Badge */}
             <span
               style={{
-                width: "8px",
-                height: "8px",
-                borderRadius: "50%",
+                width: "24px",
+                height: "24px",
+                borderRadius: "6px",
                 background: isPending
-                  ? "rgba(255, 255, 255, 0.4)"
+                  ? "rgba(255, 255, 255, 0.08)"
                   : isError
-                    ? "#FF6B6B"
-                    : "rgba(118, 185, 0, 0.9)",
-                boxShadow: isPending
-                  ? "none"
-                  : isError
-                    ? "0 0 0 4px rgba(255, 107, 107, 0.12)"
-                    : "0 0 0 4px rgba(118, 185, 0, 0.12)",
-                display: "inline-block",
+                    ? "rgba(255, 107, 107, 0.15)"
+                    : "rgba(118, 185, 0, 0.15)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
               }}
-            ></span>
-            {typeInfo.label} Decision
+            >
+              <Bot
+                style={{
+                  width: "14px",
+                  height: "14px",
+                  color: isPending
+                    ? "rgba(255, 255, 255, 0.5)"
+                    : isError
+                      ? "#FF6B6B"
+                      : "rgba(118, 185, 0, 0.9)",
+                }}
+              />
+            </span>
+            Promotion Agent
           </div>
           <div
             className={`glass-pill ${isPending ? "yellow" : isError ? "" : outcomeInfo?.isPositive ? "green" : ""}`}

--- a/src/ui/components/agent-activity/AgentActivityItem.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.tsx
@@ -151,7 +151,10 @@ function PostPurchaseCard({
             gap: "12px",
           }}
         >
-          <div className="glass-kicker" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <div
+            className="glass-kicker"
+            style={{ display: "flex", alignItems: "center", gap: "8px" }}
+          >
             {/* AI Agent Icon Badge */}
             <span
               style={{
@@ -342,7 +345,10 @@ function RecommendationCard({
             gap: "12px",
           }}
         >
-          <div className="glass-kicker" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <div
+            className="glass-kicker"
+            style={{ display: "flex", alignItems: "center", gap: "8px" }}
+          >
             {/* AI Agent Icon Badge */}
             <span
               style={{
@@ -533,7 +539,10 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
             gap: "12px",
           }}
         >
-          <div className="glass-kicker" style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <div
+            className="glass-kicker"
+            style={{ display: "flex", alignItems: "center", gap: "8px" }}
+          >
             {/* AI Agent Icon Badge */}
             <span
               style={{

--- a/src/ui/components/agent-activity/AgentActivityPanel.tsx
+++ b/src/ui/components/agent-activity/AgentActivityPanel.tsx
@@ -3,92 +3,6 @@
 import { useEffect, useRef } from "react";
 import { useAgentActivityLog } from "@/hooks/useAgentActivityLog";
 import { AgentActivityItem } from "./AgentActivityItem";
-import type {
-  AgentActivityEvent,
-  AgentDecision,
-  PromotionDecision,
-  RecommendationDecision,
-} from "@/types";
-
-/**
- * Type guard for promotion decision
- */
-function isPromotionDecision(decision: AgentDecision): decision is PromotionDecision {
-  return "action" in decision && "discountAmount" in decision;
-}
-
-/**
- * Type guard for recommendation decision
- */
-function isRecommendationDecision(decision: AgentDecision): decision is RecommendationDecision {
-  return "recommendations" in decision && Array.isArray(decision.recommendations);
-}
-
-/**
- * Convert action code to human-readable text for timeline display
- */
-function getHumanReadableAction(action: string): string {
-  switch (action) {
-    case "DISCOUNT_5_PCT":
-      return "Applied 5% discount";
-    case "DISCOUNT_10_PCT":
-      return "Applied 10% discount";
-    case "DISCOUNT_15_PCT":
-      return "Applied 15% discount";
-    case "FREE_SHIPPING":
-      return "Applied free shipping";
-    case "NO_PROMO":
-      return "No promotion needed";
-    default:
-      return action;
-  }
-}
-
-/**
- * Get timeline message for an event
- */
-function getTimelineMessage(event: AgentActivityEvent): string {
-  // Get product name from input signals - all signal types have productName
-  const productName =
-    "productName" in event.inputSignals
-      ? (event.inputSignals as { productName: string }).productName
-      : "Unknown";
-
-  if (event.status === "pending") {
-    if (event.agentType === "post_purchase") {
-      return `Generating message for ${productName}...`;
-    }
-    if (event.agentType === "recommendation") {
-      return `Finding recommendations for ${productName}...`;
-    }
-    return `Evaluating ${productName}...`;
-  }
-
-  if (event.agentType === "post_purchase") {
-    if (event.status === "success" && event.decision) {
-      return `Generated confirmation for ${productName}`;
-    }
-    return `Failed to generate message for ${productName}`;
-  }
-
-  // Recommendation events
-  if (event.agentType === "recommendation") {
-    if (event.status === "success" && event.decision && isRecommendationDecision(event.decision)) {
-      const count = event.decision.recommendations.length;
-      return count > 0
-        ? `Found ${count} recommendations for ${productName}`
-        : `No recommendations found for ${productName}`;
-    }
-    return `Failed to get recommendations for ${productName}`;
-  }
-
-  // Promotion events
-  if (event.decision && isPromotionDecision(event.decision)) {
-    return `${getHumanReadableAction(event.decision.action)} for ${productName}`;
-  }
-
-  return `Processed ${productName}`;
-}
 
 /**
  * Empty state - shows agent waiting state
@@ -219,41 +133,10 @@ function ActiveAgentActivity() {
       </div>
 
       {/* Decision cards - newest first */}
-      <div ref={scrollRef} style={{ maxHeight: "calc(100vh - 350px)", overflowY: "auto" }}>
+      <div ref={scrollRef} style={{ maxHeight: "calc(100vh - 200px)", overflowY: "auto" }}>
         {[...state.events].reverse().map((event, index, arr) => (
           <AgentActivityItem key={event.id} event={event} isLast={index === arr.length - 1} />
         ))}
-      </div>
-
-      {/* Timeline */}
-      <div className="glass-section">
-        <h3>Agent Timeline</h3>
-        <div className="glass-timeline" style={{ maxHeight: "200px", overflowY: "auto" }}>
-          {[...state.events].reverse().map((event) => (
-            <div key={`timeline-${event.id}`} className="glass-event">
-              <div className="time">
-                {event.timestamp.toLocaleTimeString("en-US", {
-                  hour12: false,
-                  hour: "2-digit",
-                  minute: "2-digit",
-                  second: "2-digit",
-                })}
-              </div>
-              <div className="msg">{getTimelineMessage(event)}</div>
-              <div
-                className={`glass-tag ${event.status === "success" ? "green" : event.status === "error" ? "" : "yellow"}`}
-              >
-                {event.status === "pending"
-                  ? "EVALUATING"
-                  : event.status === "success"
-                    ? "DECIDED"
-                    : event.status === "error"
-                      ? "ERROR"
-                      : "SKIPPED"}
-              </div>
-            </div>
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -538,9 +538,11 @@ export function AgentPanel() {
       {activeMode === "apps-sdk" && (
         <div className="flex flex-col flex-1 overflow-hidden">
           {/* Chat bubble - same as native mode */}
-          <div style={{ padding: "24px 32px 16px 32px" }}>
-            <ChatMessage message={messages[0]} />
-          </div>
+          {messages[0] && (
+            <div style={{ padding: "24px 32px 16px 32px" }}>
+              <ChatMessage message={messages[0]} />
+            </div>
+          )}
           {/* Spacer between chat bubble and iframe */}
           <div style={{ height: "12px", flexShrink: 0 }} />
           {/* Merchant widget iframe */}

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -526,7 +526,6 @@ export function AgentPanel() {
                 quantity={context.quantity}
                 shippingPrice={shipping}
                 orderId={context.session.order.id}
-                orderUrl={context.session.order.permalink_url}
                 estimatedDelivery={selectedShippingOption?.estimatedDelivery ?? "5-7 business days"}
                 onStartOver={handleStartOver}
               />
@@ -537,7 +536,16 @@ export function AgentPanel() {
 
       {/* Apps SDK Mode Content */}
       {activeMode === "apps-sdk" && (
-        <MerchantIframeContainer onCheckoutComplete={handleAppsSdkCheckoutComplete} />
+        <div className="flex flex-col flex-1 overflow-hidden">
+          {/* Chat bubble - same as native mode */}
+          <div style={{ padding: "24px 32px 16px 32px" }}>
+            <ChatMessage message={messages[0]} />
+          </div>
+          {/* Spacer between chat bubble and iframe */}
+          <div style={{ height: "12px", flexShrink: 0 }} />
+          {/* Merchant widget iframe */}
+          <MerchantIframeContainer onCheckoutComplete={handleAppsSdkCheckoutComplete} />
+        </div>
       )}
     </section>
   );

--- a/src/ui/components/agent/ConfirmationCard.test.tsx
+++ b/src/ui/components/agent/ConfirmationCard.test.tsx
@@ -143,37 +143,4 @@ describe("ConfirmationCard", () => {
     expect(screen.getByText("Amount Paid")).toBeInTheDocument();
   });
 
-  describe("order URL handling", () => {
-    it("renders order ID as link when orderUrl is provided", () => {
-      render(<ConfirmationCard {...defaultProps} orderUrl="https://merchant.com/orders/xyz789" />);
-
-      const orderLink = screen.getByRole("link", { name: "ORD-ABC12345" });
-      expect(orderLink).toBeInTheDocument();
-      expect(orderLink).toHaveAttribute("href", "https://merchant.com/orders/xyz789");
-      expect(orderLink).toHaveAttribute("target", "_blank");
-      expect(orderLink).toHaveAttribute("rel", "noopener noreferrer");
-    });
-
-    it("renders order ID as plain text when orderUrl is not provided", () => {
-      render(<ConfirmationCard {...defaultProps} />);
-
-      // Order ID should be plain text, not a link
-      expect(screen.getByText("ORD-ABC12345")).toBeInTheDocument();
-      expect(screen.queryByRole("link", { name: "ORD-ABC12345" })).not.toBeInTheDocument();
-    });
-
-    it("renders View Order Details link when orderUrl is provided", () => {
-      render(<ConfirmationCard {...defaultProps} orderUrl="https://merchant.com/orders/xyz789" />);
-
-      const viewOrderLink = screen.getByRole("link", { name: /view order details/i });
-      expect(viewOrderLink).toBeInTheDocument();
-      expect(viewOrderLink).toHaveAttribute("href", "https://merchant.com/orders/xyz789");
-    });
-
-    it("does not render View Order Details link when orderUrl is not provided", () => {
-      render(<ConfirmationCard {...defaultProps} />);
-
-      expect(screen.queryByRole("link", { name: /view order details/i })).not.toBeInTheDocument();
-    });
-  });
 });

--- a/src/ui/components/agent/ConfirmationCard.test.tsx
+++ b/src/ui/components/agent/ConfirmationCard.test.tsx
@@ -142,5 +142,4 @@ describe("ConfirmationCard", () => {
 
     expect(screen.getByText("Amount Paid")).toBeInTheDocument();
   });
-
 });

--- a/src/ui/components/agent/ConfirmationCard.tsx
+++ b/src/ui/components/agent/ConfirmationCard.tsx
@@ -23,7 +23,6 @@ interface ConfirmationCardProps {
   quantity: number;
   shippingPrice: number;
   orderId: string;
-  orderUrl?: string;
   estimatedDelivery: string;
   onStartOver: () => void;
 }
@@ -36,7 +35,6 @@ export function ConfirmationCard({
   quantity,
   shippingPrice,
   orderId,
-  orderUrl,
   estimatedDelivery,
   onStartOver,
 }: ConfirmationCardProps) {
@@ -137,20 +135,9 @@ export function ConfirmationCard({
             <Text kind="body/regular/sm" className="text-secondary">
               Order ID
             </Text>
-            {orderUrl ? (
-              <a
-                href={orderUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm font-mono text-[#76b900] hover:underline"
-              >
-                {orderId}
-              </a>
-            ) : (
-              <Text kind="label/regular/sm" className="text-primary font-mono">
-                {orderId}
-              </Text>
-            )}
+            <Text kind="label/regular/sm" className="text-primary font-mono">
+              {orderId}
+            </Text>
           </Flex>
           <Flex justify="between" align="center">
             <Text kind="body/regular/sm" className="text-secondary">
@@ -161,21 +148,6 @@ export function ConfirmationCard({
             </Text>
           </Flex>
         </Stack>
-
-        {/* View order link */}
-        {orderUrl && (
-          <>
-            <Divider />
-            <a
-              href={orderUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-full py-2 px-4 text-center text-sm font-medium text-[#76b900] hover:bg-[#76b900]/10 rounded-md transition-colors"
-            >
-              View Order Details
-            </a>
-          </>
-        )}
 
         {/* Start over button */}
         <Button

--- a/src/ui/components/business/BusinessPanel.test.tsx
+++ b/src/ui/components/business/BusinessPanel.test.tsx
@@ -2,10 +2,15 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { BusinessPanel } from "./BusinessPanel";
 import { ACPLogProvider } from "@/hooks/useACPLog";
+import { AgentActivityLogProvider } from "@/hooks/useAgentActivityLog";
 
 // Wrapper component to provide required context
 function renderWithProviders(ui: React.ReactElement) {
-  return render(<ACPLogProvider>{ui}</ACPLogProvider>);
+  return render(
+    <AgentActivityLogProvider>
+      <ACPLogProvider>{ui}</ACPLogProvider>
+    </AgentActivityLogProvider>
+  );
 }
 
 describe("BusinessPanel", () => {

--- a/src/ui/components/business/BusinessPanel.tsx
+++ b/src/ui/components/business/BusinessPanel.tsx
@@ -54,8 +54,16 @@ function ACPEventItem({ event }: { event: ACPEvent }) {
           <span style={{ color: "var(--text-muted)" }}>Processing request...</span>
         ) : (
           <>
-            <span style={{ color: "var(--text-muted)" }}>{event.method}</span>{" "}
-            <span style={{ color: "var(--text-secondary)" }}>{event.endpoint}</span>
+            <div
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              <span style={{ color: "var(--text-muted)" }}>{event.method}</span>{" "}
+              <span style={{ color: "var(--text-secondary)" }}>{event.endpoint}</span>
+            </div>
             {event.responseSummary && (
               <span
                 style={{
@@ -255,7 +263,8 @@ export function BusinessPanel() {
   // This allows the widget to remain isolated (no postMessage)
   useCheckoutEvents();
 
-  // Clear both local state and server-side event store
+  // Clear local ACP log state and server-side event store
+  // Note: Agent Activity is cleared by switching tabs or refreshing the page
   const handleClear = useCallback(async () => {
     // Clear local state first for immediate UI feedback
     clear();

--- a/src/ui/components/icons/index.tsx
+++ b/src/ui/components/icons/index.tsx
@@ -209,3 +209,102 @@ export function Globe({ className, ...props }: IconProps) {
     </svg>
   );
 }
+
+/**
+ * Sparkles icon - for AI/recommendations
+ */
+export function Sparkles({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" />
+      <path d="M5 3v4" />
+      <path d="M19 17v4" />
+      <path d="M3 5h4" />
+      <path d="M17 19h4" />
+    </svg>
+  );
+}
+
+/**
+ * Tag icon - for promotions/discounts
+ */
+export function Tag({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z" />
+      <circle cx="7.5" cy="7.5" r=".5" fill="currentColor" />
+    </svg>
+  );
+}
+
+/**
+ * Mail/envelope icon - for post-purchase messages
+ */
+export function Mail({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <rect width="20" height="16" x="2" y="4" rx="2" />
+      <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+    </svg>
+  );
+}
+
+/**
+ * Bot/Robot icon - for AI agent representation
+ */
+export function Bot({ className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 8V4H8" />
+      <rect width="16" height="12" x="4" y="8" rx="2" />
+      <path d="M2 14h2" />
+      <path d="M20 14h2" />
+      <path d="M15 13v2" />
+      <path d="M9 13v2" />
+    </svg>
+  );
+}

--- a/src/ui/hooks/useCheckoutEvents.tsx
+++ b/src/ui/hooks/useCheckoutEvents.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useCallback, useRef } from "react";
 import { useACPLog, type ACPEventType } from "./useACPLog";
+import { useAgentActivityLog } from "./useAgentActivityLog";
+import type { PromotionInputSignals, PromotionDecision } from "@/types";
 
 /**
  * SSE event from the MCP server
@@ -16,6 +18,23 @@ interface CheckoutSSEEvent {
   statusCode?: number;
   sessionId?: string;
   orderId?: string;
+  timestamp: string;
+}
+
+/**
+ * Agent activity SSE event from the MCP server
+ */
+interface AgentActivitySSEEvent {
+  id: string;
+  agentType: string;
+  productId: string;
+  productName: string;
+  action: string;
+  discountAmount: number;
+  reasonCodes: string[];
+  reasoning: string;
+  stockCount: number;
+  basePrice: number;
   timestamp: string;
 }
 
@@ -48,10 +67,11 @@ function mapEventType(type: string): ACPEventType {
  */
 export function useCheckoutEvents(mcpServerUrl = "http://localhost:2091") {
   const { logEvent, completeEvent } = useACPLog();
+  const { addAgentEvent } = useAgentActivityLog();
   const eventSourceRef = useRef<EventSource | null>(null);
   const pendingEventsRef = useRef<Map<string, string>>(new Map());
 
-  const handleEvent = useCallback(
+  const handleCheckoutEvent = useCallback(
     (event: MessageEvent) => {
       try {
         const data = JSON.parse(event.data) as CheckoutSSEEvent;
@@ -95,10 +115,46 @@ export function useCheckoutEvents(mcpServerUrl = "http://localhost:2091") {
           }
         }
       } catch (error) {
-        console.error("[useCheckoutEvents] Failed to parse event:", error);
+        console.error("[useCheckoutEvents] Failed to parse checkout event:", error);
       }
     },
     [logEvent, completeEvent]
+  );
+
+  const handleAgentActivityEvent = useCallback(
+    (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data) as AgentActivitySSEEvent;
+
+        // Only handle promotion agent events for now
+        if (data.agentType === "promotion") {
+          // Build input signals
+          const inputSignals: PromotionInputSignals = {
+            productId: data.productId,
+            productName: data.productName,
+            stockCount: data.stockCount,
+            basePrice: data.basePrice,
+            competitorPrice: null,
+            inventoryPressure: data.stockCount > 50 ? "high" : "low",
+            competitionPosition: inferCompetitionPosition(data.reasonCodes),
+          };
+
+          // Build decision
+          const decision: PromotionDecision = {
+            action: data.action,
+            discountAmount: data.discountAmount,
+            reasonCodes: data.reasonCodes,
+            reasoning: data.reasoning,
+          };
+
+          // Add to agent activity log
+          addAgentEvent("promotion", inputSignals, decision, "success");
+        }
+      } catch (error) {
+        console.error("[useCheckoutEvents] Failed to parse agent activity event:", error);
+      }
+    },
+    [addAgentEvent]
   );
 
   useEffect(() => {
@@ -111,7 +167,8 @@ export function useCheckoutEvents(mcpServerUrl = "http://localhost:2091") {
     const eventSource = new EventSource(`${mcpServerUrl}/events`);
     eventSourceRef.current = eventSource;
 
-    eventSource.addEventListener("checkout", handleEvent);
+    eventSource.addEventListener("checkout", handleCheckoutEvent);
+    eventSource.addEventListener("agent_activity", handleAgentActivityEvent);
 
     eventSource.onerror = () => {
       // EventSource will automatically reconnect
@@ -121,5 +178,15 @@ export function useCheckoutEvents(mcpServerUrl = "http://localhost:2091") {
       eventSource.close();
       eventSourceRef.current = null;
     };
-  }, [mcpServerUrl, handleEvent]);
+  }, [mcpServerUrl, handleCheckoutEvent, handleAgentActivityEvent]);
+}
+
+/**
+ * Infer competition position from reason codes
+ */
+function inferCompetitionPosition(reasonCodes: string[]): "above_market" | "at_market" | "below_market" | "unknown" {
+  if (reasonCodes.includes("ABOVE_MARKET")) return "above_market";
+  if (reasonCodes.includes("BELOW_MARKET")) return "below_market";
+  if (reasonCodes.includes("AT_MARKET")) return "at_market";
+  return "unknown";
 }

--- a/src/ui/hooks/useCheckoutEvents.tsx
+++ b/src/ui/hooks/useCheckoutEvents.tsx
@@ -184,7 +184,9 @@ export function useCheckoutEvents(mcpServerUrl = "http://localhost:2091") {
 /**
  * Infer competition position from reason codes
  */
-function inferCompetitionPosition(reasonCodes: string[]): "above_market" | "at_market" | "below_market" | "unknown" {
+function inferCompetitionPosition(
+  reasonCodes: string[]
+): "above_market" | "at_market" | "below_market" | "unknown" {
   if (reasonCodes.includes("ABOVE_MARKET")) return "above_market";
   if (reasonCodes.includes("BELOW_MARKET")) return "below_market";
   if (reasonCodes.includes("AT_MARKET")) return "at_market";


### PR DESCRIPTION
## Summary

- Refactor Apps SDK widget to use backend ACP session for all cart totals (removes local price calculations)
- Add loading states during async backend price/tax calculations
- Fix Phoenix container health check using Python instead of unavailable wget
- Add agent activity SSE events for promotion decisions (syncs widget with Protocol Inspector)
- Include product name and stock_count in line items for better observability
- Expand competitor pricing data for all 17 products to demonstrate promotion scenarios
- UI/UX improvements: Bot icons in agent activity panel, cleaner layout, simplified confirmation card

## Test plan

- [x] Verify widget loads correctly at http://localhost:2091/widget/merchant-app.html
- [x] Add items to cart and verify totals update from backend (not local)
- [x] Change shipping option and verify totals recalculate with loading spinner
- [x] Complete checkout flow end-to-end
- [x] Verify Protocol Inspector shows promotion agent activity events
- [x] Verify Phoenix container shows as healthy (`docker ps`)
- [x] Run frontend tests: `cd src/ui && pnpm test:run`
- [x] Run backend tests: `pytest tests/ -v`