### PR TITLE
[apps-sdk][infra] Add RAG search and refactor Docker container naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,8 @@ src/
 │       ├── promotion.yml        # Promotion strategy arbiter (port 8002)
 │       ├── post-purchase.yml    # Multilingual shipping messages (port 8003)
 │       ├── recommendation.yml   # ARAG multi-agent recommendations (full version)
-│       └── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
+│       ├── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
+│       └── search.yml           # RAG product search (port 8005)
 │
 ├── apps_sdk/           # Apps SDK MCP Server (port 2091)
 │   ├── main.py         # FastAPI + MCP server entry point
@@ -301,6 +302,7 @@ tests/
 └── payment/            # PSP service test files
 
 docs/                   # Project documentation
+├──NEMO_AGENT_TOOLKIT_DOCUMENTATION.md # Nemo Agent Toolkit Documentation
 .cursor/skills/         # AI assistant skill definitions
 ```
 
@@ -331,6 +333,8 @@ NAT Agents (from `src/agents/`):
 - Start Promotion Agent: `nat serve --config_file configs/promotion.yml --port 8002`
 - Start Post-Purchase Agent: `nat serve --config_file configs/post-purchase.yml --port 8003`
 - Start Recommendation Agent (ARAG): `nat serve --config_file configs/recommendation-ultrafast.yml --port 8004`
+- Start Search Agent (RAG): `nat serve --config_file configs/search.yml --port 8005`
+- Apps SDK `search-products` relies on Search Agent; no local fallback.
 - Test Promotion: `nat run --config_file configs/promotion.yml --input '{...}'`
 - Test Post-Purchase: `nat run --config_file configs/post-purchase.yml --input '{...}'`
 

--- a/README.md
+++ b/README.md
@@ -108,17 +108,23 @@ nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
 
 > **Note**: The Recommendation Agent requires Milvus. See [Optional: Milvus Setup](#optional-milvus-setup) below.
 
+```bash
+# Terminal 7: Search Agent (port 8005) - requires Milvus container
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/search.yml --port 8005
+```
 ### 4. Frontend
 
 ```bash
-# Terminal 7: Demo UI (port 3000)
+# Terminal 8: Demo UI (port 3000)
 cd src/ui
 pnpm install
 pnpm dev
 ```
 
 ```bash
-# Terminal 8: Apps SDK Widget (port 3001) - for development
+# Terminal 9: Apps SDK Widget (port 3001) - for development
 cd src/apps_sdk/web
 pnpm install
 pnpm dev
@@ -215,6 +221,7 @@ flowchart TB
 | Promotion Agent | 8002 | Discount strategy (NAT) |
 | Post-Purchase Agent | 8003 | Multilingual messages (NAT) |
 | Recommendation Agent | 8004 | Personalized recs (requires Docker) |
+| Search Agent | 8005 | RAG product search (requires Docker) |
 
 ## API Docs
 
@@ -271,7 +278,7 @@ The project uses two Docker Compose files:
    This starts all services including:
    - nginx (reverse proxy on port 80)
    - Merchant API, PSP, Apps SDK
-   - NAT Agents (Promotion, Post-Purchase, Recommendation)
+   - NAT Agents (Promotion, Post-Purchase, Recommendation, Search)
    - Milvus (vector database) and Phoenix (observability)
 
 3. **Verify services:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # =============================================================================
   nginx:
     image: nginx:alpine
-    container_name: acp-nginx
+    container_name: nginx
     ports:
       - "80:80"
     volumes:
@@ -44,7 +44,7 @@ services:
     build:
       context: .
       dockerfile: src/merchant/Dockerfile
-    container_name: acp-merchant
+    container_name: merchant
     expose:
       - "8000"
     environment:
@@ -70,7 +70,7 @@ services:
     build:
       context: .
       dockerfile: src/payment/Dockerfile
-    container_name: acp-psp
+    container_name: psp
     expose:
       - "8001"
     environment:
@@ -87,13 +87,14 @@ services:
     build:
       context: .
       dockerfile: src/apps_sdk/Dockerfile
-    container_name: acp-apps-sdk
+    container_name: apps-sdk
     expose:
       - "2091"
     environment:
       - MERCHANT_API_URL=http://merchant:8000
       - PSP_API_URL=http://psp:8001
       - RECOMMENDATION_AGENT_URL=http://recommendation-agent:8004
+      - SEARCH_AGENT_URL=http://search-agent:8005
       - MERCHANT_API_KEY=${MERCHANT_API_KEY:-merchant-api-key-12345}
       - PSP_API_KEY=${PSP_API_KEY:-psp-api-key-12345}
     networks:
@@ -105,7 +106,7 @@ services:
     build:
       context: .
       dockerfile: src/ui/Dockerfile
-    container_name: acp-ui
+    container_name: ui
     expose:
       - "3000"
     environment:
@@ -130,8 +131,8 @@ services:
     build:
       context: .
       dockerfile: src/agents/Dockerfile
-    image: acp-agents:latest
-    container_name: acp-promotion-agent
+    image: nat-agents:latest
+    container_name: nat-promotion-agent
     command: nat serve --config_file configs/promotion.yml --host 0.0.0.0 --port 8002
     expose:
       - "8002"
@@ -145,8 +146,8 @@ services:
 
   # Post-Purchase Agent (Port 8003) - Uses shared image
   post-purchase-agent:
-    image: acp-agents:latest
-    container_name: acp-post-purchase-agent
+    image: nat-agents:latest
+    container_name: nat-post-purchase-agent
     command: nat serve --config_file configs/post-purchase.yml --host 0.0.0.0 --port 8003
     expose:
       - "8003"
@@ -163,11 +164,30 @@ services:
 
   # Recommendation Agent (Port 8004) - Uses shared image, requires Milvus
   recommendation-agent:
-    image: acp-agents:latest
-    container_name: acp-recommendation-agent
+    image: nat-agents:latest
+    container_name: nat-recommendation-agent
     command: nat serve --config_file configs/recommendation-ultrafast.yml --host 0.0.0.0 --port 8004
     expose:
       - "8004"
+    environment:
+      - NVIDIA_API_KEY=${NVIDIA_API_KEY}
+      - MILVUS_URI=http://milvus-standalone:19530
+      - PHOENIX_ENDPOINT=http://phoenix:6006/v1/traces
+    depends_on:
+      promotion-agent:
+        condition: service_started
+    networks:
+      - acp-network
+      - acp-infra-network
+    restart: unless-stopped
+
+  # Search Agent (Port 8005) - Uses shared image, requires Milvus for RAG
+  search-agent:
+    image: nat-agents:latest
+    container_name: nat-search-agent
+    command: nat serve --config_file configs/search.yml --host 0.0.0.0 --port 8005
+    expose:
+      - "8005"
     environment:
       - NVIDIA_API_KEY=${NVIDIA_API_KEY}
       - MILVUS_URI=http://milvus-standalone:19530

--- a/env.example
+++ b/env.example
@@ -42,6 +42,13 @@ POST_PURCHASE_AGENT_TIMEOUT=15.0
 RECOMMENDATION_AGENT_URL=http://localhost:8004
 RECOMMENDATION_AGENT_TIMEOUT=15.0
 
+# Search Agent Configuration
+SEARCH_AGENT_URL=http://localhost:8005
+# Maximum L2 distance allowed in Milvus range search
+SEARCH_DISTANCE_CUTOFF=1.4
+# Minimum similarity threshold for search results (0.0-1.0)
+SEARCH_MIN_SIMILARITY=0.35
+
 # Phoenix Observability (for Recommendation Agent tracing)
 # Start Phoenix: docker compose up -d
 # View traces: http://localhost:6006

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -51,6 +51,7 @@ All ACP agents follow a **3-layer hybrid architecture** that combines determinis
 | Promotion Agent | `configs/promotion.yml` | 8002 | Strategy arbiter for dynamic pricing |
 | Post-Purchase Agent | `configs/post-purchase.yml` | 8003 | Multilingual shipping message generator |
 | Recommendation Agent (ARAG) | `configs/recommendation-ultrafast.yml` | 8004 | Multi-agent personalized recommendations |
+| Search Agent (RAG) | `configs/search.yml` | 8005 | Lightweight semantic product search |
 
 ### ARAG Recommendation Agent Architecture
 
@@ -398,6 +399,26 @@ The Recommendation Agent requires Milvus for vector search and Phoenix for obser
 | Phoenix | 6006 | LLM observability UI and trace collection |
 | MinIO | 9001 | Object storage for Milvus (console optional) |
 
+### Search Agent (`configs/search.yml`)
+
+**Workflow Type:** `tool_calling_agent`
+
+Lightweight RAG search agent that performs semantic product search against the
+Milvus `product_catalog` collection and returns top-k matches for a query.
+
+```bash
+# Start as REST endpoint
+nat serve --config_file configs/search.yml --port 8005
+
+# Test with direct input
+nat run --config_file configs/search.yml --input '{
+  "query": "lightweight summer tee",
+  "limit": 3
+}'
+```
+
+**Requires:** Milvus running and seeded (same setup as Recommendation Agent).
+
 ```bash
 # Start infrastructure
 docker compose up -d
@@ -595,7 +616,8 @@ src/agents/
     ├── promotion.yml        # Promotion strategy arbiter (port 8002)
     ├── post-purchase.yml    # Multilingual shipping messages (port 8003)
     ├── recommendation.yml   # ARAG multi-agent recommendations (full version)
-    └── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
+    ├── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
+    └── search.yml           # RAG product search agent (port 8005)
 ```
 
 ## Development

--- a/src/agents/configs/post-purchase.yml
+++ b/src/agents/configs/post-purchase.yml
@@ -37,6 +37,7 @@ workflow:
   _type: chat_completion
   workflow_alias: post_purchase_agent
   llm_name: nim_llm
+  verbose: true
   system_prompt: |
     You are a Post-Purchase Communication Specialist for e-commerce retailers. You generate 
     human-like shipping update messages that reflect the brand's personality and the customer's

--- a/src/agents/configs/promotion.yml
+++ b/src/agents/configs/promotion.yml
@@ -35,6 +35,7 @@ workflow:
   _type: chat_completion
   workflow_alias: promotion_agent
   llm_name: nim_llm
+  verbose: true
   system_prompt: |
     You are a Promotion Strategy Arbiter for an e-commerce retailer. You receive pre-computed 
     business context from the merchant system and select the optimal promotion action.

