### PR TITLE
[backend][frontend][apps-sdk] Fix post-purchase customer name personalization

### DIFF
--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -1133,6 +1133,7 @@ class CartCheckoutRequest(BaseModel):
 
     cart_id: str = Field(..., alias="cartId")
     cart_items: list[dict[str, Any]] = Field(..., alias="cartItems")
+    customer_name: str | None = Field(None, alias="customerName")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -1611,9 +1612,9 @@ async def api_checkout(request: CartCheckoutRequest) -> dict[str, Any]:
     ]
 
     logger.info(
-        f"Checkout REST API called for cart {cart_id} with {len(carts[cart_id])} items"
+        f"Checkout REST API called for cart {cart_id} with {len(carts[cart_id])} items, customer: {request.customer_name}"
     )
 
-    # Process checkout
-    result = await checkout(cart_id)
+    # Process checkout with customer name for personalized post-purchase messages
+    result = await checkout(cart_id, customer_name=request.customer_name)
     return result

--- a/src/apps_sdk/tools/checkout.py
+++ b/src/apps_sdk/tools/checkout.py
@@ -61,7 +61,9 @@ def _emit_event(
         pass
 
 
-async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
+async def process_acp_checkout(
+    cart_id: str, customer_name: str | None = None
+) -> dict[str, Any]:
     """
     Process checkout through the ACP payment flow with PSP delegation.
 
@@ -74,6 +76,7 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
 
     Args:
         cart_id: The cart ID to checkout.
+        customer_name: Customer's full name for personalized messages.
 
     Returns:
         Dictionary with checkout result including:
@@ -84,6 +87,11 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
         - total: Order total in cents
         - itemCount: Number of items in order
     """
+    # Parse customer name into first and last name for API calls
+    name_parts = (customer_name or "Customer").strip().split(maxsplit=1)
+    first_name = name_parts[0] if name_parts else "Customer"
+    last_name = name_parts[1] if len(name_parts) > 1 else ""
+    full_name = customer_name or "Customer"
     settings = get_apps_sdk_settings()
     merchant_api_url = settings.merchant_api_url
     psp_api_url = settings.psp_api_url
@@ -128,12 +136,12 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
                 json={
                     "items": items,
                     "buyer": {
-                        "first_name": "John",
-                        "last_name": "Doe",
-                        "email": "john@example.com",
+                        "first_name": first_name,
+                        "last_name": last_name or None,
+                        "email": "customer@example.com",
                     },
                     "fulfillment_address": {
-                        "name": "John Doe",
+                        "name": full_name,
                         "line_one": "123 Main St",
                         "city": "San Francisco",
                         "state": "CA",
@@ -243,7 +251,7 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
                         }
                     ],
                     "billing_address": {
-                        "name": "John Doe",
+                        "name": full_name,
                         "line_one": "123 Main St",
                         "city": "San Francisco",
                         "state": "CA",
@@ -295,7 +303,7 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
                         "token": vault_token_id,
                         "provider": "stripe",
                         "billing_address": {
-                            "name": "John Doe",
+                            "name": full_name,
                             "line_one": "123 Main St",
                             "city": "San Francisco",
                             "state": "CA",
@@ -380,17 +388,18 @@ async def process_acp_checkout(cart_id: str) -> dict[str, Any]:
         }
 
 
-async def checkout(cart_id: str) -> dict[str, Any]:
+async def checkout(cart_id: str, customer_name: str | None = None) -> dict[str, Any]:
     """
     Process checkout using ACP payment flow.
 
     Args:
         cart_id: The cart ID to checkout.
+        customer_name: Customer's full name for personalized messages.
 
     Returns:
         Checkout result with order ID or error.
     """
-    result = await process_acp_checkout(cart_id)
+    result = await process_acp_checkout(cart_id, customer_name=customer_name)
 
     return {
         **result,

--- a/src/apps_sdk/web/src/App.tsx
+++ b/src/apps_sdk/web/src/App.tsx
@@ -495,7 +495,7 @@ export function App() {
 
   // Handle checkout - makes real API calls to the MCP server
   // Widget is fully isolated - no postMessage communication with parent
-  const handleCheckout = useCallback(async () => {
+  const handleCheckout = useCallback(async (paymentFormData?: { fullName: string; address: string; city: string; zipCode: string }) => {
     if (cartItems.length === 0) return;
 
     setIsCheckingOut(true);
@@ -505,11 +505,14 @@ export function App() {
     const apiBaseUrl = getApiBaseUrl();
     const cartId = cartState.cartId || `cart_${Date.now().toString(36)}`;
 
+    // Extract customer name from form data for personalized post-purchase messages
+    const customerName = paymentFormData?.fullName || "Customer";
+
     try {
       // Make real HTTP call to the MCP server's REST API
       // The MCP server handles the full ACP flow and emits SSE events
       // that the Protocol Inspector can subscribe to independently
-      console.log("[Checkout] Calling checkout REST API...", { cartId, itemCount: cartItems.length });
+      console.log("[Checkout] Calling checkout REST API...", { cartId, itemCount: cartItems.length, customerName });
       
       const response = await fetch(`${apiBaseUrl}/cart/checkout`, {
         method: "POST",
@@ -519,6 +522,7 @@ export function App() {
         body: JSON.stringify({
           cartId,
           cartItems: cartItems,
+          customerName: customerName,
         }),
       });
 

--- a/src/apps_sdk/web/src/components/CheckoutPage.tsx
+++ b/src/apps_sdk/web/src/components/CheckoutPage.tsx
@@ -15,7 +15,7 @@ import {
 import type { CartItem, CartState, Product, CheckoutResult } from "@/types";
 import { formatPrice, getProductImage } from "@/types";
 import { RecommendationSkeleton } from "@/components/RecommendationSkeleton";
-import { PaymentSheet } from "@/components/PaymentSheet";
+import { PaymentSheet, type PaymentFormData } from "@/components/PaymentSheet";
 
 /**
  * Delivery option configuration
@@ -61,7 +61,7 @@ interface CheckoutPageProps {
   onBack: () => void;
   onUpdateQuantity: (productId: string, quantity: number) => void;
   onRemoveItem: (productId: string) => void;
-  onCheckout: () => void;
+  onCheckout: (formData?: PaymentFormData) => void;
   onProductClick: (product: Product) => void;
   onQuickAdd: (product: Product) => void;
   onClearResult: () => void;
@@ -296,9 +296,9 @@ export function CheckoutPage({
     }
   }, [isProcessing]);
 
-  // Handle payment completion - calls the backend
-  const handlePay = useCallback(() => {
-    onCheckout();
+  // Handle payment completion - calls the backend with form data for personalization
+  const handlePay = useCallback((formData: PaymentFormData) => {
+    onCheckout(formData);
   }, [onCheckout]);
 
   // Close payment sheet when checkout result comes back

--- a/src/apps_sdk/web/src/components/PaymentSheet.tsx
+++ b/src/apps_sdk/web/src/components/PaymentSheet.tsx
@@ -2,12 +2,19 @@ import { useState, useCallback, useEffect } from "react";
 import { X, CreditCard, MapPin, Lock } from "lucide-react";
 import { formatPrice } from "@/types";
 
+export interface PaymentFormData {
+  fullName: string;
+  address: string;
+  city: string;
+  zipCode: string;
+}
+
 interface PaymentSheetProps {
   isOpen: boolean;
   isProcessing: boolean;
   total: number;
   onClose: () => void;
-  onPay: () => void;
+  onPay: (formData: PaymentFormData) => void;
 }
 
 /**
@@ -98,9 +105,15 @@ export function PaymentSheet({
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
-      onPay();
+      // Pass the form data (name, address) to the checkout handler
+      onPay({
+        fullName: formData.fullName,
+        address: formData.address,
+        city: formData.city,
+        zipCode: formData.zipCode,
+      });
     },
-    [onPay]
+    [onPay, formData]
   );
 
   // Handle backdrop click

--- a/src/merchant/api/routes/checkout.py
+++ b/src/merchant/api/routes/checkout.py
@@ -242,9 +242,23 @@ def complete_checkout(
         # Trigger post-purchase agent and webhook delivery (ACP architecture)
         # This runs as a background task so it doesn't block the checkout response
         if response.order is not None:
-            # Extract customer name (use buyer from request or response)
+            # Extract customer name from multiple sources (in priority order):
+            # 1. billing_address.name from payment_data (user's actual input)
+            # 2. buyer.first_name from request
+            # 3. buyer.first_name from session response
             customer_name = "Customer"
-            if request.buyer and request.buyer.first_name:
+            billing_name = None
+            if (
+                request.payment_data
+                and request.payment_data.billing_address
+                and request.payment_data.billing_address.name
+            ):
+                # Extract first name from billing address (e.g., "John Doe" -> "John")
+                billing_name = request.payment_data.billing_address.name.strip()
+                name_parts = billing_name.split()
+                if name_parts:
+                    customer_name = name_parts[0]
+            elif request.buyer and request.buyer.first_name:
                 customer_name = request.buyer.first_name
             elif response.buyer and response.buyer.first_name:
                 customer_name = response.buyer.first_name

--- a/src/ui/hooks/useCheckoutFlow.test.ts
+++ b/src/ui/hooks/useCheckoutFlow.test.ts
@@ -415,6 +415,57 @@ describe("useCheckoutFlow", () => {
       );
     });
 
+    it("passes billing_address.name from form to completeCheckout for post-purchase personalization", async () => {
+      // Use a DIFFERENT name than defaults to catch bugs where defaults are used
+      const customBillingAddress = {
+        fullName: "Antonio Martinez",
+        address: "456 Test Ave, Los Angeles, CA 90001",
+        preferredLanguage: "en" as const,
+      };
+
+      vi.mocked(apiClient.createCheckoutSession).mockResolvedValueOnce(mockSession);
+      vi.mocked(apiClient.updateCheckoutSession).mockResolvedValue(mockReadySession);
+      vi.mocked(apiClient.delegatePayment).mockResolvedValueOnce(mockVaultToken);
+      vi.mocked(apiClient.completeCheckout).mockResolvedValueOnce(mockCompletedSession);
+
+      const { result } = renderHook(() => useCheckoutFlow());
+
+      await act(async () => {
+        await result.current.selectProduct(mockProduct);
+      });
+
+      await waitFor(() => {
+        expect(result.current.context.state).toBe("checkout");
+      });
+
+      // Set payment info and custom billing address with non-default name
+      act(() => {
+        result.current.setPaymentInfo(mockPaymentInfo);
+        result.current.setBillingAddress(customBillingAddress);
+      });
+
+      await act(async () => {
+        await result.current.submitPayment();
+      });
+
+      await waitFor(() => {
+        expect(result.current.context.state).toBe("confirmation");
+      });
+
+      // Verify that billing_address.name is passed with the user's actual name
+      // The backend extracts the first name from billing_address.name for post-purchase messages
+      expect(apiClient.completeCheckout).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          payment_data: expect.objectContaining({
+            billing_address: expect.objectContaining({
+              name: "Antonio Martinez",
+            }),
+          }),
+        })
+      );
+    });
+
     it("stores vault token after delegation", async () => {
       vi.mocked(apiClient.createCheckoutSession).mockResolvedValueOnce(mockSession);
       vi.mocked(apiClient.updateCheckoutSession).mockResolvedValue(mockReadySession);


### PR DESCRIPTION
## Summary
- Fix bug where post-purchase agent always showed "John" instead of the actual customer name
- Backend now extracts customer name from `billing_address.name` in the payment data
- Apps SDK properly passes customer name from PaymentSheet form through the checkout flow

## Root Cause
The name flow was disconnected:
1. Frontend sent name in `payment_data.billing_address.name`
2. Backend looked for name in `request.buyer.first_name` (which was never sent)
3. Fallback used `session.buyer.first_name` which had hardcoded "John" from session creation

## Changes
| Component | Change |
|-----------|--------|
| Merchant API | Extract first name from `billing_address.name` as primary source |
| Apps SDK Tool | Pass customer name through `billing_address.name` |
| Apps SDK Widget | Wire form data from PaymentSheet → CheckoutPage → App |
| Frontend Test | Add test verifying `billing_address.name` is passed correctly |

## Test plan
- [x] Native ACP: Enter custom name in payment form, verify post-purchase toast shows correct name
- [x] Apps SDK: Enter custom name in payment form, verify post-purchase toast shows correct name
- [x] Run `pnpm test:run` in `src/ui/` - all 193 tests pass

Made with [Cursor](https://cursor.com)