### PR TITLE
[backend][frontend][docs] Support multi-item post-purchase messages

### DIFF
--- a/docs/features/feature-15-multi-language.md
+++ b/docs/features/feature-15-multi-language.md
@@ -85,7 +85,10 @@ POST /api/agents/post-purchase
   "order": {
     "order_id": "order_123",
     "customer_name": "Juan",
-    "product_name": "Camiseta Clásica",
+    "items": [
+      { "name": "Camiseta Clásica", "quantity": 1 },
+      { "name": "Sudadera Logo", "quantity": 2 }
+    ],
     "tracking_url": null,
     "estimated_delivery": "2026-01-29T00:00:00Z"
   },

--- a/src/agents/configs/post-purchase.yml
+++ b/src/agents/configs/post-purchase.yml
@@ -58,7 +58,7 @@ workflow:
     - order:
         - order_id: Order identifier
         - customer_name: Customer's first name
-        - product_name: Name of the purchased product
+        - items: Array of items with name and quantity
         - tracking_url: Package tracking URL (may be null for some statuses)
         - estimated_delivery: Estimated delivery date (ISO format)
     - status: Current shipping status
@@ -75,18 +75,18 @@ workflow:
     - fr: French (France)
 
     SHIPPING STATUSES AND MESSAGE CONTENT:
-    - order_confirmed: Thank customer, confirm order received, mention product
-    - order_shipped: Notify shipment, provide tracking URL, mention estimated delivery
-    - out_for_delivery: Alert customer package is arriving today, provide tracking URL
-    - delivered: Confirm delivery, thank customer, invite feedback
+    - order_confirmed: Thank customer, confirm order received, mention items
+    - order_shipped: Notify shipment, provide tracking URL, mention items and estimated delivery
+    - out_for_delivery: Alert customer package is arriving today, provide tracking URL, mention items
+    - delivered: Confirm delivery, thank customer, mention items, invite feedback
 
     MESSAGE GUIDELINES BY TONE:
 
     FRIENDLY (English examples):
     - order_confirmed: "Hey {customer_name}! 🎉 Great news - we've got your order..."
-    - order_shipped: "Your {product_name} is on its way! 🚚 Track it here..."
+    - order_shipped: "Your items are on their way! 🚚 Track them here..."
     - out_for_delivery: "Exciting! Your package arrives today! 📦..."
-    - delivered: "Your {product_name} has arrived! 🎁 We hope you love it..."
+    - delivered: "Your items have arrived! 🎁 We hope you love them..."
 
     PROFESSIONAL (English examples):
     - order_confirmed: "Dear {customer_name}, Thank you for your order..."
@@ -98,7 +98,7 @@ workflow:
     - order_confirmed: "Got it, {customer_name}! Your order's in the system 👍..."
     - order_shipped: "Heads up - your stuff just shipped! 📬..."
     - out_for_delivery: "Today's the day! Your package is almost there..."
-    - delivered: "Dropped off! Your {product_name} is waiting for you..."
+    - delivered: "Dropped off! Your items are waiting for you..."
 
     URGENT (English examples):
     - order_confirmed: "ORDER CONFIRMED: {customer_name}, your order is being processed..."
@@ -130,7 +130,10 @@ workflow:
       "order": {
         "order_id": "order_xyz789",
         "customer_name": "John",
-        "product_name": "Classic Tee",
+        "items": [
+          { "name": "Classic Tee", "quantity": 1 },
+          { "name": "Logo Hoodie", "quantity": 2 }
+        ],
         "tracking_url": "https://track.example.com/abc123",
         "estimated_delivery": "2026-01-28"
       },

--- a/src/merchant/api/routes/checkout.py
+++ b/src/merchant/api/routes/checkout.py
@@ -24,6 +24,7 @@ from src.merchant.services.checkout import (
     get_checkout_session,
     update_checkout_session,
 )