--- a/src/agents/configs/search.yml
+++ b/src/agents/configs/search.yml
@@ -1,0 +1,109 @@
+# RAG Search Agent (Lightweight)
+# ==============================
+# Purpose: Provide top-k product search results from Milvus embeddings.
+#
+# Usage:
+#   nat serve --config_file configs/search.yml --port 8005
+#   nat run --config_file configs/search.yml --input '{"query": "lightweight summer tee", "limit": 3}'
+
+general:
+  use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: info
+    tracing:
+      phoenix:
+        _type: phoenix
+        project: "search-agent"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006/v1/traces}
+
+# =============================================================================
+# EMBEDDERS - Semantic embeddings for product search
+# =============================================================================
+embedders:
+  product_embedder:
+    _type: nim
+    model_name: nvidia/nv-embedqa-e5-v5
+    truncate: "END"
+
+# =============================================================================
+# RETRIEVERS - Vector search for candidate products
+# =============================================================================
+retrievers:
+  product_retriever:
+    _type: milvus_retriever
+    uri: ${MILVUS_URI:-http://localhost:19530}
+    collection_name: "product_catalog"
+    embedding_model: product_embedder
+    top_k: 10
+
+# =============================================================================
+# FUNCTIONS - Product search tool
+# =============================================================================
+functions:
+  product_search:
+    _type: nat_retriever
+    retriever: product_retriever
+    topic: Search product catalog for items matching the user query
+
+# =============================================================================
+# LLM PROVIDERS
+# =============================================================================
+llms:
+  search_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-nano-30b-a3b
+    temperature: 0.2
+    max_tokens: 512
+    chat_template_kwargs:
+      enable_thinking: false
+
+# =============================================================================
+# MAIN WORKFLOW - Tool-calling agent
+# =============================================================================
+workflow:
+  _type: tool_calling_agent
+  name: rag_search_agent
+  workflow_alias: search_agent
+  llm_name: search_llm
+  tool_names:
+    - product_search
+  verbose: true
+  max_iterations: 2
+  system_prompt: |-
+    You are a product search assistant. You must retrieve products using the product_search tool
+    and return the best results for the user's query. If the search results do not match the query,
+    return an empty results list instead of unrelated items.
+
+    INPUT FORMAT:
+    The input is a JSON object with:
+    - query: string (the search query)
+    - category: string | null (optional category hint)
+    - limit: number (maximum results to return)
+
+    MANDATORY FIRST STEP:
+    You MUST call product_search with a query derived directly from the user's query.
+    If a category is provided, include it in the search query.
+    Do not respond before calling the tool.
+
+    OUTPUT FORMAT (return ONLY this JSON):
+    {
+      "query": "<original query>",
+      "results": [
+        {
+          "product_id": "<exact product_id from search>",
+          "product_name": "<exact product_name from search>",
+          "snippet": "Short relevance note in one sentence",
+          "distance": 0.123
+        }
+      ]
+    }
+
+    RULES:
+    - Use exact product_id and product_name from search results.
+    - Preserve distance/score/similarity from the tool output when available.
+    - Return at most the requested limit.
+    - Do not include products not present in the search results.
+    - Return valid JSON only (no extra text).

--- a/src/apps_sdk/README.md
+++ b/src/apps_sdk/README.md
@@ -174,7 +174,7 @@ Settings are managed via environment variables or `.env` file:
 | `MCP_SERVER_PORT` | `2091` | Server port |
 | `MERCHANT_API_URL` | `http://localhost:8000` | Merchant API URL |
 | `PSP_API_URL` | `http://localhost:8001` | PSP service URL |
-| `ARAG_AGENT_URL` | `http://localhost:8004` | Recommendation agent URL |
+| `RECOMMENDATION_AGENT_URL` | `http://localhost:8004` | Recommendation agent URL |
 | `MERCHANT_API_KEY` | `merchant-api-key-12345` | Merchant API authentication key |
 | `PSP_API_KEY` | `psp-api-key-12345` | PSP API authentication key |
 

--- a/src/apps_sdk/config.py
+++ b/src/apps_sdk/config.py
@@ -29,6 +29,15 @@ class AppsSdkSettings(BaseSettings):
     merchant_api_url: str = "http://localhost:8000"
     psp_api_url: str = "http://localhost:8001"
     arag_agent_url: str = "http://localhost:8004"
+    search_agent_url: str = "http://localhost:8005"
+
+    # Search tuning
+    # Minimum similarity score required to keep a search result.
+    # Similarity is computed from the vector distance returned by Milvus.
+    search_min_similarity: float = 0.35
+    # Maximum distance allowed from vector search results.
+    # Lower values are stricter; set to 0 to disable distance filtering.
+    search_distance_cutoff: float = 1.4
 
     # API keys for calling merchant and PSP services
     merchant_api_key: str = "merchant-api-key-12345"

--- a/src/apps_sdk/config.py
+++ b/src/apps_sdk/config.py
@@ -28,7 +28,7 @@ class AppsSdkSettings(BaseSettings):
     # Backend URLs
     merchant_api_url: str = "http://localhost:8000"
     psp_api_url: str = "http://localhost:8001"
-    arag_agent_url: str = "http://localhost:8004"
+    recommendation_agent_url: str = "http://localhost:8004"
     search_agent_url: str = "http://localhost:8005"
 
     # Search tuning

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -42,7 +42,7 @@ from src.apps_sdk.tools import (
 settings = get_apps_sdk_settings()
 
 # Agent URLs
-RECOMMENDATION_AGENT_URL = settings.arag_agent_url
+RECOMMENDATION_AGENT_URL = settings.recommendation_agent_url
 SEARCH_AGENT_URL = settings.search_agent_url
 
 # Configure logging

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -39,12 +39,11 @@ from src.apps_sdk.tools import (
     update_cart_quantity,
 )
 
-# ARAG Recommendation Agent URL
-RECOMMENDATION_AGENT_URL = os.getenv(
-    "RECOMMENDATION_AGENT_URL", "http://localhost:8004"
-)
-
 settings = get_apps_sdk_settings()
+
+# Agent URLs
+RECOMMENDATION_AGENT_URL = settings.arag_agent_url
+SEARCH_AGENT_URL = settings.search_agent_url
 
 # Configure logging
 logging.basicConfig(
@@ -122,7 +121,7 @@ class SearchProductsInput(BaseModel):
 
     query: str = Field(..., description="Search query for products")
     category: str | None = Field(None, description="Optional category filter")
-    limit: int = Field(default=10, ge=1, le=50, description="Max results (1-50)")
+    limit: int = Field(default=3, ge=1, le=50, description="Max results (1-50)")
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -682,6 +681,20 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
     if tool_name == "search-products":
         payload = SearchProductsInput.model_validate(args)
         result = await search_products(payload.query, payload.category, payload.limit)
+        if result.get("error"):
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[
+                        types.TextContent(
+                            type="text",
+                            text=str(result.get("error")),
+                        )
+                    ],
+                    structuredContent=result,
+                    _meta=result.get("_meta", _search_meta()),
+                    isError=True,
+                )
+            )
         return types.ServerResult(
             types.CallToolResult(
                 content=[
@@ -840,6 +853,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     """
     logger.info("Apps SDK MCP Server starting up...")
     logger.info(f"Widget dist directory: {DIST_DIR}")
+    logger.info(f"Search agent URL: {SEARCH_AGENT_URL}")
 
     # Initialize MCP server's session manager
     async with mcp.session_manager.run():

--- a/src/apps_sdk/tools/cart.py
+++ b/src/apps_sdk/tools/cart.py
@@ -2,14 +2,22 @@
 Cart tools for the MCP server.
 
 Manages shopping cart state with add, remove, update, and get operations.
+Product data is fetched from the merchant API (single source of truth).
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from uuid import uuid4
 
-from src.apps_sdk.tools.recommendations import CATALOG_PRODUCTS
+import httpx
+
+from src.apps_sdk.config import get_apps_sdk_settings
+
+logger = logging.getLogger(__name__)
+settings = get_apps_sdk_settings()
+MERCHANT_API_URL = settings.merchant_api_url
 
 # In-memory cart storage (use database in production)
 # Exported for use by checkout module
@@ -34,8 +42,8 @@ def get_or_create_cart(
     return new_id, carts[new_id]
 
 
-def find_product(product_id: str) -> dict[str, Any] | None:
-    """Find a product by ID.
+async def find_product(product_id: str) -> dict[str, Any] | None:
+    """Find a product by ID from the merchant API.
 
     Args:
         product_id: The product ID to look up.
@@ -43,7 +51,26 @@ def find_product(product_id: str) -> dict[str, Any] | None:
     Returns:
         Product dictionary or None if not found.
     """
-    return next((p for p in CATALOG_PRODUCTS if p["id"] == product_id), None)
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{MERCHANT_API_URL}/products/{product_id}")
+            if response.status_code != 200:
+                logger.debug(f"Product {product_id} not found in merchant API")
+                return None
+            product = response.json()
+            return {
+                "id": product.get("id", product_id),
+                "sku": product.get("sku", ""),
+                "name": product.get("name", ""),
+                "basePrice": product.get("base_price", product.get("price_cents", 0)),
+                "stockCount": product.get("stock_count", 0),
+                "category": product.get("category", ""),
+                "description": product.get("description", ""),
+                "imageUrl": product.get("image_url"),
+            }
+    except Exception as e:
+        logger.warning(f"Failed to fetch product {product_id}: {e}")
+        return None
 
 
 def calculate_cart_totals(items: list[dict[str, Any]]) -> dict[str, int]:
@@ -95,7 +122,7 @@ async def add_to_cart(
         Updated cart state with items and totals.
     """
     cart_id, cart_items = get_or_create_cart(cart_id)
-    product = find_product(product_id)
+    product = await find_product(product_id)
 
     if not product:
         return {

--- a/src/apps_sdk/tools/recommendations.py
+++ b/src/apps_sdk/tools/recommendations.py
@@ -3,30 +3,29 @@ Search products tool for the MCP server.
 
 This module provides the search_products MCP tool which serves as the
 entry point for widget discovery per the Apps SDK spec.
+
+This module delegates search entirely to the NAT RAG search agent and
+enriches results from the merchant API - no hardcoded product data.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import json
+import logging
+from typing import Any, cast
 
-from src.data.product_catalog import PRODUCTS
+import httpx
 
-# Transform catalog products to widget format
-CATALOG_PRODUCTS = [
-    {
-        "id": p["id"],
-        "sku": p["sku"],
-        "name": p["name"],
-        "basePrice": p["price_cents"],
-        "stockCount": p["stock_count"],
-        "category": p["category"],
-        "description": p["description"],
-        "imageUrl": p["image_url"],
-    }
-    for p in PRODUCTS
-]
+from src.apps_sdk.config import get_apps_sdk_settings
 
-# Default user context for widget
+logger = logging.getLogger(__name__)
+
+settings = get_apps_sdk_settings()
+SEARCH_AGENT_URL = settings.search_agent_url
+MERCHANT_API_URL = settings.merchant_api_url
+SEARCH_MIN_SIMILARITY = settings.search_min_similarity
+SEARCH_DISTANCE_CUTOFF = settings.search_distance_cutoff
+
 DEFAULT_USER = {
     "id": "user_demo123",
     "name": "John Doe",
@@ -37,6 +36,142 @@ DEFAULT_USER = {
 }
 
 
+def _error_search_response(
+    query: str,
+    category: str | None,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "products": [],
+        "query": query,
+        "category": category,
+        "totalResults": 0,
+        "error": message,
+        "user": DEFAULT_USER,
+        "theme": "dark",
+        "locale": "en-US",
+        "_meta": {
+            "openai/outputTemplate": "ui://widget/merchant-app.html",
+            "openai/toolInvocation/invoking": "Searching products...",
+            "openai/toolInvocation/invoked": message,
+            "openai/widgetAccessible": True,
+        },
+    }
+
+
+def _extract_similarity(item: dict[str, Any]) -> float | None:
+    similarity = item.get("similarity")
+    if isinstance(similarity, (int, float)):
+        return float(similarity)
+
+    score = item.get("score")
+    if isinstance(score, (int, float)):
+        return 1 / (1 + float(score))
+
+    distance = item.get("distance")
+    if isinstance(distance, (int, float)):
+        return 1 / (1 + float(distance))
+
+    return None
+
+
+def _extract_distance(item: dict[str, Any]) -> float | None:
+    distance = item.get("distance")
+    if isinstance(distance, (int, float)):
+        return float(distance)
+    return None
+
+
+def _parse_search_agent_response(raw_result: Any) -> dict[str, Any]:
+    """Parse the search agent response into a typed dictionary."""
+    parsed: dict[str, Any] = {}
+
+    if isinstance(raw_result, dict):
+        raw_dict = cast(dict[str, Any], raw_result)
+        value = raw_dict.get("value")
+        if isinstance(value, str):
+            loaded = json.loads(value)
+            if isinstance(loaded, dict):
+                parsed = cast(dict[str, Any], loaded)
+        elif isinstance(value, dict):
+            parsed = cast(dict[str, Any], value)
+        elif "results" in raw_dict:
+            parsed = raw_dict
+    elif isinstance(raw_result, str):
+        loaded = json.loads(raw_result)
+        if isinstance(loaded, dict):
+            parsed = cast(dict[str, Any], loaded)
+
+    return parsed
+
+
+async def _fetch_product_from_merchant(product_id: str) -> dict[str, Any] | None:
+    """Fetch a product from the merchant API.
+    
+    This is the single source of truth for product data.
+    Returns None if the product doesn't exist in the merchant database.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{MERCHANT_API_URL}/products/{product_id}")
+            if response.status_code != 200:
+                logger.debug(f"Product {product_id} not found in merchant API: {response.status_code}")
+                return None
+            product = response.json()
+            return {
+                "id": product.get("id", product_id),
+                "sku": product.get("sku", ""),
+                "name": product.get("name", ""),
+                "basePrice": product.get("base_price", product.get("price_cents", 0)),
+                "stockCount": product.get("stock_count", 0),
+                "category": product.get("category", ""),
+                "description": product.get("description", ""),
+                "imageUrl": product.get("image_url"),
+            }
+    except Exception as e:
+        logger.warning(f"Failed to fetch product {product_id} from merchant API: {e}")
+        return None
+
+
+async def call_search_agent(
+    query: str,
+    category: str | None,
+    limit: int,
+) -> dict[str, Any]:
+    """Call the NAT RAG search agent to retrieve top products."""
+    payload = {
+        "input_message": json.dumps(
+            {
+                "query": query,
+                "category": category,
+                "limit": limit,
+            }
+        )
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.post(
+                f"{SEARCH_AGENT_URL}/generate",
+                json=payload,
+            )
+            response.raise_for_status()
+            raw_result = response.json()
+            parsed = _parse_search_agent_response(raw_result)
+            return {
+                "query": parsed.get("query", query),
+                "results": parsed.get("results", []),
+            }
+    except httpx.TimeoutException:
+        return {"results": [], "error": "Search agent timeout"}
+    except httpx.HTTPStatusError as e:
+        return {"results": [], "error": f"Agent error: {e.response.status_code}"}
+    except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+        return {"results": [], "error": f"Search agent unavailable: {e}"}
+    except Exception as e:
+        return {"results": [], "error": str(e)}
+
+
 async def search_products(
     query: str,
     category: str | None = None,
@@ -44,6 +179,10 @@ async def search_products(
 ) -> dict[str, Any]:
     """
     Search for products by query and optional category.
+
+    Delegates search entirely to the NAT RAG search agent, then enriches
+    results from the merchant API. Returns 0 results if no matching products
+    exist in the database (e.g., searching for "skirts" when none exist).
 
     This is the entry point tool that exposes the widget URI to clients.
     The client discovers the widget location by calling this tool and reading
@@ -57,35 +196,80 @@ async def search_products(
     Returns:
         Dictionary containing products, query info, and widget metadata.
     """
-    # Filter products based on query (simple case-insensitive search)
-    query_lower = query.lower()
-    filtered_products = [
-        p
-        for p in CATALOG_PRODUCTS
-        if query_lower in str(p["name"]).lower()
-        or query_lower in str(p.get("category", "")).lower()
-        or query_lower in str(p.get("sku", "")).lower()
-        or query_lower in str(p.get("description", "")).lower()
-    ]
-
-    # Apply category filter if provided
-    if category:
-        category_lower = category.lower()
-        filtered_products = [
-            p
-            for p in filtered_products
-            if category_lower in str(p.get("category", "")).lower()
-            or category_lower in str(p["name"]).lower()
-        ]
-
-    # If no matches, return all products (for demo purposes)
-    if not filtered_products:
-        filtered_products = CATALOG_PRODUCTS
-
-    # Apply limit
     limit = min(limit, 50)
-    results = filtered_products[:limit]
 
+    logger.info(f"Search request: query='{query}', category={category}, limit={limit}")
+
+    agent_result = await call_search_agent(query=query, category=category, limit=limit)
+    if agent_result.get("error"):
+        logger.warning(f"Search agent error: {agent_result.get('error')}")
+        return _error_search_response(
+            query=query,
+            category=category,
+            message="Search agent unavailable. Try again.",
+        )
+    
+    agent_items = agent_result.get("results", [])
+    logger.info(f"Search agent returned {len(agent_items)} results")
+
+    if SEARCH_DISTANCE_CUTOFF > 0:
+        filtered_items: list[dict[str, Any]] = []
+        has_distances = False
+        for item in agent_items:
+            distance = _extract_distance(item)
+            if distance is None:
+                continue
+            has_distances = True
+            if distance <= SEARCH_DISTANCE_CUTOFF:
+                filtered_items.append(item)
+        if has_distances:
+            logger.info(
+                "Applied distance filter (max=%s): %s -> %s",
+                SEARCH_DISTANCE_CUTOFF,
+                len(agent_items),
+                len(filtered_items),
+            )
+            agent_items = filtered_items
+
+    if SEARCH_MIN_SIMILARITY > 0:
+        filtered_items: list[dict[str, Any]] = []
+        has_scores = False
+        for item in agent_items:
+            similarity = _extract_similarity(item)
+            if similarity is None:
+                continue
+            has_scores = True
+            if similarity >= SEARCH_MIN_SIMILARITY:
+                filtered_items.append(item)
+        if has_scores:
+            logger.info(f"Applied similarity filter (min={SEARCH_MIN_SIMILARITY}): {len(agent_items)} -> {len(filtered_items)}")
+            agent_items = filtered_items
+
+    results: list[dict[str, Any]] = []
+    for item in agent_items:
+        product_id = item.get("product_id") or item.get("productId")
+        if not product_id:
+            logger.warning(f"Agent returned item without product_id: {item}")
+            continue
+        
+        enriched = await _fetch_product_from_merchant(product_id)
+        if enriched:
+            results.append(enriched)
+        else:
+            logger.debug(f"Product {product_id} returned by agent not found in merchant database (skipping)")
+
+    if len(results) > limit:
+        results = results[:limit]
+
+    if not results:
+        logger.info(f"No products found for query '{query}'")
+        return _error_search_response(
+            query=query,
+            category=category,
+            message=f"No products found for '{query}'.",
+        )
+
+    logger.info(f"Returning {len(results)} products for query '{query}'")
     return {
         "products": results,
         "query": query,

--- a/src/apps_sdk/tools/recommendations.py
+++ b/src/apps_sdk/tools/recommendations.py
@@ -107,7 +107,7 @@ def _parse_search_agent_response(raw_result: Any) -> dict[str, Any]:
 
 async def _fetch_product_from_merchant(product_id: str) -> dict[str, Any] | None:
     """Fetch a product from the merchant API.
-    
+
     This is the single source of truth for product data.
     Returns None if the product doesn't exist in the merchant database.
     """
@@ -208,7 +208,7 @@ async def search_products(
             category=category,
             message="Search agent unavailable. Try again.",
         )
-    
+
     agent_items = agent_result.get("results", [])
     logger.info(f"Search agent returned {len(agent_items)} results")
 
@@ -251,7 +251,7 @@ async def search_products(
         if not product_id:
             logger.warning(f"Agent returned item without product_id: {item}")
             continue
-        
+
         enriched = await _fetch_product_from_merchant(product_id)
         if enriched:
             results.append(enriched)

--- a/src/apps_sdk/tools/recommendations.py
+++ b/src/apps_sdk/tools/recommendations.py
@@ -115,7 +115,9 @@ async def _fetch_product_from_merchant(product_id: str) -> dict[str, Any] | None
         async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(f"{MERCHANT_API_URL}/products/{product_id}")
             if response.status_code != 200:
-                logger.debug(f"Product {product_id} not found in merchant API: {response.status_code}")
+                logger.debug(
+                    f"Product {product_id} not found in merchant API: {response.status_code}"
+                )
                 return None
             product = response.json()
             return {
@@ -242,7 +244,9 @@ async def search_products(
             if similarity >= SEARCH_MIN_SIMILARITY:
                 filtered_items.append(item)
         if has_scores:
-            logger.info(f"Applied similarity filter (min={SEARCH_MIN_SIMILARITY}): {len(agent_items)} -> {len(filtered_items)}")
+            logger.info(
+                f"Applied similarity filter (min={SEARCH_MIN_SIMILARITY}): {len(agent_items)} -> {len(filtered_items)}"
+            )
             agent_items = filtered_items
 
     results: list[dict[str, Any]] = []
@@ -256,7 +260,9 @@ async def search_products(
         if enriched:
             results.append(enriched)
         else:
-            logger.debug(f"Product {product_id} returned by agent not found in merchant database (skipping)")
+            logger.debug(
+                f"Product {product_id} returned by agent not found in merchant database (skipping)"
+            )
 
     if len(results) > limit:
         results = results[:limit]

--- a/src/apps_sdk/web/src/App.test.tsx
+++ b/src/apps_sdk/web/src/App.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+ import { render, screen } from "@testing-library/react";
+ import { App } from "./App";
+ import type { Product } from "./types";
+ 
+ const mockProducts: Product[] = [
+   {
+     id: "prod_1",
+     sku: "TS-001",
+     name: "Classic Tee",
+     basePrice: 2500,
+     stockCount: 100,
+     variant: "Black",
+     size: "Large",
+     imageUrl: "/prod_1.jpeg",
+   },
+   {
+     id: "prod_2",
+     sku: "TS-002",
+     name: "V-Neck Tee",
+     basePrice: 2800,
+     stockCount: 50,
+     variant: "Natural",
+     size: "Large",
+     imageUrl: "/prod_2.jpeg",
+   },
+   {
+     id: "prod_3",
+     sku: "TS-003",
+     name: "Graphic Tee",
+     basePrice: 3200,
+     stockCount: 200,
+     variant: "Grey",
+     size: "Large",
+     imageUrl: "/prod_3.jpeg",
+   },
+ ];
+ 
+const toolOutput = {
+  products: mockProducts,
+  user: {
+    id: "user_demo123",
+    name: "John Doe",
+    email: "john@example.com",
+    loyaltyPoints: 1250,
+    tier: "Gold",
+    memberSince: "2024-03-15",
+  },
+} as Record<string, unknown>;
+
+vi.mock("@/hooks", () => ({
+  useToolOutput: () => toolOutput,
+}));
+ 
+ describe("App", () => {
+  beforeEach(() => {
+    toolOutput.products = mockProducts;
+    toolOutput.error = undefined;
+  });
+
+   it("renders products from toolOutput.products", () => {
+     render(<App />);
+ 
+     expect(screen.getByText("Classic Tee")).toBeInTheDocument();
+     expect(screen.getByText("V-Neck Tee")).toBeInTheDocument();
+     expect(screen.getByText("Graphic Tee")).toBeInTheDocument();
+   });
+
+  it("shows an empty state when no products are found", () => {
+    toolOutput.products = [];
+    toolOutput.error = "No products found for 'dresses'.";
+
+    render(<App />);
+
+    expect(screen.getByText("No products found")).toBeInTheDocument();
+    expect(screen.getByText("No products found for 'dresses'.")).toBeInTheDocument();
+  });
+ });

--- a/src/apps_sdk/web/src/App.tsx
+++ b/src/apps_sdk/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { SearchX } from "lucide-react";
 import { LoyaltyHeader } from "@/components/LoyaltyHeader";
 import { RecommendationCarousel } from "@/components/RecommendationCarousel";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -77,8 +78,18 @@ export function App() {
 
   // User and recommendations from toolOutput or defaults
   const user: MerchantUser = (toolOutput?.user as MerchantUser) ?? DEFAULT_USER;
-  const browseRecommendations: Product[] =
-    (toolOutput?.recommendations as Product[]) ?? DEFAULT_RECOMMENDATIONS;
+  const toolError =
+    toolOutput && typeof toolOutput.error === "string" ? (toolOutput.error as string) : null;
+  const browseRecommendations: Product[] = toolOutput
+    ? toolError
+      ? []
+      : ((toolOutput?.products as Product[]) ??
+        (toolOutput?.recommendations as Product[]) ??
+        [])
+    : DEFAULT_RECOMMENDATIONS;
+  const showEmptyState = browseRecommendations.length === 0;
+  const emptyStateMessage =
+    toolError ?? "No products found. Try a different search or browse trending items.";
 
   // Page navigation state
   const [currentPage, setCurrentPage] = useState<WidgetPage>("browse");
@@ -539,7 +550,7 @@ export function App() {
     } finally {
       setIsCheckingOut(false);
     }
-  }, [cartItems, cartState]);
+  }, [cartItems, cartState, getApiBaseUrl]);
 
   // Render product detail page
   if (currentPage === "product_detail" && selectedProduct) {
@@ -606,11 +617,28 @@ export function App() {
 
       {/* Main Content - Only show recommendations */}
       <div className="px-5 pb-6">
-        <RecommendationCarousel
-          products={browseRecommendations}
-          onAddToCart={handleAddToCart}
-          onProductClick={handleProductClick}
-        />
+        {toolError && (
+          <div className="mb-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+            {toolError}
+          </div>
+        )}
+        {showEmptyState ? (
+          <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-default/60 bg-surface-elevated/50 px-6 py-10 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-default/60 bg-surface-elevated">
+              <SearchX className="h-6 w-6 text-text-secondary" strokeWidth={1.75} />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-text">No products found</p>
+              <p className="text-xs text-text-secondary">{emptyStateMessage}</p>
+            </div>
+          </div>
+        ) : (
+          <RecommendationCarousel
+            products={browseRecommendations}
+            onAddToCart={handleAddToCart}
+            onProductClick={handleProductClick}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/apps_sdk/web/src/components/RecommendationCarousel.test.tsx
+++ b/src/apps_sdk/web/src/components/RecommendationCarousel.test.tsx
@@ -1,0 +1,28 @@
+ import { describe, it, expect, vi } from "vitest";
+ import { render, screen } from "@testing-library/react";
+ import { RecommendationCarousel } from "./RecommendationCarousel";
+ import type { Product } from "@/types";
+ 
+ describe("RecommendationCarousel", () => {
+   it("renders a fallback label when variant and size are missing", () => {
+     const products: Product[] = [
+       {
+         id: "prod_1",
+         sku: "TS-001",
+         name: "Classic Tee",
+         basePrice: 2500,
+         stockCount: 100,
+       },
+     ];
+ 
+     render(
+       <RecommendationCarousel
+         products={products}
+         onAddToCart={vi.fn()}
+         onProductClick={vi.fn()}
+       />
+     );
+ 
+     expect(screen.getByText("Standard")).toBeInTheDocument();
+   });
+ });

--- a/src/apps_sdk/web/src/components/RecommendationCarousel.tsx
+++ b/src/apps_sdk/web/src/components/RecommendationCarousel.tsx
@@ -21,6 +21,7 @@ interface ProductCardProps {
 }
 
 function ProductCard({ product, onAddToCart, onProductClick }: ProductCardProps) {
+  const variantLabel = [product.variant, product.size].filter(Boolean).join(" - ");
   const handleAddToCart = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -70,9 +71,7 @@ function ProductCard({ product, onAddToCart, onProductClick }: ProductCardProps)
       <div className="flex flex-1 flex-col gap-0.5 px-2.5 pt-2.5 pb-1.5">
         <h3 className="text-sm font-medium text-text leading-tight truncate">{product.name}</h3>
         <div className="flex items-center justify-between text-[11px] text-text-secondary">
-          <span className="truncate">
-            {product.variant} - {product.size}
-          </span>
+          <span className="truncate">{variantLabel || "Standard"}</span>
           <span className="flex items-center gap-0.5 flex-shrink-0">
             <Star className="h-2.5 w-2.5 text-amber-500" strokeWidth={2} fill="currentColor" /> 4.8
           </span>

--- a/src/apps_sdk/web/src/components/RecommendationSkeleton.test.tsx
+++ b/src/apps_sdk/web/src/components/RecommendationSkeleton.test.tsx
@@ -17,16 +17,16 @@ describe("RecommendationSkeleton", () => {
   it("has proper structure for loading animation", () => {
     const { container } = render(<RecommendationSkeleton />);
     
-    // Check that the main flex container exists
-    const flexContainer = container.querySelector(".flex.gap-3");
-    expect(flexContainer).toBeInTheDocument();
+    // Check that the grid container exists
+    const gridContainer = container.querySelector(".grid.grid-cols-3.gap-3");
+    expect(gridContainer).toBeInTheDocument();
   });
 
   it("contains accessible content placeholders", () => {
     const { container } = render(<RecommendationSkeleton />);
     
     // Check that rounded cards exist
-    const roundedCards = container.querySelectorAll(".rounded-xl");
+    const roundedCards = container.querySelectorAll(".rounded-lg");
     expect(roundedCards.length).toBe(3);
   });
 });

--- a/src/apps_sdk/web/src/main.tsx
+++ b/src/apps_sdk/web/src/main.tsx
@@ -125,12 +125,45 @@ function setupBridgeFromParent(): Promise<void> {
   });
 }
 
+function applyGlobalsUpdate(globals?: Partial<OpenAiGlobals>) {
+  if (!globals) return;
+
+  if (globals.toolOutput) {
+    simulatedToolOutput = globals.toolOutput as ToolOutput;
+  }
+
+  if (!window.openai) {
+    window.openai = createSimulatedOpenAi(globals);
+  } else {
+    window.openai = { ...window.openai, ...globals };
+  }
+
+  window.dispatchEvent(
+    new CustomEvent("openai:set_globals", {
+      detail: { globals: window.openai },
+    })
+  );
+}
+
+function setupUpdateListener() {
+  window.addEventListener("message", (event: MessageEvent) => {
+    if (
+      event.data?.type === "UPDATE_OPENAI_GLOBALS" ||
+      event.data?.type === "INIT_OPENAI_BRIDGE"
+    ) {
+      applyGlobalsUpdate(event.data.globals as Partial<OpenAiGlobals> | undefined);
+    }
+  });
+}
+
 /**
  * Wait for window.openai to be available.
  * In production mode, this is injected by the client agent.
  * In standalone mode, we create a simulated bridge.
  */
 async function initializeBridge(): Promise<void> {
+  setupUpdateListener();
+
   // If real window.openai exists (production mode), use it
   if (window.openai) {
     console.log("[Bridge] Using real window.openai from client agent");

--- a/src/apps_sdk/web/src/types/index.ts
+++ b/src/apps_sdk/web/src/types/index.ts
@@ -168,7 +168,9 @@ export type DisplayMode = "pip" | "inline" | "fullscreen";
 export type Theme = "light" | "dark";
 
 export interface ToolOutput {
+  products?: Product[];
   recommendations?: Product[];
+  error?: string;
   user?: MerchantUser;
   theme?: Theme;
   locale?: string;

--- a/src/ui/components/WebhookToAgentActivityBridge.test.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { WebhookToAgentActivityBridge } from "./WebhookToAgentActivityBridge";
+
+const addPostPurchaseEvent = vi.fn();
+const logEvent = vi.fn(() => "acp_event_1");
+const completeEvent = vi.fn();
+
+vi.mock("@/hooks/useAgentActivityLog", () => ({
+  useAgentActivityLog: () => ({
+    addPostPurchaseEvent,
+  }),
+}));
+
+vi.mock("@/hooks/useACPLog", () => ({
+  useACPLog: () => ({
+    logEvent,
+    completeEvent,
+  }),
+}));
+
+class MockEventSource {
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(url: string) {
+    this.url = url;
+  }
+  close() {
+    // no-op
+  }
+}
+
+describe("WebhookToAgentActivityBridge", () => {
+  beforeEach(() => {
+    addPostPurchaseEvent.mockClear();
+    logEvent.mockClear();
+    completeEvent.mockClear();
+    global.EventSource = MockEventSource as unknown as typeof EventSource;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("processes missed webhook events from polling", async () => {
+    const shippingEvent = {
+      id: "evt_1",
+      type: "shipping_update",
+      receivedAt: new Date().toISOString(),
+      data: {
+        type: "shipping_update",
+        checkout_session_id: "checkout_123",
+        order_id: "order_123",
+        status: "order_shipped",
+        language: "en",
+        subject: "Your order is on the way",
+        message: "Tracking details inside",
+      },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ events: [shippingEvent] }),
+    });
+    global.fetch = fetchMock;
+
+    render(<WebhookToAgentActivityBridge />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      expect(addPostPurchaseEvent).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ui/components/WebhookToAgentActivityBridge.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.tsx
@@ -38,6 +38,7 @@ export function WebhookToAgentActivityBridge() {
   const { addPostPurchaseEvent } = useAgentActivityLog();
   const { logEvent, completeEvent } = useACPLog();
   const seenEventIdsRef = useRef<Set<string>>(new Set());
+  const lastReceivedAtRef = useRef<string | null>(null);
 
   const addPostPurchaseEventRef = useRef(addPostPurchaseEvent);
   const logEventRef = useRef(logEvent);
@@ -52,6 +53,15 @@ export function WebhookToAgentActivityBridge() {
   const processWebhookEvent = useCallback((event: WebhookEvent) => {
     if (seenEventIdsRef.current.has(event.id)) return;
     seenEventIdsRef.current.add(event.id);
+
+    if (event.receivedAt) {
+      if (
+        !lastReceivedAtRef.current ||
+        new Date(event.receivedAt) > new Date(lastReceivedAtRef.current)
+      ) {
+        lastReceivedAtRef.current = event.receivedAt;
+      }
+    }
 
     if (event.type !== "shipping_update" || event.data.type !== "shipping_update") return;
 
@@ -126,13 +136,36 @@ export function WebhookToAgentActivityBridge() {
     });
   }, []);
 
+  const fetchMissedEvents = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (lastReceivedAtRef.current) {
+        params.set("since", lastReceivedAtRef.current);
+      }
+      const response = await fetch(
+        `/api/webhooks/acp${params.toString() ? `?${params.toString()}` : ""}`
+      );
+      if (!response.ok) {
+        return;
+      }
+      const data = await response.json();
+      const events = Array.isArray(data.events) ? data.events : [];
+      events.forEach((event: WebhookEvent) => {
+        processWebhookEvent(event);
+      });
+    } catch {
+      // Ignore fetch errors - SSE will keep trying
+    }
+  }, [processWebhookEvent]);
+
   useEffect(() => {
     let eventSource: EventSource | null = null;
     let reconnectTimeout: NodeJS.Timeout | null = null;
 
     const connect = () => {
+      fetchMissedEvents();
       eventSource = new EventSource("/api/webhooks/sse");
-      eventSource.onmessage = (event) => {
+      eventSource.onmessage = (event: MessageEvent) => {
         try {
           const data = JSON.parse(event.data);
           if (data.type === "heartbeat" || data.type === "connected") return;
@@ -143,6 +176,7 @@ export function WebhookToAgentActivityBridge() {
       };
       eventSource.onerror = () => {
         eventSource?.close();
+        fetchMissedEvents();
         reconnectTimeout = setTimeout(connect, 5000);
       };
     };
@@ -152,7 +186,7 @@ export function WebhookToAgentActivityBridge() {
       eventSource?.close();
       if (reconnectTimeout) clearTimeout(reconnectTimeout);
     };
-  }, [processWebhookEvent]);
+  }, [processWebhookEvent, fetchMissedEvents]);
 
   return null; // No UI - just event dispatching
 }

--- a/src/ui/components/WebhookToAgentActivityBridge.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.tsx
@@ -63,7 +63,7 @@ export function WebhookToAgentActivityBridge() {
       }
     }
 
-    if (event.type !== "shipping_update" || event.data.type !== "shipping_update") return;
+    if (event.type !== "shipping_update") return;
 
     const shippingData = event.data as ShippingUpdateData;
 

--- a/src/ui/components/agent-activity/AgentActivityItem.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.tsx
@@ -10,6 +10,8 @@ import type {
   PostPurchaseDecision,
   RecommendationInputSignals,
   RecommendationDecision,
+  SearchInputSignals,
+  SearchDecision,
 } from "@/types";
 
 /**
@@ -34,6 +36,13 @@ function isRecommendationEvent(event: AgentActivityEvent): event is AgentActivit
   decision?: RecommendationDecision;
 } {
   return event.agentType === "recommendation";
+}
+
+function isSearchEvent(event: AgentActivityEvent): event is AgentActivityEvent & {
+  inputSignals: SearchInputSignals;
+  decision?: SearchDecision;
+} {
+  return event.agentType === "search";
 }
 
 /**
@@ -491,6 +500,157 @@ function RecommendationCard({
 }
 
 /**
+ * Search Card - displays search agent activity
+ */
+function SearchCard({
+  event,
+  isLast,
+}: {
+  event: AgentActivityEvent & {
+    inputSignals: SearchInputSignals;
+    decision?: SearchDecision;
+  };
+  isLast: boolean;
+}) {
+  const isPending = event.status === "pending";
+  const isError = event.status === "error";
+  const resultCount = event.decision?.results?.length ?? 0;
+  const totalResults = event.decision?.totalResults ?? resultCount;
+
+  return (
+    <div style={{ marginBottom: isLast ? 0 : "12px" }}>
+      <div className="glass-decision">
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: "12px",
+          }}
+        >
+          <div
+            className="glass-kicker"
+            style={{ display: "flex", alignItems: "center", gap: "8px" }}
+          >
+            <span
+              style={{
+                width: "24px",
+                height: "24px",
+                borderRadius: "6px",
+                background: isPending
+                  ? "rgba(255, 255, 255, 0.08)"
+                  : isError
+                    ? "rgba(255, 107, 107, 0.15)"
+                    : "rgba(118, 185, 0, 0.15)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <Bot
+                style={{
+                  width: "14px",
+                  height: "14px",
+                  color: isPending
+                    ? "rgba(255, 255, 255, 0.5)"
+                    : isError
+                      ? "#FF6B6B"
+                      : "rgba(118, 185, 0, 0.9)",
+                }}
+              />
+            </span>
+            Search Agent
+          </div>
+          <div className={`glass-pill ${isPending ? "yellow" : isError ? "" : "green"}`}>
+            {isPending ? "Searching" : isError ? "Error" : `${resultCount} items`}
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: "8px",
+            fontSize: "13px",
+            color: "var(--text-secondary)",
+            fontWeight: "650",
+          }}
+        >
+          {event.inputSignals.query}
+        </div>
+
+        {event.decision?.results && event.decision.results.length > 0 && (
+          <div style={{ marginTop: "10px" }}>
+            {event.decision.results.map((result, index) => (
+              <div
+                key={result.productId}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  padding: "6px 0",
+                  borderTop: index === 0 ? "none" : "1px solid rgba(255, 255, 255, 0.06)",
+                }}
+              >
+                <span
+                  style={{
+                    width: "20px",
+                    height: "20px",
+                    borderRadius: "50%",
+                    background: "rgba(118, 185, 0, 0.15)",
+                    color: "rgba(118, 185, 0, 0.9)",
+                    fontSize: "11px",
+                    fontWeight: "600",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  {index + 1}
+                </span>
+                <div style={{ flex: 1 }}>
+                  <div
+                    style={{ fontSize: "12px", fontWeight: "500", color: "var(--text-primary)" }}
+                  >
+                    {result.productName}
+                  </div>
+                </div>
+              </div>
+            ))}
+            {totalResults > resultCount && (
+              <div style={{ marginTop: "8px", fontSize: "11px", color: "var(--text-muted)" }}>
+                {totalResults} total matches
+              </div>
+            )}
+          </div>
+        )}
+
+        {isPending && (
+          <div style={{ color: "var(--text-muted)", fontSize: "12px", marginTop: "10px" }}>
+            Searching catalog for matching products...
+          </div>
+        )}
+
+        {isError && event.error && (
+          <div
+            style={{
+              marginTop: "12px",
+              padding: "10px 12px",
+              borderRadius: "14px",
+              border: "1px solid rgba(255, 107, 107, 0.25)",
+              background: "rgba(255, 107, 107, 0.08)",
+              fontSize: "12px",
+              color: "#FF6B6B",
+            }}
+          >
+            {event.error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
  * Decision Card - displays a single agent decision with glass design
  */
 export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
@@ -506,6 +666,10 @@ export function AgentActivityItem({ event, isLast }: AgentActivityItemProps) {
   // Handle recommendation events with specialized card
   if (isRecommendationEvent(event)) {
     return <RecommendationCard event={event} isLast={isLast} />;
+  }
+
+  if (isSearchEvent(event)) {
+    return <SearchCard event={event} isLast={isLast} />;
   }
 
   // Only process promotion events from here

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -10,6 +10,7 @@ import { StreamingText } from "./StreamingText";
 import { PaymentShippingForm } from "./PaymentShippingForm";
 import { ModeTabSwitcher } from "./ModeTabSwitcher";
 import { MerchantIframeContainer } from "./MerchantIframeContainer";
+import { SearchPromptBar } from "./SearchPromptBar";
 import { useCheckoutFlow } from "@/hooks/useCheckoutFlow";
 import { useACPLog } from "@/hooks/useACPLog";
 import { useAgentActivityLog } from "@/hooks/useAgentActivityLog";
@@ -374,6 +375,12 @@ export function AgentPanel() {
   const [showProducts, setShowProducts] = useState(false);
   const [activeMode, setActiveMode] = useState<CheckoutMode>("native");
   const [notification, setNotification] = useState<WebhookNotification | null>(null);
+  const [appsSdkQuery, setAppsSdkQuery] = useState("");
+  const [appsSdkLastPrompt, setAppsSdkLastPrompt] = useState<ChatMessageType | null>(null);
+  const [appsSdkSearchRequest, setAppsSdkSearchRequest] = useState<{
+    query: string;
+    requestId: number;
+  } | null>(null);
   const acpLog = useACPLog();
   const agentActivityLog = useAgentActivityLog();
 
@@ -463,6 +470,9 @@ export function AgentPanel() {
       if (mode === "apps-sdk") {
         reset();
         setIsModalOpen(false);
+        setAppsSdkQuery("");
+        setAppsSdkLastPrompt(null);
+        setAppsSdkSearchRequest(null);
       }
     },
     [reset, acpLog, agentActivityLog]
@@ -477,6 +487,19 @@ export function AgentPanel() {
     },
     []
   );
+
+  const handleAppsSdkSearch = useCallback((query: string) => {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) return;
+    setAppsSdkLastPrompt({
+      id: `apps-sdk-${Date.now()}`,
+      role: "user",
+      content: trimmedQuery,
+      timestamp: new Date().toISOString(),
+    });
+    setAppsSdkSearchRequest({ query: trimmedQuery, requestId: Date.now() });
+    setAppsSdkQuery("");
+  }, []);
 
   // Handle continue from summary to payment form
   const handleContinueToPayment = useCallback(() => {
@@ -697,16 +720,27 @@ export function AgentPanel() {
       {/* Apps SDK Mode Content */}
       {activeMode === "apps-sdk" && (
         <div className="flex flex-col flex-1 overflow-hidden">
-          {/* Chat bubble - same as native mode */}
-          {messages[0] && (
+          {/* Show user's search query as chat message */}
+          {appsSdkLastPrompt && (
             <div style={{ padding: "24px 32px 16px 32px" }}>
-              <ChatMessage message={messages[0]} />
+              <ChatMessage message={appsSdkLastPrompt} />
             </div>
           )}
-          {/* Spacer between chat bubble and iframe */}
-          <div style={{ height: "12px", flexShrink: 0 }} />
-          {/* Merchant widget iframe */}
-          <MerchantIframeContainer onCheckoutComplete={handleAppsSdkCheckoutComplete} />
+          {/* Search bar */}
+          <div className="pb-3" style={{ paddingLeft: "16px", paddingRight: "16px" }}>
+            <SearchPromptBar
+              value={appsSdkQuery}
+              onChange={setAppsSdkQuery}
+              onSubmit={handleAppsSdkSearch}
+            />
+          </div>
+          {/* Merchant widget iframe - only shown after search */}
+          {appsSdkSearchRequest && (
+            <MerchantIframeContainer
+              onCheckoutComplete={handleAppsSdkCheckoutComplete}
+              searchRequest={appsSdkSearchRequest}
+            />
+          )}
         </div>
       )}
     </section>

--- a/src/ui/components/agent/MerchantIframeContainer.test.tsx
+++ b/src/ui/components/agent/MerchantIframeContainer.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { MerchantIframeContainer } from "./MerchantIframeContainer";
+
+const mockGetWidgetUrl = vi.fn();
+const mockCallToolWithWidget = vi.fn();
+
+vi.mock("@/hooks/useMCPClient", () => ({
+  useMCPClient: () => ({
+    getWidgetUrl: mockGetWidgetUrl,
+    callTool: vi.fn(),
+    callToolWithWidget: mockCallToolWithWidget,
+  }),
+}));
+
+vi.mock("@/hooks/useACPLog", () => ({
+  useACPLog: () => ({
+    logEvent: vi.fn(),
+    completeEvent: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useAgentActivityLog", () => ({
+  useAgentActivityLog: () => ({
+    logAgentCall: vi.fn(() => "agent-event"),
+    completeAgentCall: vi.fn(),
+  }),
+}));
+
+describe("MerchantIframeContainer", () => {
+  beforeEach(() => {
+    mockGetWidgetUrl.mockResolvedValue({
+      widgetUrl: "http://example.com/widget",
+      widgetUri: "ui://widget/merchant-app.html",
+      result: { products: [] },
+      error: null,
+    });
+    mockCallToolWithWidget.mockReset();
+  });
+
+  it("hides the iframe while search loading is active", async () => {
+    vi.useFakeTimers();
+
+    const { rerender, container } = render(
+      <MerchantIframeContainer searchRequest={{ query: "initial", requestId: 1 }} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toBeTruthy();
+
+    await act(async () => {
+      iframe?.dispatchEvent(new Event("load"));
+    });
+
+    const pendingSearch = new Promise(() => {});
+    mockCallToolWithWidget.mockReturnValue(pendingSearch);
+
+    rerender(<MerchantIframeContainer searchRequest={{ query: "dresses", requestId: 2 }} />);
+
+    const updatedIframe = container.querySelector("iframe");
+    expect(updatedIframe).toHaveStyle({ opacity: "0" });
+    expect(container.firstChild).toHaveClass("is-search-loading");
+
+    vi.useRealTimers();
+  });
+});

--- a/src/ui/components/agent/MerchantIframeContainer.tsx
+++ b/src/ui/components/agent/MerchantIframeContainer.tsx
@@ -12,6 +12,8 @@ import type { RecommendationInputSignals, RecommendationDecision } from "@/types
 interface MerchantIframeContainerProps {
   /** Callback when checkout is completed */
   onCheckoutComplete?: (orderId: string) => void;
+  /** Trigger a search request in the widget */
+  searchRequest?: { query: string; requestId: number } | null;
 }
 
 /**
@@ -42,6 +44,11 @@ const LOADING_DELAY_MS = 4000;
 const MIN_RECOMMENDATION_DELAY_MS = 1000;
 
 /**
+ * Minimum delay for search refresh loading animation in milliseconds.
+ */
+const MIN_SEARCH_DELAY_MS = 800;
+
+/**
  * MerchantIframeContainer Component
  *
  * Embeds the merchant widget within the Client Agent panel.
@@ -65,20 +72,29 @@ const MIN_RECOMMENDATION_DELAY_MS = 1000;
  * - Logs Apps SDK events to the Protocol Inspector
  * - No data injection - widget is self-contained
  */
-export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeContainerProps) {
+export function MerchantIframeContainer({
+  onCheckoutComplete,
+  searchRequest,
+}: MerchantIframeContainerProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const mcpCalledRef = useRef(false);
+  const bridgeInitializedRef = useRef(false);
+  const lastSearchRequestIdRef = useRef<number | null>(null);
+  const searchLoadingTokenRef = useRef(0);
+  const latestGlobalsRef = useRef<Record<string, unknown> | null>(null);
   const [isIframeLoaded, setIsIframeLoaded] = useState(false);
   const [isAnimationComplete, setIsAnimationComplete] = useState(false);
+  const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [iframeSrc, setIframeSrc] = useState<string | null>(null);
   const [mcpStatus, setMcpStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [discoveredWidgetUri, setDiscoveredWidgetUri] = useState<string | null>(null);
+  const shouldRevealIframe = isIframeLoaded && !isSearchLoading;
 
   // ACP logging for protocol inspector - extract stable functions only
   const { logEvent, completeEvent } = useACPLog();
 
   // MCP client hook for URL discovery and tool calls
-  const { getWidgetUrl, callTool } = useMCPClient();
+  const { getWidgetUrl, callTool, callToolWithWidget } = useMCPClient();
 
   // Agent activity logging for recommendation events
   const { logAgentCall, completeAgentCall } = useAgentActivityLog();
@@ -93,11 +109,33 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
    * 3. Resolve URI to HTTP URL
    * 4. Load in iframe
    */
-  const initializeMCPWidget = useCallback(async () => {
+  const postGlobalsToIframe = useCallback((globals: Record<string, unknown>, type: string) => {
+    if (!iframeRef.current?.contentWindow) {
+      return;
+    }
+    iframeRef.current.contentWindow.postMessage(
+      {
+        type,
+        globals,
+      },
+      "*"
+    );
+  }, []);
+
+  const initializeMCPWidget = useCallback(async (query: string) => {
     if (mcpCalledRef.current) return;
     mcpCalledRef.current = true;
 
     setMcpStatus("loading");
+
+    const trimmedQuery = query.trim();
+    const searchEventId = logAgentCall("search", {
+      query: trimmedQuery,
+      limit: 3,
+    });
+    const searchLoadingToken = Date.now();
+    searchLoadingTokenRef.current = searchLoadingToken;
+    setIsSearchLoading(true);
 
     // Log MCP tool call - we're calling an actual tool, not just checking health
     const eventId = logEvent(
@@ -109,40 +147,77 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
 
     try {
       // Call MCP tool - widget URL is DISCOVERED from response, not hardcoded
-      const { widgetUrl, widgetUri, error } = await getWidgetUrl();
-
-      if (error) {
-        throw new Error(error);
-      }
+      const { widgetUrl, widgetUri, error, result } = await getWidgetUrl(query, 3);
+      const toolError =
+        error ??
+        (typeof result?.error === "string" ? (result.error as string) : null);
 
       if (widgetUrl && widgetUri) {
         // Successfully discovered widget URL from MCP tool response
         // Include both the discovery and resolution in the completion message
-        completeEvent(eventId, "success", `Discovered: ${widgetUri}`, 200);
+        if (toolError) {
+          completeEvent(eventId, "error", toolError, 500);
+        } else {
+          completeEvent(eventId, "success", `Discovered: ${widgetUri}`, 200);
+        }
 
         setDiscoveredWidgetUri(widgetUri);
         setIframeSrc(widgetUrl);
         setMcpStatus("success");
+
+        const toolOutput =
+          result ?? (toolError ? { error: toolError, products: [] } : null);
+
+        if (toolError) {
+          completeAgentCall(searchEventId, "error", undefined, toolError);
+        } else if (toolOutput) {
+          const productCount = Array.isArray(toolOutput.products)
+            ? toolOutput.products.length
+            : 0;
+          const decision = {
+            results: Array.isArray(toolOutput.products)
+              ? toolOutput.products.map((product: { id?: string; name?: string }) => ({
+                  productId: product.id ?? "",
+                  productName: product.name ?? "Product",
+                }))
+              : [],
+            totalResults:
+              typeof toolOutput.totalResults === "number"
+                ? toolOutput.totalResults
+                : productCount,
+          };
+          completeAgentCall(searchEventId, "success", decision);
+        }
+
+        if (toolOutput) {
+          latestGlobalsRef.current = {
+            toolInput: { query, limit: 3 },
+            toolOutput: toolOutput,
+          };
+        }
       } else {
-        throw new Error("MCP tool did not return widget URI in _meta");
+        throw new Error(toolError ?? "MCP tool did not return widget URI in _meta");
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "MCP tool call failed";
 
       // Complete the original event with error, include fallback info in the message
       completeEvent(eventId, "error", `${errorMessage} → Fallback: ${FALLBACK_WIDGET_URL}`, 500);
+      completeAgentCall(searchEventId, "error", undefined, errorMessage);
 
       setIframeSrc(FALLBACK_WIDGET_URL);
       setMcpStatus("error");
+    } finally {
+      const elapsed = Date.now() - searchLoadingToken;
+      const remaining = MIN_SEARCH_DELAY_MS - elapsed;
+      if (remaining > 0) {
+        await new Promise((resolve) => setTimeout(resolve, remaining));
+      }
+      if (searchLoadingTokenRef.current === searchLoadingToken) {
+        setIsSearchLoading(false);
+      }
     }
-  }, [logEvent, completeEvent, getWidgetUrl]);
-
-  /**
-   * Initialize MCP widget on component mount
-   */
-  useEffect(() => {
-    initializeMCPWidget();
-  }, [initializeMCPWidget]);
+  }, [logAgentCall, completeAgentCall, logEvent, completeEvent, getWidgetUrl]);
 
   /**
    * Handle iframe load event.
@@ -157,7 +232,12 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
     if (isAnimationComplete) {
       setIsIframeLoaded(true);
     }
-  }, [logEvent, completeEvent, isAnimationComplete]);
+
+    if (!bridgeInitializedRef.current && latestGlobalsRef.current) {
+      postGlobalsToIframe(latestGlobalsRef.current, "UPDATE_OPENAI_GLOBALS");
+      bridgeInitializedRef.current = true;
+    }
+  }, [logEvent, completeEvent, isAnimationComplete, postGlobalsToIframe]);
 
   /**
    * Start the loading animation timer when component mounts
@@ -383,8 +463,130 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
     };
   }, [handleMessage]);
 
+  const handleSearchRequest = useCallback(
+    async (query: string) => {
+      const trimmedQuery = query.trim();
+      if (!trimmedQuery) return;
+
+      const searchLoadingToken = Date.now();
+      searchLoadingTokenRef.current = searchLoadingToken;
+      setIsSearchLoading(true);
+
+      const searchEventId = logAgentCall("search", {
+        query: trimmedQuery,
+        limit: 3,
+      });
+
+      const acpEventId = logEvent(
+        "session_update",
+        "POST",
+        "/api/mcp (tools/call: search-products)",
+        `Searching for "${trimmedQuery}"...`
+      );
+
+      try {
+        const { result, error } = await callToolWithWidget("search-products", {
+          query: trimmedQuery,
+          limit: 3,
+        });
+
+        const toolError =
+          error ??
+          (typeof result?.error === "string" ? (result.error as string) : null);
+        const toolOutput =
+          result ?? (toolError ? { error: toolError, products: [] } : null);
+
+        if (toolOutput) {
+          const productCount = Array.isArray(toolOutput.products)
+            ? toolOutput.products.length
+            : 0;
+          const globals = {
+            toolInput: { query: trimmedQuery, limit: 3 },
+            toolOutput: toolOutput,
+          };
+          latestGlobalsRef.current = globals;
+          if (bridgeInitializedRef.current) {
+            postGlobalsToIframe(globals, "UPDATE_OPENAI_GLOBALS");
+          } else {
+            postGlobalsToIframe(globals, "UPDATE_OPENAI_GLOBALS");
+            bridgeInitializedRef.current = true;
+          }
+
+          if (toolError) {
+            completeEvent(acpEventId, "error", toolError, 500);
+            completeAgentCall(searchEventId, "error", undefined, toolError);
+          } else {
+            completeEvent(
+              acpEventId,
+              "success",
+              `Found ${productCount} products`,
+              200
+            );
+            const decision = {
+              results: Array.isArray(toolOutput.products)
+                ? toolOutput.products.map((product: { id?: string; name?: string }) => ({
+                    productId: product.id ?? "",
+                    productName: product.name ?? "Product",
+                  }))
+                : [],
+              totalResults:
+                typeof toolOutput.totalResults === "number"
+                  ? toolOutput.totalResults
+                  : productCount,
+            };
+            completeAgentCall(searchEventId, "success", decision);
+          }
+        } else if (toolError) {
+          throw new Error(toolError);
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Failed to search products";
+        completeEvent(acpEventId, "error", errorMessage, 500);
+        completeAgentCall(searchEventId, "error", undefined, errorMessage);
+      } finally {
+        const elapsed = Date.now() - searchLoadingToken;
+        const remaining = MIN_SEARCH_DELAY_MS - elapsed;
+        if (remaining > 0) {
+          await new Promise((resolve) => setTimeout(resolve, remaining));
+        }
+        if (searchLoadingTokenRef.current === searchLoadingToken) {
+          setIsSearchLoading(false);
+        }
+      }
+    },
+    [
+      callToolWithWidget,
+      logAgentCall,
+      completeAgentCall,
+      logEvent,
+      completeEvent,
+      postGlobalsToIframe,
+    ]
+  );
+
+  useEffect(() => {
+    if (!searchRequest?.query) return;
+    if (searchRequest.requestId === lastSearchRequestIdRef.current) return;
+    lastSearchRequestIdRef.current = searchRequest.requestId;
+
+    if (!mcpCalledRef.current) {
+      initializeMCPWidget(searchRequest.query);
+      return;
+    }
+
+    handleSearchRequest(searchRequest.query);
+  }, [
+    searchRequest?.requestId,
+    searchRequest?.query,
+    initializeMCPWidget,
+    handleSearchRequest,
+  ]);
+
   return (
-    <div className="merchant-iframe-container">
+    <div
+      className={`merchant-iframe-container${isSearchLoading ? " is-search-loading" : ""}`}
+    >
       {/* MCP Status indicator */}
       {mcpStatus === "loading" && (
         <div className="mcp-status">
@@ -406,7 +608,7 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
       )}
 
       {/* Skeleton loader overlay - only render when not loaded */}
-      {!isIframeLoaded && (
+      {(!isIframeLoaded || isSearchLoading) && (
         <div className="loader">
           <div className="topbar">
             <div className="pill shimmer"></div>
@@ -436,7 +638,7 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
               <span className="dot"></span>
               <span className="dot"></span>
             </span>
-            <span>Loading...</span>
+            <span>{isSearchLoading ? "Refreshing results..." : "Loading..."}</span>
           </div>
         </div>
       )}
@@ -448,9 +650,11 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
           src={iframeSrc}
           title="Merchant Widget"
           style={{
-            opacity: isIframeLoaded ? 1 : 0,
-            transform: isIframeLoaded ? "scale(1)" : "scale(0.995)",
-            filter: isIframeLoaded ? "none" : "saturate(0.98)",
+            opacity: shouldRevealIframe ? 1 : 0,
+            transform: shouldRevealIframe ? "scale(1)" : "scale(0.995)",
+            filter: shouldRevealIframe ? "none" : "saturate(0.98)",
+            visibility: shouldRevealIframe ? "visible" : "hidden",
+            pointerEvents: shouldRevealIframe ? "auto" : "none",
           }}
           className="merchant-iframe"
           onLoad={handleIframeLoad}
@@ -557,7 +761,7 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
           flex: 1;
           width: 100%;
           border: none;
-          background: transparent;
+          background: #1a1a1a;
           transition:
             opacity 220ms ease,
             transform 220ms ease,
@@ -576,7 +780,7 @@ export function MerchantIframeContainer({ onCheckoutComplete }: MerchantIframeCo
           pointer-events: none;
           opacity: 1;
           transition: opacity 200ms ease;
-          background: linear-gradient(to bottom, rgba(26, 26, 26, 0.95), rgba(26, 26, 26, 0.88));
+          background: linear-gradient(to bottom, rgba(26, 26, 26, 0.98), rgba(26, 26, 26, 0.96));
           animation: breathe 1.6s ease-in-out infinite;
           z-index: 10;
         }

--- a/src/ui/components/agent/MerchantIframeContainer.tsx
+++ b/src/ui/components/agent/MerchantIframeContainer.tsx
@@ -122,102 +122,103 @@ export function MerchantIframeContainer({
     );
   }, []);
 
-  const initializeMCPWidget = useCallback(async (query: string) => {
-    if (mcpCalledRef.current) return;
-    mcpCalledRef.current = true;
+  const initializeMCPWidget = useCallback(
+    async (query: string) => {
+      if (mcpCalledRef.current) return;
+      mcpCalledRef.current = true;
 
-    setMcpStatus("loading");
+      setMcpStatus("loading");
 
-    const trimmedQuery = query.trim();
-    const searchEventId = logAgentCall("search", {
-      query: trimmedQuery,
-      limit: 3,
-    });
-    const searchLoadingToken = Date.now();
-    searchLoadingTokenRef.current = searchLoadingToken;
-    setIsSearchLoading(true);
+      const trimmedQuery = query.trim();
+      const searchEventId = logAgentCall("search", {
+        query: trimmedQuery,
+        limit: 3,
+      });
+      const searchLoadingToken = Date.now();
+      searchLoadingTokenRef.current = searchLoadingToken;
+      setIsSearchLoading(true);
 
-    // Log MCP tool call - we're calling an actual tool, not just checking health
-    const eventId = logEvent(
-      "session_create",
-      "POST",
-      "/api/mcp (tools/call: search-products)",
-      "Calling MCP tool to discover widget URI"
-    );
+      // Log MCP tool call - we're calling an actual tool, not just checking health
+      const eventId = logEvent(
+        "session_create",
+        "POST",
+        "/api/mcp (tools/call: search-products)",
+        "Calling MCP tool to discover widget URI"
+      );
 
-    try {
-      // Call MCP tool - widget URL is DISCOVERED from response, not hardcoded
-      const { widgetUrl, widgetUri, error, result } = await getWidgetUrl(query, 3);
-      const toolError =
-        error ??
-        (typeof result?.error === "string" ? (result.error as string) : null);
+      try {
+        // Call MCP tool - widget URL is DISCOVERED from response, not hardcoded
+        const { widgetUrl, widgetUri, error, result } = await getWidgetUrl(query, 3);
+        const toolError =
+          error ?? (typeof result?.error === "string" ? (result.error as string) : null);
 
-      if (widgetUrl && widgetUri) {
-        // Successfully discovered widget URL from MCP tool response
-        // Include both the discovery and resolution in the completion message
-        if (toolError) {
-          completeEvent(eventId, "error", toolError, 500);
+        if (widgetUrl && widgetUri) {
+          // Successfully discovered widget URL from MCP tool response
+          // Include both the discovery and resolution in the completion message
+          if (toolError) {
+            completeEvent(eventId, "error", toolError, 500);
+          } else {
+            completeEvent(eventId, "success", `Discovered: ${widgetUri}`, 200);
+          }
+
+          setDiscoveredWidgetUri(widgetUri);
+          setIframeSrc(widgetUrl);
+          setMcpStatus("success");
+
+          const toolOutput = result ?? (toolError ? { error: toolError, products: [] } : null);
+
+          if (toolError) {
+            completeAgentCall(searchEventId, "error", undefined, toolError);
+          } else if (toolOutput) {
+            const productCount = Array.isArray(toolOutput.products)
+              ? toolOutput.products.length
+              : 0;
+            const decision = {
+              results: Array.isArray(toolOutput.products)
+                ? toolOutput.products.map((product: { id?: string; name?: string }) => ({
+                    productId: product.id ?? "",
+                    productName: product.name ?? "Product",
+                  }))
+                : [],
+              totalResults:
+                typeof toolOutput.totalResults === "number"
+                  ? toolOutput.totalResults
+                  : productCount,
+            };
+            completeAgentCall(searchEventId, "success", decision);
+          }
+
+          if (toolOutput) {
+            latestGlobalsRef.current = {
+              toolInput: { query, limit: 3 },
+              toolOutput: toolOutput,
+            };
+          }
         } else {
-          completeEvent(eventId, "success", `Discovered: ${widgetUri}`, 200);
+          throw new Error(toolError ?? "MCP tool did not return widget URI in _meta");
         }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "MCP tool call failed";
 
-        setDiscoveredWidgetUri(widgetUri);
-        setIframeSrc(widgetUrl);
-        setMcpStatus("success");
+        // Complete the original event with error, include fallback info in the message
+        completeEvent(eventId, "error", `${errorMessage} → Fallback: ${FALLBACK_WIDGET_URL}`, 500);
+        completeAgentCall(searchEventId, "error", undefined, errorMessage);
 
-        const toolOutput =
-          result ?? (toolError ? { error: toolError, products: [] } : null);
-
-        if (toolError) {
-          completeAgentCall(searchEventId, "error", undefined, toolError);
-        } else if (toolOutput) {
-          const productCount = Array.isArray(toolOutput.products)
-            ? toolOutput.products.length
-            : 0;
-          const decision = {
-            results: Array.isArray(toolOutput.products)
-              ? toolOutput.products.map((product: { id?: string; name?: string }) => ({
-                  productId: product.id ?? "",
-                  productName: product.name ?? "Product",
-                }))
-              : [],
-            totalResults:
-              typeof toolOutput.totalResults === "number"
-                ? toolOutput.totalResults
-                : productCount,
-          };
-          completeAgentCall(searchEventId, "success", decision);
+        setIframeSrc(FALLBACK_WIDGET_URL);
+        setMcpStatus("error");
+      } finally {
+        const elapsed = Date.now() - searchLoadingToken;
+        const remaining = MIN_SEARCH_DELAY_MS - elapsed;
+        if (remaining > 0) {
+          await new Promise((resolve) => setTimeout(resolve, remaining));
         }
-
-        if (toolOutput) {
-          latestGlobalsRef.current = {
-            toolInput: { query, limit: 3 },
-            toolOutput: toolOutput,
-          };
+        if (searchLoadingTokenRef.current === searchLoadingToken) {
+          setIsSearchLoading(false);
         }
-      } else {
-        throw new Error(toolError ?? "MCP tool did not return widget URI in _meta");
       }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "MCP tool call failed";
-
-      // Complete the original event with error, include fallback info in the message
-      completeEvent(eventId, "error", `${errorMessage} → Fallback: ${FALLBACK_WIDGET_URL}`, 500);
-      completeAgentCall(searchEventId, "error", undefined, errorMessage);
-
-      setIframeSrc(FALLBACK_WIDGET_URL);
-      setMcpStatus("error");
-    } finally {
-      const elapsed = Date.now() - searchLoadingToken;
-      const remaining = MIN_SEARCH_DELAY_MS - elapsed;
-      if (remaining > 0) {
-        await new Promise((resolve) => setTimeout(resolve, remaining));
-      }
-      if (searchLoadingTokenRef.current === searchLoadingToken) {
-        setIsSearchLoading(false);
-      }
-    }
-  }, [logAgentCall, completeAgentCall, logEvent, completeEvent, getWidgetUrl]);
+    },
+    [logAgentCall, completeAgentCall, logEvent, completeEvent, getWidgetUrl]
+  );
 
   /**
    * Handle iframe load event.
@@ -491,15 +492,11 @@ export function MerchantIframeContainer({
         });
 
         const toolError =
-          error ??
-          (typeof result?.error === "string" ? (result.error as string) : null);
-        const toolOutput =
-          result ?? (toolError ? { error: toolError, products: [] } : null);
+          error ?? (typeof result?.error === "string" ? (result.error as string) : null);
+        const toolOutput = result ?? (toolError ? { error: toolError, products: [] } : null);
 
         if (toolOutput) {
-          const productCount = Array.isArray(toolOutput.products)
-            ? toolOutput.products.length
-            : 0;
+          const productCount = Array.isArray(toolOutput.products) ? toolOutput.products.length : 0;
           const globals = {
             toolInput: { query: trimmedQuery, limit: 3 },
             toolOutput: toolOutput,
@@ -516,12 +513,7 @@ export function MerchantIframeContainer({
             completeEvent(acpEventId, "error", toolError, 500);
             completeAgentCall(searchEventId, "error", undefined, toolError);
           } else {
-            completeEvent(
-              acpEventId,
-              "success",
-              `Found ${productCount} products`,
-              200
-            );
+            completeEvent(acpEventId, "success", `Found ${productCount} products`, 200);
             const decision = {
               results: Array.isArray(toolOutput.products)
                 ? toolOutput.products.map((product: { id?: string; name?: string }) => ({
@@ -540,8 +532,7 @@ export function MerchantIframeContainer({
           throw new Error(toolError);
         }
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : "Failed to search products";
+        const errorMessage = error instanceof Error ? error.message : "Failed to search products";
         completeEvent(acpEventId, "error", errorMessage, 500);
         completeAgentCall(searchEventId, "error", undefined, errorMessage);
       } finally {
@@ -576,17 +567,10 @@ export function MerchantIframeContainer({
     }
 
     handleSearchRequest(searchRequest.query);
-  }, [
-    searchRequest?.requestId,
-    searchRequest?.query,
-    initializeMCPWidget,
-    handleSearchRequest,
-  ]);
+  }, [searchRequest?.requestId, searchRequest?.query, initializeMCPWidget, handleSearchRequest]);
 
   return (
-    <div
-      className={`merchant-iframe-container${isSearchLoading ? " is-search-loading" : ""}`}
-    >
+    <div className={`merchant-iframe-container${isSearchLoading ? " is-search-loading" : ""}`}>
       {/* MCP Status indicator */}
       {mcpStatus === "loading" && (
         <div className="mcp-status">

--- a/src/ui/components/agent/SearchPromptBar.test.tsx
+++ b/src/ui/components/agent/SearchPromptBar.test.tsx
@@ -1,0 +1,53 @@
+ import { describe, it, expect, vi } from "vitest";
+ import { render, screen, fireEvent } from "@testing-library/react";
+ import { SearchPromptBar } from "./SearchPromptBar";
+ 
+ describe("SearchPromptBar", () => {
+   it("renders input and button", () => {
+     render(
+       <SearchPromptBar value="" onChange={vi.fn()} onSubmit={vi.fn()} />
+     );
+ 
+     expect(screen.getByLabelText("Search query")).toBeInTheDocument();
+     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+   });
+ 
+   it("calls onChange when typing", () => {
+     const onChange = vi.fn();
+     render(<SearchPromptBar value="" onChange={onChange} onSubmit={vi.fn()} />);
+ 
+     const input = screen.getByLabelText("Search query");
+     fireEvent.change(input, { target: { value: "graphic tee" } });
+ 
+     expect(onChange).toHaveBeenCalledWith("graphic tee");
+   });
+ 
+   it("calls onSubmit with current value", () => {
+     const onSubmit = vi.fn();
+     render(
+       <SearchPromptBar value="summer tee" onChange={vi.fn()} onSubmit={onSubmit} />
+     );
+ 
+     fireEvent.submit(screen.getByLabelText("Search products"));
+ 
+     expect(onSubmit).toHaveBeenCalledWith("summer tee");
+   });
+ 
+   it("disables submit button when input is empty", () => {
+     render(
+       <SearchPromptBar value=" " onChange={vi.fn()} onSubmit={vi.fn()} />
+     );
+ 
+     expect(screen.getByRole("button", { name: "Search" })).toBeDisabled();
+   });
+
+  it("uses Kaizen button styling and padded layout", () => {
+    render(<SearchPromptBar value="" onChange={vi.fn()} onSubmit={vi.fn()} />);
+
+    const button = screen.getByRole("button", { name: "Search" });
+    expect(button).toHaveClass("nv-button");
+    expect(button).toHaveClass("nv-button--primary");
+    expect(button).toHaveClass("nv-button--brand");
+
+  });
+ });

--- a/src/ui/components/agent/SearchPromptBar.test.tsx
+++ b/src/ui/components/agent/SearchPromptBar.test.tsx
@@ -1,45 +1,39 @@
- import { describe, it, expect, vi } from "vitest";
- import { render, screen, fireEvent } from "@testing-library/react";
- import { SearchPromptBar } from "./SearchPromptBar";
- 
- describe("SearchPromptBar", () => {
-   it("renders input and button", () => {
-     render(
-       <SearchPromptBar value="" onChange={vi.fn()} onSubmit={vi.fn()} />
-     );
- 
-     expect(screen.getByLabelText("Search query")).toBeInTheDocument();
-     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
-   });
- 
-   it("calls onChange when typing", () => {
-     const onChange = vi.fn();
-     render(<SearchPromptBar value="" onChange={onChange} onSubmit={vi.fn()} />);
- 
-     const input = screen.getByLabelText("Search query");
-     fireEvent.change(input, { target: { value: "graphic tee" } });
- 
-     expect(onChange).toHaveBeenCalledWith("graphic tee");
-   });
- 
-   it("calls onSubmit with current value", () => {
-     const onSubmit = vi.fn();
-     render(
-       <SearchPromptBar value="summer tee" onChange={vi.fn()} onSubmit={onSubmit} />
-     );
- 
-     fireEvent.submit(screen.getByLabelText("Search products"));
- 
-     expect(onSubmit).toHaveBeenCalledWith("summer tee");
-   });
- 
-   it("disables submit button when input is empty", () => {
-     render(
-       <SearchPromptBar value=" " onChange={vi.fn()} onSubmit={vi.fn()} />
-     );
- 
-     expect(screen.getByRole("button", { name: "Search" })).toBeDisabled();
-   });
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SearchPromptBar } from "./SearchPromptBar";
+
+describe("SearchPromptBar", () => {
+  it("renders input and button", () => {
+    render(<SearchPromptBar value="" onChange={vi.fn()} onSubmit={vi.fn()} />);
+
+    expect(screen.getByLabelText("Search query")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+  });
+
+  it("calls onChange when typing", () => {
+    const onChange = vi.fn();
+    render(<SearchPromptBar value="" onChange={onChange} onSubmit={vi.fn()} />);
+
+    const input = screen.getByLabelText("Search query");
+    fireEvent.change(input, { target: { value: "graphic tee" } });
+
+    expect(onChange).toHaveBeenCalledWith("graphic tee");
+  });
+
+  it("calls onSubmit with current value", () => {
+    const onSubmit = vi.fn();
+    render(<SearchPromptBar value="summer tee" onChange={vi.fn()} onSubmit={onSubmit} />);
+
+    fireEvent.submit(screen.getByLabelText("Search products"));
+
+    expect(onSubmit).toHaveBeenCalledWith("summer tee");
+  });
+
+  it("disables submit button when input is empty", () => {
+    render(<SearchPromptBar value=" " onChange={vi.fn()} onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Search" })).toBeDisabled();
+  });
 
   it("uses Kaizen button styling and padded layout", () => {
     render(<SearchPromptBar value="" onChange={vi.fn()} onSubmit={vi.fn()} />);
@@ -48,6 +42,5 @@
     expect(button).toHaveClass("nv-button");
     expect(button).toHaveClass("nv-button--primary");
     expect(button).toHaveClass("nv-button--brand");
-
   });
- });
+});

--- a/src/ui/components/agent/SearchPromptBar.tsx
+++ b/src/ui/components/agent/SearchPromptBar.tsx
@@ -1,0 +1,60 @@
+ "use client";
+ 
+import { useCallback } from "react";
+import type { ChangeEvent, FormEvent } from "react";
+ 
+ interface SearchPromptBarProps {
+   value: string;
+   onChange: (value: string) => void;
+   onSubmit: (value: string) => void;
+ }
+ 
+export function SearchPromptBar({
+  value,
+  onChange,
+  onSubmit,
+}: SearchPromptBarProps) {
+   const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+       event.preventDefault();
+      if (value.trim().length === 0) return;
+       onSubmit(value);
+     },
+     [onSubmit, value]
+   );
+ 
+   const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+       onChange(event.target.value);
+     },
+     [onChange]
+   );
+ 
+   const isDisabled = value.trim().length === 0;
+ 
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex w-full items-center gap-2"
+      aria-label="Search products"
+    >
+      <div className="nv-input nv-text-input-root flex-1">
+        <input
+          type="search"
+          value={value}
+          onChange={handleChange}
+          placeholder="Search for products..."
+          className="nv-text-input-element px-4"
+          aria-label="Search query"
+        />
+      </div>
+      <button
+        type="submit"
+        className="nv-button nv-button--primary nv-button--brand text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={isDisabled}
+      >
+        Search
+      </button>
+    </form>
+  );
+ }

--- a/src/ui/components/agent/SearchPromptBar.tsx
+++ b/src/ui/components/agent/SearchPromptBar.tsx
@@ -1,37 +1,33 @@
- "use client";
- 
+"use client";
+
 import { useCallback } from "react";
 import type { ChangeEvent, FormEvent } from "react";
- 
- interface SearchPromptBarProps {
-   value: string;
-   onChange: (value: string) => void;
-   onSubmit: (value: string) => void;
- }
- 
-export function SearchPromptBar({
-  value,
-  onChange,
-  onSubmit,
-}: SearchPromptBarProps) {
-   const handleSubmit = useCallback(
+
+interface SearchPromptBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+}
+
+export function SearchPromptBar({ value, onChange, onSubmit }: SearchPromptBarProps) {
+  const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
-       event.preventDefault();
+      event.preventDefault();
       if (value.trim().length === 0) return;
-       onSubmit(value);
-     },
-     [onSubmit, value]
-   );
- 
-   const handleChange = useCallback(
+      onSubmit(value);
+    },
+    [onSubmit, value]
+  );
+
+  const handleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-       onChange(event.target.value);
-     },
-     [onChange]
-   );
- 
-   const isDisabled = value.trim().length === 0;
- 
+      onChange(event.target.value);
+    },
+    [onChange]
+  );
+
+  const isDisabled = value.trim().length === 0;
+
   return (
     <form
       onSubmit={handleSubmit}
@@ -57,4 +53,4 @@ export function SearchPromptBar({
       </button>
     </form>
   );
- }
+}

--- a/src/ui/hooks/useMCPClient.ts
+++ b/src/ui/hooks/useMCPClient.ts
@@ -166,7 +166,7 @@ export function useMCPClient() {
         const contentErrorText = mcpResponse.result?.content?.[0]?.text;
         const toolErrorMessage =
           mcpResponse.result?.isError || errorFromStructured
-            ? errorFromStructured ?? contentErrorText ?? "Tool call failed"
+            ? (errorFromStructured ?? contentErrorText ?? "Tool call failed")
             : null;
 
         // Extract widget URI from _meta.openai/outputTemplate
@@ -298,7 +298,7 @@ export function useMCPClient() {
         const contentErrorText = mcpResponse.result?.content?.[0]?.text;
         const toolErrorMessage =
           mcpResponse.result?.isError || errorFromStructured
-            ? errorFromStructured ?? contentErrorText ?? "Tool call failed"
+            ? (errorFromStructured ?? contentErrorText ?? "Tool call failed")
             : null;
 
         if (toolErrorMessage) {

--- a/src/ui/hooks/useMCPClient.ts
+++ b/src/ui/hooks/useMCPClient.ts
@@ -28,6 +28,7 @@ interface MCPToolResponse {
   result?: {
     content?: Array<{ type: string; text: string }>;
     structuredContent?: Record<string, unknown>;
+    isError?: boolean;
     _meta?: {
       "openai/outputTemplate"?: string;
       "openai/widgetAccessible"?: boolean;
@@ -155,6 +156,19 @@ export function useMCPClient() {
           throw new Error(`MCP error: ${mcpResponse.error.message}`);
         }
 
+        const structuredContent = mcpResponse.result?.structuredContent || null;
+        const errorFromStructured =
+          structuredContent &&
+          typeof structuredContent === "object" &&
+          typeof (structuredContent as { error?: unknown }).error === "string"
+            ? (structuredContent as { error: string }).error
+            : null;
+        const contentErrorText = mcpResponse.result?.content?.[0]?.text;
+        const toolErrorMessage =
+          mcpResponse.result?.isError || errorFromStructured
+            ? errorFromStructured ?? contentErrorText ?? "Tool call failed"
+            : null;
+
         // Extract widget URI from _meta.openai/outputTemplate
         const meta = mcpResponse.result?._meta;
         const widgetUri = meta?.["openai/outputTemplate"] || null;
@@ -170,17 +184,17 @@ export function useMCPClient() {
 
         setState({
           isLoading: false,
-          error: null,
+          error: toolErrorMessage,
           widgetUrl,
           widgetUri,
-          toolResult: mcpResponse.result?.structuredContent || null,
+          toolResult: structuredContent,
         });
 
         return {
           widgetUrl,
           widgetUri,
-          result: mcpResponse.result?.structuredContent || null,
-          error: null,
+          result: structuredContent,
+          error: toolErrorMessage,
         };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "MCP call failed";
@@ -274,8 +288,25 @@ export function useMCPClient() {
           throw new Error(`MCP error: ${mcpResponse.error.message}`);
         }
 
-        console.log("[MCP] Returning structuredContent:", mcpResponse.result?.structuredContent);
-        return mcpResponse.result?.structuredContent || null;
+        const structuredContent = mcpResponse.result?.structuredContent || null;
+        const errorFromStructured =
+          structuredContent &&
+          typeof structuredContent === "object" &&
+          typeof (structuredContent as { error?: unknown }).error === "string"
+            ? (structuredContent as { error: string }).error
+            : null;
+        const contentErrorText = mcpResponse.result?.content?.[0]?.text;
+        const toolErrorMessage =
+          mcpResponse.result?.isError || errorFromStructured
+            ? errorFromStructured ?? contentErrorText ?? "Tool call failed"
+            : null;
+
+        if (toolErrorMessage) {
+          throw new Error(toolErrorMessage);
+        }
+
+        console.log("[MCP] Returning structuredContent:", structuredContent);
+        return structuredContent;
       } catch (error) {
         console.error("MCP tool call failed:", error);
         throw error;
@@ -292,8 +323,8 @@ export function useMCPClient() {
    * returns products and exposes the widget URI in _meta.openai/outputTemplate.
    */
   const getWidgetUrl = useCallback(
-    async (query: string = "tee") => {
-      return callTool("search-products", { query, limit: 10 });
+    async (query: string = "tee", limit: number = 3) => {
+      return callTool("search-products", { query, limit });
     },
     [callTool]
   );

--- a/src/ui/lib/webhook-emitter.ts
+++ b/src/ui/lib/webhook-emitter.ts
@@ -90,4 +90,5 @@ const globalForWebhook = globalThis as typeof globalThis & {
 // Export the singleton instance using globalThis for true global singleton
 // This ensures the same instance is shared across all Next.js API routes
 export const webhookEmitter =
-  globalForWebhook[WEBHOOK_EMITTER_KEY] ?? (globalForWebhook[WEBHOOK_EMITTER_KEY] = new WebhookEventEmitter());
+  globalForWebhook[WEBHOOK_EMITTER_KEY] ??
+  (globalForWebhook[WEBHOOK_EMITTER_KEY] = new WebhookEventEmitter());

--- a/src/ui/lib/webhook-emitter.ts
+++ b/src/ui/lib/webhook-emitter.ts
@@ -47,23 +47,17 @@ export interface ShippingUpdateData {
  * Global webhook event emitter singleton.
  * Uses Node.js EventEmitter for simplicity.
  *
+ * IMPORTANT: Uses globalThis to ensure true singleton across Next.js App Router
+ * API routes, which can have separate module instances due to code splitting.
+ *
  * Note: In a production multi-instance setup, you'd use Redis Pub/Sub
  * or a similar distributed messaging system.
  */
 class WebhookEventEmitter extends EventEmitter {
-  private static instance: WebhookEventEmitter;
-
-  private constructor() {
+  constructor() {
     super();
     // Increase max listeners to avoid warnings with many SSE connections
     this.setMaxListeners(100);
-  }
-
-  static getInstance(): WebhookEventEmitter {
-    if (!WebhookEventEmitter.instance) {
-      WebhookEventEmitter.instance = new WebhookEventEmitter();
-    }
-    return WebhookEventEmitter.instance;
   }
 
   /**
@@ -85,5 +79,15 @@ class WebhookEventEmitter extends EventEmitter {
   }
 }
 
-// Export the singleton instance
-export const webhookEmitter = WebhookEventEmitter.getInstance();
+// Use Symbol.for to get a global key that persists across module instances
+const WEBHOOK_EMITTER_KEY = Symbol.for("acp.webhook-emitter");
+
+// Type augmentation for globalThis
+const globalForWebhook = globalThis as typeof globalThis & {
+  [WEBHOOK_EMITTER_KEY]?: WebhookEventEmitter;
+};
+
+// Export the singleton instance using globalThis for true global singleton
+// This ensures the same instance is shared across all Next.js API routes
+export const webhookEmitter =
+  globalForWebhook[WEBHOOK_EMITTER_KEY] ?? (globalForWebhook[WEBHOOK_EMITTER_KEY] = new WebhookEventEmitter());

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -638,7 +638,7 @@ export interface ACPRequest {
 /**
  * Agent types for activity logging
  */
-export type AgentType = "promotion" | "recommendation" | "post_purchase";
+export type AgentType = "promotion" | "recommendation" | "post_purchase" | "search";
 
 /**
  * Agent activity event status
@@ -729,17 +729,46 @@ export interface RecommendationDecision {
 }
 
 /**
+ * Input signals for search agent
+ */
+export interface SearchInputSignals {
+  query: string;
+  limit: number;
+}
+
+/**
+ * Search result item
+ */
+export interface SearchResultItem {
+  productId: string;
+  productName: string;
+}
+
+/**
+ * Search decision from agent
+ */
+export interface SearchDecision {
+  results: SearchResultItem[];
+  totalResults: number;
+}
+
+/**
  * Union type for agent input signals
  */
 export type AgentInputSignals =
   | PromotionInputSignals
   | PostPurchaseInputSignals
-  | RecommendationInputSignals;
+  | RecommendationInputSignals
+  | SearchInputSignals;
 
 /**
  * Union type for agent decisions
  */
-export type AgentDecision = PromotionDecision | PostPurchaseDecision | RecommendationDecision;
+export type AgentDecision =
+  | PromotionDecision
+  | PostPurchaseDecision
+  | RecommendationDecision
+  | SearchDecision;
 
 /**
  * Agent activity event for the activity panel

--- a/tests/apps_sdk/conftest.py
+++ b/tests/apps_sdk/conftest.py
@@ -1,12 +1,53 @@
 """Pytest configuration and fixtures for Apps SDK tests."""
 
 from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from src.apps_sdk.main import app
 from src.apps_sdk.tools.cart import carts
+
+# Mock products that match the expected schema from merchant API
+MOCK_PRODUCTS: dict[str, dict[str, Any]] = {
+    "prod_1": {
+        "id": "prod_1",
+        "sku": "TS-001",
+        "name": "Classic White Tee",
+        "base_price": 2500,
+        "stock_count": 100,
+        "category": "tops",
+        "description": "A classic white t-shirt",
+        "image_url": "/prod_1.jpeg",
+    },
+    "prod_2": {
+        "id": "prod_2",
+        "sku": "TS-002",
+        "name": "Navy Blue Polo",
+        "base_price": 3500,
+        "stock_count": 50,
+        "category": "tops",
+        "description": "A navy blue polo shirt",
+        "image_url": "/prod_2.jpeg",
+    },
+    "prod_3": {
+        "id": "prod_3",
+        "sku": "TS-003",
+        "name": "Black Hoodie",
+        "base_price": 4500,
+        "stock_count": 30,
+        "category": "outerwear",
+        "description": "A comfortable black hoodie",
+        "image_url": "/prod_3.jpeg",
+    },
+}
+
+
+async def mock_find_product(product_id: str) -> dict[str, Any] | None:
+    """Mock find_product that returns from MOCK_PRODUCTS."""
+    return MOCK_PRODUCTS.get(product_id)
 
 
 @pytest.fixture(autouse=True)
@@ -18,6 +59,19 @@ def reset_cart_storage() -> Generator[None, None, None]:
     carts.clear()
     yield
     carts.clear()
+
+
+@pytest.fixture(autouse=True)
+def mock_merchant_api() -> Generator[None, None, None]:
+    """Mock the merchant API calls for cart operations.
+
+    This prevents actual HTTP calls during tests.
+    """
+    with patch(
+        "src.apps_sdk.tools.cart.find_product",
+        new=AsyncMock(side_effect=mock_find_product),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/apps_sdk/conftest.py
+++ b/tests/apps_sdk/conftest.py
@@ -10,37 +10,37 @@ from fastapi.testclient import TestClient
 from src.apps_sdk.main import app
 from src.apps_sdk.tools.cart import carts
 
-# Mock products that match the expected schema from merchant API
+# Mock products that match the normalized schema from find_product (camelCase)
 MOCK_PRODUCTS: dict[str, dict[str, Any]] = {
     "prod_1": {
         "id": "prod_1",
         "sku": "TS-001",
         "name": "Classic White Tee",
-        "base_price": 2500,
-        "stock_count": 100,
+        "basePrice": 2500,
+        "stockCount": 100,
         "category": "tops",
         "description": "A classic white t-shirt",
-        "image_url": "/prod_1.jpeg",
+        "imageUrl": "/prod_1.jpeg",
     },
     "prod_2": {
         "id": "prod_2",
         "sku": "TS-002",
         "name": "Navy Blue Polo",
-        "base_price": 3500,
-        "stock_count": 50,
+        "basePrice": 3500,
+        "stockCount": 50,
         "category": "tops",
         "description": "A navy blue polo shirt",
-        "image_url": "/prod_2.jpeg",
+        "imageUrl": "/prod_2.jpeg",
     },
     "prod_3": {
         "id": "prod_3",
         "sku": "TS-003",
         "name": "Black Hoodie",
-        "base_price": 4500,
-        "stock_count": 30,
+        "basePrice": 4500,
+        "stockCount": 30,
         "category": "outerwear",
         "description": "A comfortable black hoodie",
-        "image_url": "/prod_3.jpeg",
+        "imageUrl": "/prod_3.jpeg",
     },
 }
 

--- a/tests/apps_sdk/test_recommendations.py
+++ b/tests/apps_sdk/test_recommendations.py
@@ -8,6 +8,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -306,3 +307,62 @@ class TestGetRecommendationsOutput:
 
         assert data["recommendations"] == []
         assert data["error"] == "Agent unavailable"
+
+
+class TestCallSearchAgent:
+    """Tests for the call_search_agent function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_search_results(self) -> None:
+        """Agent returns parsed search results."""
+        from src.apps_sdk.tools.recommendations import call_search_agent
+
+        mock_response = {
+            "value": json.dumps(
+                {
+                    "query": "summer tee",
+                    "results": [
+                        {
+                            "product_id": "prod_1",
+                            "product_name": "Classic Tee",
+                            "snippet": "Lightweight summer essential",
+                        }
+                    ],
+                }
+            )
+        }
+
+        mock_http_response = MagicMock()
+        mock_http_response.status_code = 200
+        mock_http_response.json.return_value = mock_response
+        mock_http_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.post.return_value = mock_http_response
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await call_search_agent(query="summer tee", category=None, limit=3)
+
+        assert result["query"] == "summer tee"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["product_id"] == "prod_1"
+
+    @pytest.mark.asyncio
+    async def test_search_agent_timeout_returns_error(self) -> None:
+        """Timeout returns empty results with error message."""
+        from src.apps_sdk.tools.recommendations import call_search_agent
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.post.side_effect = httpx.TimeoutException("Timeout")
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_instance
+
+            result = await call_search_agent(query="summer tee", category=None, limit=3)
+
+        assert result["results"] == []
+        assert "timeout" in result["error"].lower()

--- a/tests/apps_sdk/test_tools.py
+++ b/tests/apps_sdk/test_tools.py
@@ -22,10 +22,7 @@ from src.apps_sdk.tools.cart import (
     update_cart_quantity,
 )
 from src.apps_sdk.tools.checkout import checkout
-from src.apps_sdk.tools.recommendations import (
-    CATALOG_PRODUCTS,
-    search_products,
-)
+from src.apps_sdk.tools.recommendations import search_products
 
 # =============================================================================
 # SEARCH PRODUCTS TESTS (Entry Point MCP Tool)
@@ -103,9 +100,7 @@ class TestSearchProducts:
     @pytest.mark.asyncio
     async def test_search_max_limit_is_50(self) -> None:
         """Search clamps limit to maximum of 50."""
-        items = [
-            {"product_id": CATALOG_PRODUCTS[0]["id"], "score": 0.4} for _ in range(60)
-        ]
+        items = [{"product_id": "prod_1", "score": 0.4} for _ in range(60)]
         with patch(
             "src.apps_sdk.tools.recommendations.call_search_agent",
             new=AsyncMock(return_value={"results": items}),
@@ -255,10 +250,20 @@ class TestAddToCart:
     @pytest.mark.asyncio
     async def test_cart_totals_calculated_correctly(self) -> None:
         """Cart totals (subtotal, tax, shipping, total) are calculated."""
-        result = await add_to_cart(product_id="prod_1", quantity=2)
+        mock_product = {
+            "id": "prod_1",
+            "name": "Test Product",
+            "base_price": 2500,
+            "stock_count": 10,
+            "category": "tops",
+        }
+        with patch(
+            "src.apps_sdk.tools.cart.find_product",
+            new=AsyncMock(return_value=mock_product),
+        ):
+            result = await add_to_cart(product_id="prod_1", quantity=2)
 
-        product_price = CATALOG_PRODUCTS[0]["basePrice"]
-        expected_subtotal = product_price * 2
+        expected_subtotal = 2500 * 2  # mock product price * quantity
 
         assert result["subtotal"] == expected_subtotal
         assert result["shipping"] == 500  # $5.00

--- a/tests/apps_sdk/test_tools.py
+++ b/tests/apps_sdk/test_tools.py
@@ -10,6 +10,8 @@ Tests cover:
   - checkout: Processing checkout
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from src.apps_sdk.tools.cart import (
@@ -40,7 +42,16 @@ class TestSearchProducts:
     @pytest.mark.asyncio
     async def test_returns_products_and_metadata(self) -> None:
         """Happy path: Returns products, query info, and widget metadata."""
-        result = await search_products(query="tee")
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(
+                return_value={
+                    "results": [{"product_id": "prod_1", "score": 0.4}],
+                    "query": "tee",
+                }
+            ),
+        ):
+            result = await search_products(query="tee")
 
         assert "products" in result
         assert "query" in result
@@ -50,28 +61,26 @@ class TestSearchProducts:
 
     @pytest.mark.asyncio
     async def test_search_filters_by_query(self) -> None:
-        """Search filters products by name/category/sku/description."""
-        result = await search_products(query="jeans")
+        """Search returns empty list when agent returns no results."""
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(return_value={"results": []}),
+        ):
+            result = await search_products(query="jeans")
 
-        # Should find products with "jeans" in name/category/description
-        assert result["totalResults"] > 0
-        # Check that filtering worked (at least one product matches)
-        for product in result["products"]:
-            name_lower = str(product.get("name", "")).lower()
-            category_lower = str(product.get("category", "")).lower()
-            sku_lower = str(product.get("sku", "")).lower()
-            description_lower = str(product.get("description", "")).lower()
-            assert (
-                "jeans" in name_lower
-                or "jeans" in category_lower
-                or "jeans" in sku_lower
-                or "jeans" in description_lower
-            )
+        assert result["totalResults"] == 0
+        assert result["products"] == []
 
     @pytest.mark.asyncio
     async def test_search_with_category_filter(self) -> None:
         """Search with category filter narrows results."""
-        result = await search_products(query="tee", category="white")
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(
+                return_value={"results": [{"product_id": "prod_1", "score": 0.4}]}
+            ),
+        ):
+            result = await search_products(query="tee", category="white")
 
         assert "products" in result
         assert result["category"] == "white"
@@ -79,14 +88,29 @@ class TestSearchProducts:
     @pytest.mark.asyncio
     async def test_search_respects_limit(self) -> None:
         """Search respects the limit parameter."""
-        result = await search_products(query="tee", limit=1)
+        items = [
+            {"product_id": "prod_1", "score": 0.4},
+            {"product_id": "prod_2", "score": 0.4},
+        ]
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(return_value={"results": items}),
+        ):
+            result = await search_products(query="tee", limit=1)
 
         assert len(result["products"]) <= 1
 
     @pytest.mark.asyncio
     async def test_search_max_limit_is_50(self) -> None:
         """Search clamps limit to maximum of 50."""
-        result = await search_products(query="tee", limit=100)
+        items = [
+            {"product_id": CATALOG_PRODUCTS[0]["id"], "score": 0.4} for _ in range(60)
+        ]
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(return_value={"results": items}),
+        ):
+            result = await search_products(query="tee", limit=100)
 
         # Limit should be clamped to 50 internally
         assert len(result["products"]) <= 50
@@ -94,7 +118,16 @@ class TestSearchProducts:
     @pytest.mark.asyncio
     async def test_metadata_includes_widget_uri(self) -> None:
         """Metadata includes widget URI for client discovery."""
-        result = await search_products(query="tee")
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(
+                return_value={
+                    "results": [{"product_id": "prod_2", "score": 0.4}],
+                    "query": "tee",
+                }
+            ),
+        ):
+            result = await search_products(query="tee")
 
         meta = result["_meta"]
         assert "openai/outputTemplate" in meta
@@ -102,12 +135,70 @@ class TestSearchProducts:
         assert meta["openai/widgetAccessible"] is True
 
     @pytest.mark.asyncio
-    async def test_no_match_returns_all_products(self) -> None:
-        """When no products match, returns all products as fallback."""
-        result = await search_products(query="nonexistent_product_xyz123", limit=50)
+    async def test_search_agent_unavailable_returns_error(self) -> None:
+        """Agent failures return an error response."""
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(
+                return_value={"results": [], "error": "Search agent timeout"}
+            ),
+        ):
+            result = await search_products(query="nonexistent_product_xyz123", limit=50)
 
-        # Should fallback to all products (up to limit)
-        assert result["totalResults"] == len(CATALOG_PRODUCTS)
+        assert result["totalResults"] == 0
+        assert result["products"] == []
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_search_filters_by_similarity_threshold(self) -> None:
+        """Search filters out results below the similarity threshold."""
+        with patch(
+            "src.apps_sdk.tools.recommendations.call_search_agent",
+            new=AsyncMock(
+                return_value={
+                    "results": [
+                        {"product_id": "prod_1", "score": 0.1},
+                        {"product_id": "prod_2", "score": 5.0},
+                    ]
+                }
+            ),
+        ):
+            result = await search_products(query="tee", limit=3)
+
+        assert result["totalResults"] == 1
+        assert result["products"][0]["id"] == "prod_1"
+
+    @pytest.mark.asyncio
+    async def test_missing_product_uses_merchant_fallback(self) -> None:
+        """Missing catalog IDs are enriched via merchant API fallback."""
+        with (
+            patch(
+                "src.apps_sdk.tools.recommendations.call_search_agent",
+                new=AsyncMock(
+                    return_value={
+                        "results": [{"product_id": "prod_missing", "score": 0.2}]
+                    }
+                ),
+            ),
+            patch(
+                "src.apps_sdk.tools.recommendations._fetch_product_from_merchant",
+                new=AsyncMock(
+                    return_value={
+                        "id": "prod_missing",
+                        "sku": "TS-999",
+                        "name": "Limited Tee",
+                        "basePrice": 3900,
+                        "stockCount": 5,
+                        "category": "tops",
+                        "description": "Limited edition tee",
+                        "imageUrl": "/prod_99.jpeg",
+                    }
+                ),
+            ),
+        ):
+            result = await search_products(query="limited tee", limit=3)
+
+        assert result["products"][0]["id"] == "prod_missing"
 
 
 # =============================================================================

--- a/tests/apps_sdk/test_tools.py
+++ b/tests/apps_sdk/test_tools.py
@@ -146,16 +146,37 @@ class TestSearchProducts:
 
     @pytest.mark.asyncio
     async def test_search_filters_by_similarity_threshold(self) -> None:
-        """Search filters out results below the similarity threshold."""
-        with patch(
-            "src.apps_sdk.tools.recommendations.call_search_agent",
-            new=AsyncMock(
-                return_value={
-                    "results": [
-                        {"product_id": "prod_1", "score": 0.1},
-                        {"product_id": "prod_2", "score": 5.0},
-                    ]
-                }
+        """Search filters out results below the similarity threshold.
+
+        Score is converted to similarity via 1/(1+score):
+        - prod_1 score=0.1 -> similarity=0.909 (passes min 0.35)
+        - prod_2 score=5.0 -> similarity=0.167 (filtered out)
+        """
+        mock_product = {
+            "id": "prod_1",
+            "sku": "TS-001",
+            "name": "Classic White Tee",
+            "basePrice": 2500,
+            "stockCount": 100,
+            "category": "tops",
+            "description": "A classic white t-shirt",
+            "imageUrl": "/prod_1.jpeg",
+        }
+        with (
+            patch(
+                "src.apps_sdk.tools.recommendations.call_search_agent",
+                new=AsyncMock(
+                    return_value={
+                        "results": [
+                            {"product_id": "prod_1", "score": 0.1},
+                            {"product_id": "prod_2", "score": 5.0},
+                        ]
+                    }
+                ),
+            ),
+            patch(
+                "src.apps_sdk.tools.recommendations._fetch_product_from_merchant",
+                new=AsyncMock(return_value=mock_product),
             ),
         ):
             result = await search_products(query="tee", limit=3)

--- a/tests/apps_sdk/test_tools.py
+++ b/tests/apps_sdk/test_tools.py
@@ -250,18 +250,8 @@ class TestAddToCart:
     @pytest.mark.asyncio
     async def test_cart_totals_calculated_correctly(self) -> None:
         """Cart totals (subtotal, tax, shipping, total) are calculated."""
-        mock_product = {
-            "id": "prod_1",
-            "name": "Test Product",
-            "base_price": 2500,
-            "stock_count": 10,
-            "category": "tops",
-        }
-        with patch(
-            "src.apps_sdk.tools.cart.find_product",
-            new=AsyncMock(return_value=mock_product),
-        ):
-            result = await add_to_cart(product_id="prod_1", quantity=2)
+        # Mock product from conftest has base_price=2500
+        result = await add_to_cart(product_id="prod_1", quantity=2)
 
         expected_subtotal = 2500 * 2  # mock product price * quantity
 


### PR DESCRIPTION
## Summary

- Add RAG-based product search for Apps SDK mode (`search-products` tool)
- Add search-agent service to docker-compose for RAG queries
- Refactor Docker container naming:
  - Agent containers: `acp-*-agent` → `nat-*-agent` prefix
  - Application services: remove `acp-` prefix (nginx, merchant, psp, ui, apps-sdk)
  - Shared agent image: `acp-agents:latest` → `nat-agents:latest`
- Fix webhook singleton using `globalThis` for proper event propagation across Next.js App Router routes (fixes post-purchase display in native ACP mode)
- Rename `arag_agent_url` to `recommendation_agent_url` for consistency

## Test plan

- [x] Deploy with `docker compose up -d --build` and verify new container names
- [x] Test Apps SDK mode: search for products using natural language
- [x] Test native ACP mode: complete checkout and verify post-purchase agent output displays
- [x] Verify all agents are accessible (promotion, post-purchase, recommendation, search)


Made with [Cursor](https://cursor.com)