+from src.merchant.services.post_purchase import OrderItem
 from src.merchant.services.post_purchase_webhook import trigger_post_purchase_flow
 
 router = APIRouter(
@@ -248,15 +249,10 @@ def complete_checkout(
             elif response.buyer and response.buyer.first_name:
                 customer_name = response.buyer.first_name
 
-            items = []
+            items: list[OrderItem] = []
             for line_item in response.line_items or []:
                 item_name = line_item.name or line_item.item.id
-                items.append(
-                    {
-                        "name": item_name,
-                        "quantity": line_item.item.quantity,
-                    }
-                )
+                items.append({"name": item_name, "quantity": line_item.item.quantity})
 
             if not items:
                 items = [{"name": "your order", "quantity": 1}]

--- a/src/merchant/api/routes/checkout.py
+++ b/src/merchant/api/routes/checkout.py
@@ -248,10 +248,18 @@ def complete_checkout(
             elif response.buyer and response.buyer.first_name:
                 customer_name = response.buyer.first_name
 
-            # Extract product name from first line item
-            product_name = "your order"
-            if response.line_items:
-                product_name = response.line_items[0].name or "your item"
+            items = []
+            for line_item in response.line_items or []:
+                item_name = line_item.name or line_item.item.id
+                items.append(
+                    {
+                        "name": item_name,
+                        "quantity": line_item.item.quantity,
+                    }
+                )
+
+            if not items:
+                items = [{"name": "your order", "quantity": 1}]
 
             # Queue the post-purchase flow as a background task
             background_tasks.add_task(
@@ -259,7 +267,7 @@ def complete_checkout(
                 checkout_session_id=session_id,
                 order_id=response.order.id,
                 customer_name=customer_name,
-                product_name=product_name,
+                items=items,
                 language="en",  # Could be extracted from buyer preferences
             )
 

--- a/src/merchant/services/post_purchase.py
+++ b/src/merchant/services/post_purchase.py
@@ -89,9 +89,16 @@ class OrderContext(TypedDict):
 
     order_id: str  # Order identifier
     customer_name: str  # Customer's first name
-    product_name: str  # Name of the purchased product
+    items: list["OrderItem"]  # Items purchased
     tracking_url: str | None  # Package tracking URL (may be null)
     estimated_delivery: str | None  # Estimated delivery date (ISO format)
+
+
+class OrderItem(TypedDict):
+    """Item info for post-purchase messaging."""
+
+    name: str
+    quantity: int
 
 
 class ShippingMessageRequest(TypedDict):
@@ -246,58 +253,64 @@ FALLBACK_TEMPLATES: dict[str, dict[str, dict[str, str]]] = {
     "en": {
         ShippingStatus.ORDER_CONFIRMED.value: {
             "subject": "Order Confirmed",
-            "message": "Thank you for your order, {customer_name}! Your {product_name} order has been confirmed.\n\n- {company_name}",
+            "message": "Thank you for your order, {customer_name}! Your {items} order has been confirmed.\n\n- {company_name}",
         },
         ShippingStatus.ORDER_SHIPPED.value: {
             "subject": "Your Order Has Shipped",
-            "message": "Hi {customer_name}, your {product_name} is on its way!\n\nTrack your package: {tracking_url}\n\n- {company_name}",
+            "message": "Hi {customer_name}, your {items} is on its way!\n\nTrack your package: {tracking_url}\n\n- {company_name}",
         },
         ShippingStatus.OUT_FOR_DELIVERY.value: {
             "subject": "Out for Delivery",
-            "message": "Hi {customer_name}, your {product_name} will arrive today!\n\nTrack your package: {tracking_url}\n\n- {company_name}",
+            "message": "Hi {customer_name}, your {items} will arrive today!\n\nTrack your package: {tracking_url}\n\n- {company_name}",
         },
         ShippingStatus.DELIVERED.value: {
             "subject": "Your Order Has Been Delivered",
-            "message": "Hi {customer_name}, your {product_name} has been delivered! We hope you enjoy it.\n\n- {company_name}",
+            "message": "Hi {customer_name}, your {items} has been delivered! We hope you enjoy it.\n\n- {company_name}",
         },
     },
     "es": {
         ShippingStatus.ORDER_CONFIRMED.value: {
             "subject": "Pedido Confirmado",
-            "message": "¡Gracias por tu pedido, {customer_name}! Tu pedido de {product_name} ha sido confirmado.\n\n- {company_name}",
+            "message": "¡Gracias por tu pedido, {customer_name}! Tu pedido de {items} ha sido confirmado.\n\n- {company_name}",
         },
         ShippingStatus.ORDER_SHIPPED.value: {
             "subject": "Tu Pedido Ha Sido Enviado",
-            "message": "Hola {customer_name}, tu {product_name} está en camino.\n\nRastrear paquete: {tracking_url}\n\n- {company_name}",
+            "message": "Hola {customer_name}, tu {items} está en camino.\n\nRastrear paquete: {tracking_url}\n\n- {company_name}",
         },
         ShippingStatus.OUT_FOR_DELIVERY.value: {
             "subject": "En Reparto",
-            "message": "Hola {customer_name}, tu {product_name} llegará hoy.\n\nRastrear paquete: {tracking_url}\n\n- {company_name}",
+            "message": "Hola {customer_name}, tu {items} llegará hoy.\n\nRastrear paquete: {tracking_url}\n\n- {company_name}",
         },
         ShippingStatus.DELIVERED.value: {
             "subject": "Tu Pedido Ha Sido Entregado",
-            "message": "Hola {customer_name}, tu {product_name} ha sido entregado. ¡Esperamos que lo disfrutes!\n\n- {company_name}",
+            "message": "Hola {customer_name}, tu {items} ha sido entregado. ¡Esperamos que lo disfrutes!\n\n- {company_name}",
         },
     },
     "fr": {
         ShippingStatus.ORDER_CONFIRMED.value: {
             "subject": "Commande Confirmée",
-            "message": "Merci pour votre commande, {customer_name} ! Votre commande de {product_name} a été confirmée.\n\n- {company_name}",
+            "message": "Merci pour votre commande, {customer_name} ! Votre commande de {items} a été confirmée.\n\n- {company_name}",
         },
         ShippingStatus.ORDER_SHIPPED.value: {
             "subject": "Votre Commande a été Expédiée",
-            "message": "Bonjour {customer_name}, votre {product_name} est en route !\n\nSuivre le colis : {tracking_url}\n\n- {company_name}",
+            "message": "Bonjour {customer_name}, votre {items} est en route !\n\nSuivre le colis : {tracking_url}\n\n- {company_name}",
         },
         ShippingStatus.OUT_FOR_DELIVERY.value: {
             "subject": "En Cours de Livraison",
-            "message": "Bonjour {customer_name}, votre {product_name} arrivera aujourd'hui !\n\nSuivre le colis : {tracking_url}\n\n- {company_name}",
+            "message": "Bonjour {customer_name}, votre {items} arrivera aujourd'hui !\n\nSuivre le colis : {tracking_url}\n\n- {company_name}",
         },
         ShippingStatus.DELIVERED.value: {
             "subject": "Votre Commande a été Livrée",
-            "message": "Bonjour {customer_name}, votre {product_name} a été livré ! Nous espérons qu'il vous plaira.\n\n- {company_name}",
+            "message": "Bonjour {customer_name}, votre {items} a été livré ! Nous espérons qu'il vous plaira.\n\n- {company_name}",
         },
     },
 }
+
+
+def format_order_items(items: list[OrderItem]) -> str:
+    if not items:
+        return ""
+    return ", ".join(f"{item['name']} (x{item['quantity']})" for item in items)
 
 
 def get_fallback_message(
@@ -323,9 +336,10 @@ def get_fallback_message(
     )
 
     # Format template with order data
+    items_text = format_order_items(order.get("items", []))
     format_data = {
         "customer_name": order["customer_name"],
-        "product_name": order["product_name"],
+        "items": items_text or "your order",
         "tracking_url": order.get("tracking_url") or "",
         "company_name": persona["company_name"],
     }
@@ -347,7 +361,7 @@ def get_fallback_message(
 def build_message_request(
     order_id: str,
     customer_name: str,
-    product_name: str,
+    items: list[OrderItem],
     status: ShippingStatus,
     company_name: str = "Acme T-Shirts",
     tone: MessageTone = MessageTone.FRIENDLY,
@@ -362,7 +376,7 @@ def build_message_request(
     Args:
         order_id: Order identifier.
         customer_name: Customer's first name.
-        product_name: Name of the purchased product.
+        items: Items included in the order.
         status: Current shipping status.
         company_name: Retailer's name.
         tone: Message tone.
@@ -382,7 +396,7 @@ def build_message_request(
         order=OrderContext(
             order_id=order_id,
             customer_name=customer_name,
-            product_name=product_name,
+            items=items,
             tracking_url=tracking_url,
             estimated_delivery=estimated_delivery,
         ),

--- a/src/merchant/services/post_purchase_webhook.py
+++ b/src/merchant/services/post_purchase_webhook.py
@@ -29,6 +29,7 @@ checkout completion, so it doesn't block the checkout response.
 import logging
 
 from src.merchant.services.post_purchase import (
+    OrderItem,
     ShippingMessageRequest,
     ShippingStatus,
     SupportedLanguage,
@@ -43,7 +44,7 @@ async def trigger_post_purchase_flow(
     checkout_session_id: str,
     order_id: str,
     customer_name: str,
-    product_name: str,
+    items: list[OrderItem],
     language: str = "en",
 ) -> None:
     """Trigger the post-purchase agent and webhook delivery flow.
@@ -57,7 +58,7 @@ async def trigger_post_purchase_flow(
         checkout_session_id: The checkout session ID
         order_id: The order ID
         customer_name: Customer's first name for personalization
-        product_name: Product name for the message
+        items: Items included in the order
         language: Preferred language (en, es, fr)
     """
     logger.info(
@@ -83,7 +84,7 @@ async def trigger_post_purchase_flow(
         "order": {
             "order_id": order_id,
             "customer_name": customer_name,
-            "product_name": product_name,
+            "items": items,
             "tracking_url": f"https://track.nvshop.demo/orders/{order_id}",
             "estimated_delivery": None,  # Could be calculated based on shipping option
         },

--- a/src/ui/app/api/agents/post-purchase/route.ts
+++ b/src/ui/app/api/agents/post-purchase/route.ts
@@ -27,7 +27,10 @@ interface BrandPersona {
 interface OrderContext {
   order_id: string;
   customer_name: string;
-  product_name: string;
+  items: Array<{
+    name: string;
+    quantity: number;
+  }>;
   tracking_url: string | null;
   estimated_delivery: string;
 }

--- a/src/ui/lib/api-client.ts
+++ b/src/ui/lib/api-client.ts
@@ -243,7 +243,10 @@ export interface BrandPersona {
 export interface OrderContext {
   order_id: string;
   customer_name: string;
-  product_name: string;
+  items: Array<{
+    name: string;
+    quantity: number;
+  }>;
   tracking_url: string | null;
   estimated_delivery: string;
 }

--- a/tests/merchant/services/test_post_purchase.py
+++ b/tests/merchant/services/test_post_purchase.py
@@ -1,0 +1,43 @@
+"""Tests for post-purchase messaging helpers."""
+
+from src.merchant.services.post_purchase import (
+    MessageTone,
+    ShippingStatus,
+    SupportedLanguage,
+    build_message_request,
+    format_order_items,
+    get_fallback_message,
+)
+
+
+def test_format_order_items_includes_name_and_quantity() -> None:
+    items = [
+        {"name": "Classic Tee", "quantity": 1},
+        {"name": "Logo Hoodie", "quantity": 2},
+    ]
+
+    result = format_order_items(items)
+
+    assert "Classic Tee (x1)" in result
+    assert "Logo Hoodie (x2)" in result
+
+
+def test_fallback_message_includes_all_items() -> None:
+    request = build_message_request(
+        order_id="order_123",
+        customer_name="Jordan",
+        items=[
+            {"name": "Classic Tee", "quantity": 1},
+            {"name": "Logo Hoodie", "quantity": 2},
+        ],
+        status=ShippingStatus.ORDER_CONFIRMED,
+        company_name="NVShop",
+        tone=MessageTone.FRIENDLY,
+        language=SupportedLanguage.ENGLISH,
+    )
+
+    response = get_fallback_message(request)
+
+    assert response["subject"] == "Order Confirmed"
+    assert "Classic Tee (x1)" in response["message"]
+    assert "Logo Hoodie (x2)" in response["message"]


### PR DESCRIPTION
## Summary
- Extend post-purchase agent to accept an `items` array (name + quantity) instead of a single `product_name`
- Update fallback templates to include all order items in messages
- NAT agent prompt now documents and expects `order.items`

## Test plan
- [x] Complete checkout with multiple items in basket
- [x] Verify post-purchase message includes all items
- [x] Verify fallback templates format items correctly
- [x] Run backend tests: `pytest tests/merchant/services/test_post_purchase.py -v`


Made with [Cursor](https://cursor.com)