### PR TITLE
[frontend][apps-sdk] Fix MCP client timeout and update search placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ flowchart TB
         PROMO["🎯 Promotion Agent<br/>(Port 8002)"]
         POST["📨 Post-Purchase Agent<br/>(Port 8003)"]
         RECS["🔍 Recommendation Agent<br/>(Port 8004)"]
+        SEARCH["🔎 Search Agent<br/>(Port 8005)"]
+    end
+
+    subgraph NIMs["NVIDIA NIMs"]
+        LLM["🧠 Nemotron Nano LLM<br/>(Port 8010)"]
+        EMBED["📐 NV-EmbedQA-E5<br/>(Port 8011)"]
+    end
+
+    subgraph Data["Data Stores"]
+        SQLITE[("🗄️ SQLite<br/>Application DB")]
+        MILVUS[("🧠 Milvus<br/>Vector DB")]
     end
 
     CA -->|MCP| MCP
@@ -200,6 +211,17 @@ flowchart TB
     MERCHANT --> PROMO
     MERCHANT --> POST
     MERCHANT --> RECS
+    MERCHANT --> SEARCH
+    MERCHANT --> SQLITE
+    PROMO --> LLM
+    POST --> LLM
+    RECS --> LLM
+    RECS --> EMBED
+    SEARCH --> LLM
+    SEARCH --> EMBED
+    EMBED --> MILVUS
+    RECS --> MILVUS
+    SEARCH --> MILVUS
 
     style CA fill:#76b900,color:#000
     style MCP fill:#1a1a2e,color:#fff
@@ -209,6 +231,11 @@ flowchart TB
     style PROMO fill:#2d2d44,color:#fff
     style POST fill:#2d2d44,color:#fff
     style RECS fill:#2d2d44,color:#fff
+    style SEARCH fill:#2d2d44,color:#fff
+    style LLM fill:#76b900,color:#000
+    style EMBED fill:#76b900,color:#000
+    style SQLITE fill:#3d5a80,color:#fff
+    style MILVUS fill:#3d5a80,color:#fff
 ```
 
 ## Services

--- a/src/merchant/api/schemas.py
+++ b/src/merchant/api/schemas.py
@@ -3,7 +3,7 @@
 Based on the Agentic Checkout Protocol specification (docs/acp-spec.md).
 """
 
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field
 # =============================================================================
 
 
-class CheckoutStatusEnum(str, Enum):
+class CheckoutStatusEnum(StrEnum):
     """Checkout session status values."""
 
     NOT_READY_FOR_PAYMENT = "not_ready_for_payment"
@@ -22,20 +22,20 @@ class CheckoutStatusEnum(str, Enum):
     CANCELED = "canceled"
 
 
-class PaymentProviderEnum(str, Enum):
+class PaymentProviderEnum(StrEnum):
     """Supported payment providers."""
 
     STRIPE = "stripe"
     ADYEN = "adyen"
 
 
-class PaymentMethodEnum(str, Enum):
+class PaymentMethodEnum(StrEnum):
     """Supported payment methods."""
 
     CARD = "card"
 
 
-class SupportedLanguageEnum(str, Enum):
+class SupportedLanguageEnum(StrEnum):
     """Supported languages for post-purchase messages."""
 
     EN = "en"
@@ -43,14 +43,14 @@ class SupportedLanguageEnum(str, Enum):
     FR = "fr"
 
 
-class FulfillmentTypeEnum(str, Enum):
+class FulfillmentTypeEnum(StrEnum):
     """Fulfillment option types."""
 
     SHIPPING = "shipping"
     DIGITAL = "digital"
 
 
-class TotalTypeEnum(str, Enum):
+class TotalTypeEnum(StrEnum):
     """Total line item types."""
 
     ITEMS_BASE_AMOUNT = "items_base_amount"
@@ -63,21 +63,21 @@ class TotalTypeEnum(str, Enum):
     TOTAL = "total"
 
 
-class MessageTypeEnum(str, Enum):
+class MessageTypeEnum(StrEnum):
     """Message types."""
 
     INFO = "info"
     ERROR = "error"
 
 
-class ContentTypeEnum(str, Enum):
+class ContentTypeEnum(StrEnum):
     """Content format types."""
 
     PLAIN = "plain"
     MARKDOWN = "markdown"
 
 
-class ErrorCodeEnum(str, Enum):
+class ErrorCodeEnum(StrEnum):
     """Error codes for error messages."""
 
     MISSING = "missing"
@@ -88,7 +88,7 @@ class ErrorCodeEnum(str, Enum):
     REQUIRES_3DS = "requires_3ds"
 
 
-class LinkTypeEnum(str, Enum):
+class LinkTypeEnum(StrEnum):
     """Link types for HATEOAS links."""
 
     TERMS_OF_USE = "terms_of_use"
@@ -386,7 +386,7 @@ class CheckoutSessionResponse(BaseModel):
 # =============================================================================
 
 
-class ErrorTypeEnum(str, Enum):
+class ErrorTypeEnum(StrEnum):
     """Error response types."""
 
     INVALID_REQUEST = "invalid_request"
@@ -397,7 +397,7 @@ class ErrorTypeEnum(str, Enum):
     FORBIDDEN = "forbidden"
 
 
-class ErrorResponseCodeEnum(str, Enum):
+class ErrorResponseCodeEnum(StrEnum):
     """Error response codes."""
 
     REQUEST_NOT_IDEMPOTENT = "request_not_idempotent"

--- a/src/merchant/config.py
+++ b/src/merchant/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     app_name: str = "Agentic Commerce Middleware"
     app_version: str = "0.1.0"
     debug: bool = False
+    log_level: str = "INFO"  # DEBUG, INFO, WARNING, ERROR
+    log_sql: bool = False  # Enable verbose SQL logging (very noisy)
 
     # Database
     database_url: str = "sqlite:///./agentic_commerce.db"

--- a/src/merchant/db/database.py
+++ b/src/merchant/db/database.py
@@ -24,7 +24,7 @@ def get_engine():
         settings = get_settings()
         _engine = create_engine(
             settings.database_url,
-            echo=settings.debug,
+            echo=settings.log_sql,  # Only log SQL when explicitly enabled
             connect_args={"check_same_thread": False},
         )
     return _engine

--- a/src/merchant/db/models.py
+++ b/src/merchant/db/models.py
@@ -1,7 +1,7 @@
 """SQLModel database models for the Agentic Commerce middleware."""
 
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import ClassVar, Optional
 
 from sqlmodel import Field, Relationship, SQLModel
@@ -12,7 +12,7 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
-class CheckoutStatus(str, Enum):
+class CheckoutStatus(StrEnum):
     """Checkout session status as per ACP specification."""
 
     NOT_READY_FOR_PAYMENT = "not_ready_for_payment"

--- a/src/merchant/main.py
+++ b/src/merchant/main.py
@@ -1,6 +1,7 @@
 """FastAPI application entry point for the Agentic Commerce middleware."""
 
 import logging
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -16,11 +17,44 @@ from src.merchant.middleware import ACPHeadersMiddleware, RequestLoggingMiddlewa
 
 settings = get_settings()
 
-# Configure logging
-logging.basicConfig(
-    level=logging.DEBUG if settings.debug else logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
+
+def configure_logging() -> None:
+    """Configure application logging with proper levels and formatting.
+
+    Sets up structured logging with:
+    - Configurable log level via LOG_LEVEL env var
+    - Suppressed verbose SQLAlchemy/uvicorn logs unless LOG_SQL=true
+    - Clean, readable format for traceability
+    """
+    log_level = getattr(logging, settings.log_level.upper(), logging.INFO)
+
+    # Root logger configuration
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stdout,
+        force=True,  # Override any existing configuration
+    )
+
+    # Suppress noisy loggers unless explicitly requested
+    if not settings.log_sql:
+        # SQLAlchemy engine logs every SQL statement - very noisy
+        logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+        logging.getLogger("sqlalchemy.pool").setLevel(logging.WARNING)
+
+    # Reduce uvicorn access log noise (it duplicates our middleware logs)
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+
+    # Keep uvicorn error logs visible
+    logging.getLogger("uvicorn.error").setLevel(log_level)
+
+    # Our application loggers at configured level
+    logging.getLogger("agentic_commerce").setLevel(log_level)
+    logging.getLogger("src.merchant").setLevel(log_level)
+
+
+configure_logging()
 
 
 @asynccontextmanager

--- a/src/merchant/middleware/logging.py
+++ b/src/merchant/middleware/logging.py
@@ -1,25 +1,44 @@
-"""Request/response logging middleware."""
+"""Request/response logging middleware with structured traceability."""
 
 import logging
 import time
+import uuid
 from collections.abc import Awaitable, Callable
-from typing import Any
+from contextvars import ContextVar
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+# Context variable for request correlation across async calls
+request_id_ctx: ContextVar[str] = ContextVar("request_id", default="")
+
 logger = logging.getLogger("agentic_commerce.api")
 
 
-class RequestLoggingMiddleware(BaseHTTPMiddleware):
-    """Middleware for logging HTTP requests and responses.
+def get_request_id() -> str:
+    """Get the current request ID from context.
 
-    Logs request details on entry and response details with duration on exit.
-    Sensitive headers (Authorization, X-API-Key) are redacted in logs.
+    Returns:
+        The current request ID or empty string if not in request context.
+    """
+    return request_id_ctx.get()
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware for structured HTTP request/response logging.
+
+    Provides:
+    - Request correlation via Request-Id header or auto-generated UUID
+    - Duration tracking for performance monitoring
+    - Clean, structured log output for traceability
+    - Sensitive header redaction
     """
 
-    SENSITIVE_HEADERS = {"authorization", "x-api-key"}
+    SENSITIVE_HEADERS = {"authorization", "x-api-key", "cookie"}
+
+    # Endpoints to skip logging (health checks, static files)
+    SKIP_ENDPOINTS = {"/health", "/healthz", "/ready", "/favicon.ico"}
 
     async def dispatch(
         self,
@@ -35,55 +54,107 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         Returns:
             The HTTP response.
         """
-        start_time = time.perf_counter()
-        request_id = request.headers.get("Request-Id", "unknown")
+        # Skip logging for health checks and other noisy endpoints
+        if request.url.path in self.SKIP_ENDPOINTS:
+            return await call_next(request)
 
-        # Log request (with sensitive headers redacted)
-        safe_headers = self._redact_headers(dict(request.headers))
-        logger.info(
-            "Request started",
-            extra={
-                "request_id": request_id,
-                "method": request.method,
-                "path": request.url.path,
-                "query": str(request.query_params),
-                "headers": safe_headers,
-            },
-        )
+        start_time = time.perf_counter()
+
+        # Get or generate request ID for correlation
+        request_id = request.headers.get("Request-Id") or f"req_{uuid.uuid4().hex[:12]}"
+        request_id_ctx.set(request_id)
+
+        # Extract useful context
+        method = request.method
+        path = request.url.path
+        client_ip = self._get_client_ip(request)
+        idempotency_key = request.headers.get("Idempotency-Key", "")
+
+        # Log request start with key context
+        log_context = f"[{request_id}] {method} {path}"
+        if idempotency_key:
+            log_context += f" idem={idempotency_key[:16]}..."
+
+        logger.info(f"{log_context} <- {client_ip}")
 
         # Process request
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except Exception as e:
+            # Log unhandled exceptions
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            logger.error(
+                f"{log_context} -> 500 ERROR ({duration_ms:.0f}ms) {type(e).__name__}: {e}"
+            )
+            raise
 
         # Calculate duration
         duration_ms = (time.perf_counter() - start_time) * 1000
 
-        # Log response
-        logger.info(
-            "Request completed",
-            extra={
-                "request_id": request_id,
-                "method": request.method,
-                "path": request.url.path,
-                "status_code": response.status_code,
-                "duration_ms": round(duration_ms, 2),
-            },
-        )
+        # Log response with status and duration
+        status = response.status_code
+        status_category = self._get_status_category(status)
+
+        log_method = logger.info if status < 400 else logger.warning
+        if status >= 500:
+            log_method = logger.error
+
+        log_method(f"{log_context} -> {status} {status_category} ({duration_ms:.0f}ms)")
+
+        # Add request ID to response headers for client correlation
+        response.headers["X-Request-Id"] = request_id
 
         return response
 
-    def _redact_headers(self, headers: dict[str, Any]) -> dict[str, str]:
-        """Redact sensitive headers for logging.
+    def _get_client_ip(self, request: Request) -> str:
+        """Extract client IP from request, handling proxies.
 
         Args:
-            headers: Dictionary of header names to values.
+            request: The HTTP request.
 
         Returns:
-            Headers with sensitive values redacted.
+            Client IP address string.
         """
-        redacted: dict[str, str] = {}
-        for key, value in headers.items():
-            if key.lower() in self.SENSITIVE_HEADERS:
-                redacted[key] = "[REDACTED]"
-            else:
-                redacted[key] = str(value)
-        return redacted
+        # Check X-Forwarded-For for proxy setups
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+
+        # Check X-Real-IP
+        real_ip = request.headers.get("X-Real-IP")
+        if real_ip:
+            return real_ip
+
+        # Fall back to direct client
+        if request.client:
+            return request.client.host
+
+        return "unknown"
+
+    def _get_status_category(self, status: int) -> str:
+        """Get a human-readable status category.
+
+        Args:
+            status: HTTP status code.
+
+        Returns:
+            Status category string.
+        """
+        if status < 300:
+            return "OK"
+        elif status < 400:
+            return "REDIRECT"
+        elif status == 401:
+            return "UNAUTHORIZED"
+        elif status == 403:
+            return "FORBIDDEN"
+        elif status == 404:
+            return "NOT_FOUND"
+        elif status == 409:
+            return "CONFLICT"
+        elif status == 422:
+            return "VALIDATION_ERROR"
+        elif status < 500:
+            return "CLIENT_ERROR"
+        else:
+            return "SERVER_ERROR"

--- a/src/merchant/services/checkout.py
+++ b/src/merchant/services/checkout.py
@@ -9,549 +9,40 @@ hybrid architecture (see services/promotion.py).
 
 import json
 import logging
-import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlmodel import Session, select
 
 from src.merchant.api.schemas import (
-    Address,
-    AddressInput,
-    Buyer,
     BuyerInput,
     CheckoutSessionResponse,
-    CheckoutStatusEnum,
-    ContentTypeEnum,
     CreateCheckoutRequest,
-    Item,
-    LineItem,
-    Link,
-    LinkTypeEnum,
-    MessageInfo,
-    Order,
     PaymentDataInput,
-    PaymentMethodEnum,
-    PaymentProvider,
-    PaymentProviderEnum,
-    PromotionMetadata,
-    ShippingFulfillmentOption,
-    Total,
-    TotalTypeEnum,
     UpdateCheckoutRequest,
 )
 from src.merchant.db.models import CheckoutSession, CheckoutStatus, Product
-from src.merchant.services.promotion import get_promotion_for_product
+from src.merchant.services.helpers import (
+    DEFAULT_CURRENCY,
+    DEFAULT_SHOP_URL,
+    address_input_to_dict,
+    buyer_input_to_dict,
+    calculate_line_item_with_promotion,
+    calculate_totals,
+    check_ready_for_payment,
+    generate_default_links,
+    generate_fulfillment_options,
+    generate_order_id,
+    generate_session_id,
+    recalculate_line_item_from_existing,
+    session_to_response,
+)
 
 logger = logging.getLogger(__name__)
 
-# =============================================================================
-# Constants
-# =============================================================================
-
-TAX_RATE = 0.10  # 10% tax rate
-DEFAULT_CURRENCY = "usd"
-DEFAULT_SHOP_URL = "https://shop.example.com"
-
 
 # =============================================================================
-# Helper Functions
-# =============================================================================
-
-
-def _generate_session_id() -> str:
-    """Generate a unique checkout session ID."""
-    return f"checkout_{uuid.uuid4().hex[:12]}"
-
-
-def _generate_line_item_id() -> str:
-    """Generate a unique line item ID."""
-    return f"li_{uuid.uuid4().hex[:8]}"
-
-
-def _generate_order_id() -> str:
-    """Generate a unique order ID."""
-    return f"order_{uuid.uuid4().hex[:12]}"
-
-
-def _buyer_input_to_dict(buyer: BuyerInput) -> dict[str, Any]:
-    """Convert BuyerInput to dictionary for JSON storage."""
-    return {
-        "first_name": buyer.first_name,
-        "last_name": buyer.last_name,
-        "email": buyer.email,
-        "phone_number": buyer.phone_number,
-    }
-
-
-def _dict_to_buyer(data: dict[str, Any]) -> Buyer:
-    """Convert dictionary to Buyer response model."""
-    return Buyer(
-        first_name=data["first_name"],
-        last_name=data.get("last_name"),
-        email=data["email"],
-        phone_number=data.get("phone_number"),
-    )
-
-
-def _address_input_to_dict(address: AddressInput) -> dict[str, Any]:
-    """Convert AddressInput to dictionary for JSON storage."""
-    return {
-        "name": address.name,
-        "line_one": address.line_one,
-        "line_two": address.line_two,
-        "city": address.city,
-        "state": address.state,
-        "country": address.country,
-        "postal_code": address.postal_code,
-        "phone_number": address.phone_number,
-    }
-
-
-def _dict_to_address(data: dict[str, Any]) -> Address:
-    """Convert dictionary to Address response model."""
-    return Address(
-        name=data["name"],
-        line_one=data["line_one"],
-        line_two=data.get("line_two"),
-        city=data["city"],
-        state=data["state"],
-        country=data["country"],
-        postal_code=data["postal_code"],
-        phone_number=data.get("phone_number"),
-    )
-
-
-def _calculate_line_item(
-    product: Product,
-    quantity: int,
-    discount_per_unit: int = 0,
-    promotion_info: dict[str, Any] | None = None,
-    line_item_id: str | None = None,
-) -> dict[str, Any]:
-    """Calculate line item totals for a product.
-
-    Args:
-        product: Product database model.
-        quantity: Quantity ordered.
-        discount_per_unit: Discount amount per unit in cents (default 0).
-        promotion_info: Optional promotion metadata (action, reason_codes, reasoning).
-        line_item_id: Optional existing line item ID to preserve (for updates).
-
-    Returns:
-        Dictionary with line item data for JSON storage.
-    """
-    base_amount = product.base_price * quantity
-    total_discount = discount_per_unit * quantity
-    subtotal = base_amount - total_discount
-    tax = int(subtotal * TAX_RATE)
-    total = subtotal + tax
-
-    line_item: dict[str, Any] = {
-        "id": line_item_id or _generate_line_item_id(),
-        "item": {
-            "id": product.id,
-            "quantity": quantity,
-        },
-        "name": product.name,
-        "base_amount": base_amount,
-        "discount": total_discount,
-        "subtotal": subtotal,
-        "tax": tax,
-        "total": total,
-    }
-
-    # Add promotion metadata if available (include stock_count for agent activity display)
-    if promotion_info:
-        line_item["promotion"] = {
-            "action": promotion_info.get("action", "NO_PROMO"),
-            "reason_codes": promotion_info.get("reason_codes", []),
-            "reasoning": promotion_info.get("reasoning", ""),
-            "stock_count": product.stock_count,
-        }
-
-    return line_item
-
-
-async def _calculate_line_item_with_promotion(
-    db: Session, product: Product, quantity: int
-) -> dict[str, Any]:
-    """Calculate line item with promotion agent discount.
-
-    Calls the promotion service to get dynamic pricing based on
-    inventory levels and competitor pricing.
-
-    Args:
-        db: Database session.
-        product: Product database model.
-        quantity: Quantity ordered.
-
-    Returns:
-        Dictionary with line item data including promotion discount.
-    """
-    # Get promotion decision from the agent (fail-open behavior)
-    promotion_result = await get_promotion_for_product(db, product)
-
-    # Calculate line item with the discount
-    return _calculate_line_item(
-        product=product,
-        quantity=quantity,
-        discount_per_unit=promotion_result["discount"],
-        promotion_info=promotion_result,
-    )
-
-
-def _recalculate_line_item_from_existing(
-    product: Product,
-    quantity: int,
-    existing_line_item: dict[str, Any],
-) -> dict[str, Any]:
-    """Recalculate line item totals using existing promotion data.
-
-    This function is used during session updates to avoid re-calling the
-    promotion agent. It preserves the per-unit discount from the original
-    promotion decision and recalculates totals for the new quantity.
-
-    Args:
-        product: Product database model.
-        quantity: New quantity ordered.
-        existing_line_item: Existing line item data with promotion info.
-
-    Returns:
-        Dictionary with recalculated line item data.
-    """
-    # Extract per-unit discount from existing line item
-    existing_quantity = existing_line_item["item"]["quantity"]
-    existing_discount = existing_line_item.get("discount", 0)
-
-    # Calculate per-unit discount (avoid division by zero)
-    if existing_quantity > 0:
-        discount_per_unit = existing_discount // existing_quantity
-    else:
-        discount_per_unit = 0
-
-    # Preserve existing promotion metadata
-    promotion_info = existing_line_item.get("promotion")
-
-    # Recalculate with new quantity, preserving the line item ID
-    return _calculate_line_item(
-        product=product,
-        quantity=quantity,
-        discount_per_unit=discount_per_unit,
-        promotion_info=promotion_info,
-        line_item_id=existing_line_item["id"],
-    )
-
-
-def _dict_to_line_item(data: dict[str, Any]) -> LineItem:
-    """Convert dictionary to LineItem response model."""
-    # Extract promotion metadata if present
-    promotion = None
-    if "promotion" in data and data["promotion"]:
-        promotion = PromotionMetadata(
-            action=data["promotion"].get("action", "NO_PROMO"),
-            reason_codes=data["promotion"].get("reason_codes", []),
-            reasoning=data["promotion"].get("reasoning", ""),
-            stock_count=data["promotion"].get("stock_count"),
-        )
-
-    return LineItem(
-        id=data["id"],
-        item=Item(id=data["item"]["id"], quantity=data["item"]["quantity"]),
-        name=data.get("name"),
-        base_amount=data["base_amount"],
-        discount=data["discount"],
-        subtotal=data["subtotal"],
-        tax=data["tax"],
-        total=data["total"],
-        promotion=promotion,
-    )
-
-
-def _generate_fulfillment_options(has_address: bool) -> list[dict[str, Any]]:
-    """Generate available fulfillment options.
-
-    Args:
-        has_address: Whether a fulfillment address has been provided.
-
-    Returns:
-        List of fulfillment option dictionaries.
-    """
-    if not has_address:
-        return []
-
-    now = datetime.now(UTC)
-    standard_earliest = now + timedelta(days=5)
-    standard_latest = now + timedelta(days=7)
-    express_earliest = now + timedelta(days=2)
-    express_latest = now + timedelta(days=3)
-
-    return [
-        {
-            "type": "shipping",
-            "id": "shipping_standard",
-            "title": "Standard Shipping",
-            "subtitle": "5-7 business days",
-            "carrier_info": "USPS",
-            "earliest_delivery_time": standard_earliest.isoformat(),
-            "latest_delivery_time": standard_latest.isoformat(),
-            "subtotal": 599,
-            "tax": 0,
-            "total": 599,
-        },
-        {
-            "type": "shipping",
-            "id": "shipping_express",
-            "title": "Express Shipping",
-            "subtitle": "2-3 business days",
-            "carrier_info": "UPS",
-            "earliest_delivery_time": express_earliest.isoformat(),
-            "latest_delivery_time": express_latest.isoformat(),
-            "subtotal": 1299,
-            "tax": 0,
-            "total": 1299,
-        },
-    ]
-
-
-def _dict_to_fulfillment_option(data: dict[str, Any]) -> ShippingFulfillmentOption:
-    """Convert dictionary to FulfillmentOption response model."""
-    return ShippingFulfillmentOption(
-        type=data["type"],
-        id=data["id"],
-        title=data["title"],
-        subtitle=data["subtitle"],
-        carrier_info=data["carrier_info"],
-        earliest_delivery_time=data["earliest_delivery_time"],
-        latest_delivery_time=data["latest_delivery_time"],
-        subtotal=data["subtotal"],
-        tax=data["tax"],
-        total=data["total"],
-    )
-
-
-def _calculate_totals(
-    line_items: list[dict[str, Any]],
-    fulfillment_options: list[dict[str, Any]],
-    selected_option_id: str | None,
-) -> list[dict[str, Any]]:
-    """Calculate checkout totals.
-
-    Args:
-        line_items: List of line item dictionaries.
-        fulfillment_options: List of fulfillment option dictionaries.
-        selected_option_id: ID of selected fulfillment option.
-
-    Returns:
-        List of total dictionaries.
-    """
-    items_base_amount: int = sum(item["base_amount"] for item in line_items)
-    items_discount: int = sum(item["discount"] for item in line_items)
-    items_subtotal: int = sum(item["subtotal"] for item in line_items)
-    items_tax: int = sum(item["tax"] for item in line_items)
-
-    # Get fulfillment cost if option selected
-    fulfillment_cost: int = 0
-    if selected_option_id:
-        for option in fulfillment_options:
-            if option["id"] == selected_option_id:
-                fulfillment_cost = int(option["total"])
-                break
-
-    total: int = items_subtotal + items_tax + fulfillment_cost
-
-    totals: list[dict[str, Any]] = [
-        {
-            "type": TotalTypeEnum.ITEMS_BASE_AMOUNT.value,
-            "display_text": "Items",
-            "amount": items_base_amount,
-        },
-    ]
-
-    if items_discount > 0:
-        totals.append(
-            {
-                "type": TotalTypeEnum.ITEMS_DISCOUNT.value,
-                "display_text": "Discount",
-                "amount": items_discount,
-            }
-        )
-
-    totals.extend(
-        [
-            {
-                "type": TotalTypeEnum.SUBTOTAL.value,
-                "display_text": "Subtotal",
-                "amount": items_subtotal,
-            },
-            {
-                "type": TotalTypeEnum.TAX.value,
-                "display_text": "Tax",
-                "amount": items_tax,
-            },
-        ]
-    )
-
-    if fulfillment_cost > 0:
-        totals.append(
-            {
-                "type": TotalTypeEnum.FULFILLMENT.value,
-                "display_text": "Shipping",
-                "amount": fulfillment_cost,
-            }
-        )
-
-    totals.append(
-        {
-            "type": TotalTypeEnum.TOTAL.value,
-            "display_text": "Total",
-            "amount": total,
-        }
-    )
-
-    return totals
-
-
-def _dict_to_total(data: dict[str, Any]) -> Total:
-    """Convert dictionary to Total response model."""
-    return Total(
-        type=TotalTypeEnum(data["type"]),
-        display_text=data["display_text"],
-        amount=data["amount"],
-    )
-
-
-def _generate_default_links() -> list[dict[str, Any]]:
-    """Generate default HATEOAS links."""
-    return [
-        {
-            "type": LinkTypeEnum.TERMS_OF_USE.value,
-            "url": f"{DEFAULT_SHOP_URL}/terms",
-        },
-        {
-            "type": LinkTypeEnum.PRIVACY_POLICY.value,
-            "url": f"{DEFAULT_SHOP_URL}/privacy",
-        },
-        {
-            "type": LinkTypeEnum.SELLER_SHOP_POLICIES.value,
-            "url": f"{DEFAULT_SHOP_URL}/policies",
-        },
-    ]
-
-
-def _dict_to_link(data: dict[str, Any]) -> Link:
-    """Convert dictionary to Link response model."""
-    return Link(type=LinkTypeEnum(data["type"]), url=data["url"])
-
-
-def _check_ready_for_payment(session: CheckoutSession) -> bool:
-    """Check if session has all required fields for payment.
-
-    A session is ready for payment when:
-    - At least one line item exists
-    - Buyer info is provided
-    - Fulfillment address is provided
-    - Fulfillment option is selected
-
-    Args:
-        session: CheckoutSession database model.
-
-    Returns:
-        True if ready for payment, False otherwise.
-    """
-    line_items = json.loads(session.line_items_json)
-    if not line_items:
-        return False
-
-    if session.buyer_json is None:
-        return False
-
-    if session.fulfillment_address_json is None:
-        return False
-
-    return session.selected_fulfillment_option_id is not None
-
-
-def _session_to_response(session: CheckoutSession) -> CheckoutSessionResponse:
-    """Convert CheckoutSession database model to API response.
-
-    Args:
-        session: CheckoutSession database model.
-
-    Returns:
-        CheckoutSessionResponse for API.
-    """
-    # Parse JSON fields
-    line_items_data: list[dict[str, Any]] = json.loads(session.line_items_json)
-    fulfillment_options_data: list[dict[str, Any]] = json.loads(
-        session.fulfillment_options_json
-    )
-    totals_data: list[dict[str, Any]] = (
-        json.loads(session.totals_json) if session.totals_json != "{}" else []
-    )
-    messages_data: list[dict[str, Any]] = json.loads(session.messages_json)
-    links_data: list[dict[str, Any]] = json.loads(session.links_json)
-
-    # Convert to response models
-    line_items = [_dict_to_line_item(item) for item in line_items_data]
-    fulfillment_options: list[ShippingFulfillmentOption] = [
-        _dict_to_fulfillment_option(opt) for opt in fulfillment_options_data
-    ]
-    totals = [_dict_to_total(t) for t in totals_data] if totals_data else []
-    links = [_dict_to_link(link) for link in links_data]
-
-    # Parse optional fields
-    buyer = None
-    if session.buyer_json:
-        buyer_data = json.loads(session.buyer_json)
-        buyer = _dict_to_buyer(buyer_data)
-
-    fulfillment_address = None
-    if session.fulfillment_address_json:
-        address_data = json.loads(session.fulfillment_address_json)
-        fulfillment_address = _dict_to_address(address_data)
-
-    order = None
-    if session.order_json:
-        order_data = json.loads(session.order_json)
-        order = Order(
-            id=order_data["id"],
-            checkout_session_id=order_data["checkout_session_id"],
-            permalink_url=order_data["permalink_url"],
-        )
-
-    # Convert messages
-    messages: list[MessageInfo] = [
-        MessageInfo(
-            param=msg_data["param"],
-            content_type=ContentTypeEnum(msg_data["content_type"]),
-            content=msg_data["content"],
-        )
-        for msg_data in messages_data
-    ]
-
-    return CheckoutSessionResponse(
-        id=session.id,
-        buyer=buyer,
-        payment_provider=PaymentProvider(
-            provider=PaymentProviderEnum.STRIPE,
-            supported_payment_methods=[PaymentMethodEnum.CARD],
-        ),
-        status=CheckoutStatusEnum(session.status.value),
-        currency=session.currency.lower(),
-        line_items=line_items,
-        fulfillment_address=fulfillment_address,
-        fulfillment_options=list(fulfillment_options),  # Cast for type compatibility
-        fulfillment_option_id=session.selected_fulfillment_option_id,
-        totals=totals,
-        messages=list(messages),  # Cast for type compatibility
-        links=links,
-        order=order,
-    )
-
-
-# =============================================================================
-# Service Functions
+# Service Exceptions
 # =============================================================================
 
 
@@ -594,6 +85,11 @@ class InvalidStateTransitionError(CheckoutServiceError):
         )
 
 
+# =============================================================================
+# Service Functions
+# =============================================================================
+
+
 async def create_checkout_session(
     db: Session, request: CreateCheckoutRequest
 ) -> CheckoutSessionResponse:
@@ -612,46 +108,52 @@ async def create_checkout_session(
     Raises:
         ProductNotFoundError: If a product in items is not found.
     """
-    session_id = _generate_session_id()
+    session_id = generate_session_id()
+    item_count = len(request.items)
+    total_quantity = sum(item.quantity for item in request.items)
+
+    logger.info(
+        f"Creating checkout session {session_id} with {item_count} item(s), "
+        f"total qty={total_quantity}"
+    )
 
     # Build line items from products with promotion discounts
     line_items: list[dict[str, Any]] = []
     for item in request.items:
         product = db.exec(select(Product).where(Product.id == item.id)).first()
         if product is None:
+            logger.warning(f"Product not found: {item.id}")
             raise ProductNotFoundError(item.id)
 
         # Get line item with promotion discount (async call to agent)
-        line_item = await _calculate_line_item_with_promotion(
-            db, product, item.quantity
-        )
+        line_item = await calculate_line_item_with_promotion(db, product, item.quantity)
         line_items.append(line_item)
 
     # Process optional buyer
     buyer_json = None
     if request.buyer:
-        buyer_json = json.dumps(_buyer_input_to_dict(request.buyer))
+        buyer_json = json.dumps(buyer_input_to_dict(request.buyer))
 
     # Process optional fulfillment address
     fulfillment_address_json = None
     has_address = request.fulfillment_address is not None
     if request.fulfillment_address:
         fulfillment_address_json = json.dumps(
-            _address_input_to_dict(request.fulfillment_address)
+            address_input_to_dict(request.fulfillment_address)
         )
 
     # Generate fulfillment options
-    fulfillment_options: list[dict[str, Any]] = _generate_fulfillment_options(
+    fulfillment_options: list[dict[str, Any]] = generate_fulfillment_options(
         has_address
     )
 
     # Calculate totals
-    totals: list[dict[str, Any]] = _calculate_totals(
+    totals: list[dict[str, Any]] = calculate_totals(
         line_items, fulfillment_options, None
     )
 
     # Generate default links
-    links: list[dict[str, Any]] = _generate_default_links()
+    links: list[dict[str, Any]] = generate_default_links()
 
     # Generate welcome message
     messages: list[dict[str, Any]] = [
@@ -681,7 +183,15 @@ async def create_checkout_session(
     db.commit()
     db.refresh(checkout_session)
 
-    return _session_to_response(checkout_session)
+    # Calculate total for logging
+    total_amount = next((t["amount"] for t in totals if t["type"] == "total"), 0)
+    logger.info(
+        f"Checkout session {session_id} created | "
+        f"status={checkout_session.status.value} | "
+        f"total=${total_amount / 100:.2f}"
+    )
+
+    return session_to_response(checkout_session)
 
 
 def get_checkout_session(db: Session, session_id: str) -> CheckoutSessionResponse:
@@ -704,7 +214,7 @@ def get_checkout_session(db: Session, session_id: str) -> CheckoutSessionRespons
     if session is None:
         raise SessionNotFoundError(session_id)
 
-    return _session_to_response(session)
+    return session_to_response(session)
 
 
 async def update_checkout_session(
@@ -734,11 +244,29 @@ async def update_checkout_session(
     ).first()
 
     if session is None:
+        logger.warning(f"Session not found for update: {session_id}")
         raise SessionNotFoundError(session_id)
 
     # Check if session can be updated
     if session.status in (CheckoutStatus.COMPLETED, CheckoutStatus.CANCELED):
+        logger.warning(
+            f"Invalid update attempt on session {session_id} | "
+            f"status={session.status.value}"
+        )
         raise InvalidStateTransitionError(session.status.value, "update")
+
+    # Track what's being updated for logging
+    update_fields: list[str] = []
+    if request.items is not None:
+        update_fields.append("items")
+    if request.buyer is not None:
+        update_fields.append("buyer")
+    if request.fulfillment_address is not None:
+        update_fields.append("address")
+    if request.fulfillment_option_id is not None:
+        update_fields.append("shipping")
+
+    logger.debug(f"Updating session {session_id} | fields={update_fields}")
 
     # Update items if provided (reuse existing promotion data, no agent call)
     if request.items is not None:
@@ -758,12 +286,12 @@ async def update_checkout_session(
             existing_li = existing_by_product_id.get(item.id)
             if existing_li is not None:
                 # Reuse existing promotion, just recalculate totals for new quantity
-                line_item = _recalculate_line_item_from_existing(
+                line_item = recalculate_line_item_from_existing(
                     product, item.quantity, existing_li
                 )
             else:
                 # New product added to cart - call promotion agent
-                line_item = await _calculate_line_item_with_promotion(
+                line_item = await calculate_line_item_with_promotion(
                     db, product, item.quantity
                 )
             new_line_items.append(line_item)
@@ -771,15 +299,15 @@ async def update_checkout_session(
 
     # Update buyer if provided
     if request.buyer is not None:
-        session.buyer_json = json.dumps(_buyer_input_to_dict(request.buyer))
+        session.buyer_json = json.dumps(buyer_input_to_dict(request.buyer))
 
     # Update fulfillment address if provided
     if request.fulfillment_address is not None:
         session.fulfillment_address_json = json.dumps(
-            _address_input_to_dict(request.fulfillment_address)
+            address_input_to_dict(request.fulfillment_address)
         )
         # Regenerate fulfillment options when address changes
-        new_options: list[dict[str, Any]] = _generate_fulfillment_options(
+        new_options: list[dict[str, Any]] = generate_fulfillment_options(
             has_address=True
         )
         session.fulfillment_options_json = json.dumps(new_options)
@@ -799,7 +327,7 @@ async def update_checkout_session(
     current_fulfillment_options: list[dict[str, Any]] = json.loads(
         session.fulfillment_options_json
     )
-    updated_totals: list[dict[str, Any]] = _calculate_totals(
+    updated_totals: list[dict[str, Any]] = calculate_totals(
         current_line_items,
         current_fulfillment_options,
         session.selected_fulfillment_option_id,
@@ -807,7 +335,7 @@ async def update_checkout_session(
     session.totals_json = json.dumps(updated_totals)
 
     # Check if ready for payment and update status
-    if _check_ready_for_payment(session):
+    if check_ready_for_payment(session):
         session.status = CheckoutStatus.READY_FOR_PAYMENT
         # Update message
         ready_messages: list[dict[str, Any]] = [
@@ -825,7 +353,14 @@ async def update_checkout_session(
     db.commit()
     db.refresh(session)
 
-    return _session_to_response(session)
+    # Log status transition if it happened
+    logger.info(
+        f"Session {session_id} updated | "
+        f"status={session.status.value} | "
+        f"fields={update_fields}"
+    )
+
+    return session_to_response(session)
 
 
 def complete_checkout_session(
@@ -849,30 +384,36 @@ def complete_checkout_session(
         SessionNotFoundError: If session is not found.
         InvalidStateTransitionError: If session cannot be completed.
     """
+    logger.info(f"Completing checkout session {session_id}")
+
     session = db.exec(
         select(CheckoutSession).where(CheckoutSession.id == session_id)
     ).first()
 
     if session is None:
+        logger.warning(f"Session not found for completion: {session_id}")
         raise SessionNotFoundError(session_id)
 
     # Check if session can be completed
     if session.status == CheckoutStatus.COMPLETED:
+        logger.warning(f"Session {session_id} already completed")
         raise InvalidStateTransitionError(session.status.value, "complete")
 
     if session.status == CheckoutStatus.CANCELED:
+        logger.warning(f"Cannot complete canceled session {session_id}")
         raise InvalidStateTransitionError(session.status.value, "complete")
 
     # Update buyer if provided
     if buyer is not None:
-        session.buyer_json = json.dumps(_buyer_input_to_dict(buyer))
+        session.buyer_json = json.dumps(buyer_input_to_dict(buyer))
 
     # Verify session is ready for payment (has all required fields)
-    if not _check_ready_for_payment(session):
+    if not check_ready_for_payment(session):
+        logger.warning(f"Session {session_id} not ready for payment")
         raise InvalidStateTransitionError(session.status.value, "complete")
 
     # Create order
-    order_id = _generate_order_id()
+    order_id = generate_order_id()
     order_data = {
         "id": order_id,
         "checkout_session_id": session_id,
@@ -899,7 +440,16 @@ def complete_checkout_session(
     db.commit()
     db.refresh(session)
 
-    return _session_to_response(session)
+    # Get total from stored JSON for logging
+    totals_data = json.loads(session.totals_json)
+    total_amount = next((t["amount"] for t in totals_data if t["type"] == "total"), 0)
+    logger.info(
+        f"Order {order_id} completed | "
+        f"session={session_id} | "
+        f"total=${total_amount / 100:.2f}"
+    )
+
+    return session_to_response(session)
 
 
 def cancel_checkout_session(db: Session, session_id: str) -> CheckoutSessionResponse:
@@ -916,18 +466,23 @@ def cancel_checkout_session(db: Session, session_id: str) -> CheckoutSessionResp
         SessionNotFoundError: If session is not found.
         InvalidStateTransitionError: If session is already completed or canceled.
     """
+    logger.info(f"Canceling checkout session {session_id}")
+
     session = db.exec(
         select(CheckoutSession).where(CheckoutSession.id == session_id)
     ).first()
 
     if session is None:
+        logger.warning(f"Session not found for cancellation: {session_id}")
         raise SessionNotFoundError(session_id)
 
     # Check if session can be canceled
     if session.status == CheckoutStatus.COMPLETED:
+        logger.warning(f"Cannot cancel completed session {session_id}")
         raise InvalidStateTransitionError(session.status.value, "cancel")
 
     if session.status == CheckoutStatus.CANCELED:
+        logger.warning(f"Session {session_id} already canceled")
         raise InvalidStateTransitionError(session.status.value, "cancel")
 
     # Update status
@@ -949,4 +504,6 @@ def cancel_checkout_session(db: Session, session_id: str) -> CheckoutSessionResp
     db.commit()
     db.refresh(session)
 
-    return _session_to_response(session)
+    logger.info(f"Session {session_id} canceled")
+
+    return session_to_response(session)

--- a/src/merchant/services/helpers.py
+++ b/src/merchant/services/helpers.py
@@ -1,0 +1,576 @@
+"""Helper functions and constants for checkout service.
+
+Contains utility functions for converting between database models and API schemas,
+calculating line items, totals, and generating IDs.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlmodel import Session
+
+from src.merchant.api.schemas import (
+    Address,
+    AddressInput,
+    Buyer,
+    BuyerInput,
+    CheckoutSessionResponse,
+    CheckoutStatusEnum,
+    ContentTypeEnum,
+    Item,
+    LineItem,
+    Link,
+    LinkTypeEnum,
+    MessageInfo,
+    Order,
+    PaymentMethodEnum,
+    PaymentProvider,
+    PaymentProviderEnum,
+    PromotionMetadata,
+    ShippingFulfillmentOption,
+    Total,
+    TotalTypeEnum,
+)
+from src.merchant.db.models import CheckoutSession, Product
+from src.merchant.services.promotion import get_promotion_for_product
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+TAX_RATE = 0.10  # 10% tax rate
+DEFAULT_CURRENCY = "usd"
+DEFAULT_SHOP_URL = "https://shop.example.com"
+
+
+# =============================================================================
+# ID Generation Functions
+# =============================================================================
+
+
+def generate_session_id() -> str:
+    """Generate a unique checkout session ID."""
+    return f"checkout_{uuid.uuid4().hex[:12]}"
+
+
+def generate_line_item_id() -> str:
+    """Generate a unique line item ID."""
+    return f"li_{uuid.uuid4().hex[:8]}"
+
+
+def generate_order_id() -> str:
+    """Generate a unique order ID."""
+    return f"order_{uuid.uuid4().hex[:12]}"
+
+
+# =============================================================================
+# Buyer Conversion Functions
+# =============================================================================
+
+
+def buyer_input_to_dict(buyer: BuyerInput) -> dict[str, Any]:
+    """Convert BuyerInput to dictionary for JSON storage."""
+    return {
+        "first_name": buyer.first_name,
+        "last_name": buyer.last_name,
+        "email": buyer.email,
+        "phone_number": buyer.phone_number,
+    }
+
+
+def dict_to_buyer(data: dict[str, Any]) -> Buyer:
+    """Convert dictionary to Buyer response model."""
+    return Buyer(
+        first_name=data["first_name"],
+        last_name=data.get("last_name"),
+        email=data["email"],
+        phone_number=data.get("phone_number"),
+    )
+
+
+# =============================================================================
+# Address Conversion Functions
+# =============================================================================
+
+
+def address_input_to_dict(address: AddressInput) -> dict[str, Any]:
+    """Convert AddressInput to dictionary for JSON storage."""
+    return {
+        "name": address.name,
+        "line_one": address.line_one,
+        "line_two": address.line_two,
+        "city": address.city,
+        "state": address.state,
+        "country": address.country,
+        "postal_code": address.postal_code,
+        "phone_number": address.phone_number,
+    }
+
+
+def dict_to_address(data: dict[str, Any]) -> Address:
+    """Convert dictionary to Address response model."""
+    return Address(
+        name=data["name"],
+        line_one=data["line_one"],
+        line_two=data.get("line_two"),
+        city=data["city"],
+        state=data["state"],
+        country=data["country"],
+        postal_code=data["postal_code"],
+        phone_number=data.get("phone_number"),
+    )
+
+
+# =============================================================================
+# Line Item Functions
+# =============================================================================
+
+
+def calculate_line_item(
+    product: Product,
+    quantity: int,
+    discount_per_unit: int = 0,
+    promotion_info: dict[str, Any] | None = None,
+    line_item_id: str | None = None,
+) -> dict[str, Any]:
+    """Calculate line item totals for a product.
+
+    Args:
+        product: Product database model.
+        quantity: Quantity ordered.
+        discount_per_unit: Discount amount per unit in cents (default 0).
+        promotion_info: Optional promotion metadata (action, reason_codes, reasoning).
+        line_item_id: Optional existing line item ID to preserve (for updates).
+
+    Returns:
+        Dictionary with line item data for JSON storage.
+    """
+    base_amount = product.base_price * quantity
+    total_discount = discount_per_unit * quantity
+    subtotal = base_amount - total_discount
+    tax = int(subtotal * TAX_RATE)
+    total = subtotal + tax
+
+    line_item: dict[str, Any] = {
+        "id": line_item_id or generate_line_item_id(),
+        "item": {
+            "id": product.id,
+            "quantity": quantity,
+        },
+        "name": product.name,
+        "base_amount": base_amount,
+        "discount": total_discount,
+        "subtotal": subtotal,
+        "tax": tax,
+        "total": total,
+    }
+
+    # Add promotion metadata if available (include stock_count for agent activity display)
+    if promotion_info:
+        line_item["promotion"] = {
+            "action": promotion_info.get("action", "NO_PROMO"),
+            "reason_codes": promotion_info.get("reason_codes", []),
+            "reasoning": promotion_info.get("reasoning", ""),
+            "stock_count": product.stock_count,
+        }
+
+    return line_item
+
+
+async def calculate_line_item_with_promotion(
+    db: Session, product: Product, quantity: int
+) -> dict[str, Any]:
+    """Calculate line item with promotion agent discount.
+
+    Calls the promotion service to get dynamic pricing based on
+    inventory levels and competitor pricing.
+
+    Args:
+        db: Database session.
+        product: Product database model.
+        quantity: Quantity ordered.
+
+    Returns:
+        Dictionary with line item data including promotion discount.
+    """
+    # Get promotion decision from the agent (fail-open behavior)
+    promotion_result = await get_promotion_for_product(db, product)
+
+    # Calculate line item with the discount
+    return calculate_line_item(
+        product=product,
+        quantity=quantity,
+        discount_per_unit=promotion_result["discount"],
+        promotion_info=promotion_result,
+    )
+
+
+def recalculate_line_item_from_existing(
+    product: Product,
+    quantity: int,
+    existing_line_item: dict[str, Any],
+) -> dict[str, Any]:
+    """Recalculate line item totals using existing promotion data.
+
+    This function is used during session updates to avoid re-calling the
+    promotion agent. It preserves the per-unit discount from the original
+    promotion decision and recalculates totals for the new quantity.
+
+    Args:
+        product: Product database model.
+        quantity: New quantity ordered.
+        existing_line_item: Existing line item data with promotion info.
+
+    Returns:
+        Dictionary with recalculated line item data.
+    """
+    # Extract per-unit discount from existing line item
+    existing_quantity = existing_line_item["item"]["quantity"]
+    existing_discount = existing_line_item.get("discount", 0)
+
+    # Calculate per-unit discount (avoid division by zero)
+    if existing_quantity > 0:
+        discount_per_unit = existing_discount // existing_quantity
+    else:
+        discount_per_unit = 0
+
+    # Preserve existing promotion metadata
+    promotion_info = existing_line_item.get("promotion")
+
+    # Recalculate with new quantity, preserving the line item ID
+    return calculate_line_item(
+        product=product,
+        quantity=quantity,
+        discount_per_unit=discount_per_unit,
+        promotion_info=promotion_info,
+        line_item_id=existing_line_item["id"],
+    )
+
+
+def dict_to_line_item(data: dict[str, Any]) -> LineItem:
+    """Convert dictionary to LineItem response model."""
+    # Extract promotion metadata if present
+    promotion = None
+    if "promotion" in data and data["promotion"]:
+        promotion = PromotionMetadata(
+            action=data["promotion"].get("action", "NO_PROMO"),
+            reason_codes=data["promotion"].get("reason_codes", []),
+            reasoning=data["promotion"].get("reasoning", ""),
+            stock_count=data["promotion"].get("stock_count"),
+        )
+
+    return LineItem(
+        id=data["id"],
+        item=Item(id=data["item"]["id"], quantity=data["item"]["quantity"]),
+        name=data.get("name"),
+        base_amount=data["base_amount"],
+        discount=data["discount"],
+        subtotal=data["subtotal"],
+        tax=data["tax"],
+        total=data["total"],
+        promotion=promotion,
+    )
+
+
+# =============================================================================
+# Fulfillment Functions
+# =============================================================================
+
+
+def generate_fulfillment_options(has_address: bool) -> list[dict[str, Any]]:
+    """Generate available fulfillment options.
+
+    Args:
+        has_address: Whether a fulfillment address has been provided.
+
+    Returns:
+        List of fulfillment option dictionaries.
+    """
+    if not has_address:
+        return []
+
+    now = datetime.now(UTC)
+    standard_earliest = now + timedelta(days=5)
+    standard_latest = now + timedelta(days=7)
+    express_earliest = now + timedelta(days=2)
+    express_latest = now + timedelta(days=3)
+
+    return [
+        {
+            "type": "shipping",
+            "id": "shipping_standard",
+            "title": "Standard Shipping",
+            "subtitle": "5-7 business days",
+            "carrier_info": "USPS",
+            "earliest_delivery_time": standard_earliest.isoformat(),
+            "latest_delivery_time": standard_latest.isoformat(),
+            "subtotal": 599,
+            "tax": 0,
+            "total": 599,
+        },
+        {
+            "type": "shipping",
+            "id": "shipping_express",
+            "title": "Express Shipping",
+            "subtitle": "2-3 business days",
+            "carrier_info": "UPS",
+            "earliest_delivery_time": express_earliest.isoformat(),
+            "latest_delivery_time": express_latest.isoformat(),
+            "subtotal": 1299,
+            "tax": 0,
+            "total": 1299,
+        },
+    ]
+
+
+def dict_to_fulfillment_option(data: dict[str, Any]) -> ShippingFulfillmentOption:
+    """Convert dictionary to FulfillmentOption response model."""
+    return ShippingFulfillmentOption(
+        type=data["type"],
+        id=data["id"],
+        title=data["title"],
+        subtitle=data["subtitle"],
+        carrier_info=data["carrier_info"],
+        earliest_delivery_time=data["earliest_delivery_time"],
+        latest_delivery_time=data["latest_delivery_time"],
+        subtotal=data["subtotal"],
+        tax=data["tax"],
+        total=data["total"],
+    )
+
+
+# =============================================================================
+# Totals Functions
+# =============================================================================
+
+
+def calculate_totals(
+    line_items: list[dict[str, Any]],
+    fulfillment_options: list[dict[str, Any]],
+    selected_option_id: str | None,
+) -> list[dict[str, Any]]:
+    """Calculate checkout totals.
+
+    Args:
+        line_items: List of line item dictionaries.
+        fulfillment_options: List of fulfillment option dictionaries.
+        selected_option_id: ID of selected fulfillment option.
+
+    Returns:
+        List of total dictionaries.
+    """
+    items_base_amount: int = sum(item["base_amount"] for item in line_items)
+    items_discount: int = sum(item["discount"] for item in line_items)
+    items_subtotal: int = sum(item["subtotal"] for item in line_items)
+    items_tax: int = sum(item["tax"] for item in line_items)
+
+    # Get fulfillment cost if option selected
+    fulfillment_cost: int = 0
+    if selected_option_id:
+        for option in fulfillment_options:
+            if option["id"] == selected_option_id:
+                fulfillment_cost = int(option["total"])
+                break
+
+    total: int = items_subtotal + items_tax + fulfillment_cost
+
+    totals: list[dict[str, Any]] = [
+        {
+            "type": TotalTypeEnum.ITEMS_BASE_AMOUNT.value,
+            "display_text": "Items",
+            "amount": items_base_amount,
+        },
+    ]
+
+    if items_discount > 0:
+        totals.append(
+            {
+                "type": TotalTypeEnum.ITEMS_DISCOUNT.value,
+                "display_text": "Discount",
+                "amount": items_discount,
+            }
+        )
+
+    totals.extend(
+        [
+            {
+                "type": TotalTypeEnum.SUBTOTAL.value,
+                "display_text": "Subtotal",
+                "amount": items_subtotal,
+            },
+            {
+                "type": TotalTypeEnum.TAX.value,
+                "display_text": "Tax",
+                "amount": items_tax,
+            },
+        ]
+    )
+
+    if fulfillment_cost > 0:
+        totals.append(
+            {
+                "type": TotalTypeEnum.FULFILLMENT.value,
+                "display_text": "Shipping",
+                "amount": fulfillment_cost,
+            }
+        )
+
+    totals.append(
+        {
+            "type": TotalTypeEnum.TOTAL.value,
+            "display_text": "Total",
+            "amount": total,
+        }
+    )
+
+    return totals
+
+
+def dict_to_total(data: dict[str, Any]) -> Total:
+    """Convert dictionary to Total response model."""
+    return Total(
+        type=TotalTypeEnum(data["type"]),
+        display_text=data["display_text"],
+        amount=data["amount"],
+    )
+
+
+# =============================================================================
+# Link Functions
+# =============================================================================
+
+
+def generate_default_links() -> list[dict[str, Any]]:
+    """Generate default HATEOAS links."""
+    return [
+        {
+            "type": LinkTypeEnum.TERMS_OF_USE.value,
+            "url": f"{DEFAULT_SHOP_URL}/terms",
+        },
+        {
+            "type": LinkTypeEnum.PRIVACY_POLICY.value,
+            "url": f"{DEFAULT_SHOP_URL}/privacy",
+        },
+        {
+            "type": LinkTypeEnum.SELLER_SHOP_POLICIES.value,
+            "url": f"{DEFAULT_SHOP_URL}/policies",
+        },
+    ]
+
+
+def dict_to_link(data: dict[str, Any]) -> Link:
+    """Convert dictionary to Link response model."""
+    return Link(type=LinkTypeEnum(data["type"]), url=data["url"])
+
+
+# =============================================================================
+# Session Helper Functions
+# =============================================================================
+
+
+def check_ready_for_payment(session: CheckoutSession) -> bool:
+    """Check if session has all required fields for payment.
+
+    A session is ready for payment when:
+    - At least one line item exists
+    - Buyer info is provided
+    - Fulfillment address is provided
+    - Fulfillment option is selected
+
+    Args:
+        session: CheckoutSession database model.
+
+    Returns:
+        True if ready for payment, False otherwise.
+    """
+    line_items = json.loads(session.line_items_json)
+    if not line_items:
+        return False
+
+    if session.buyer_json is None:
+        return False
+
+    if session.fulfillment_address_json is None:
+        return False
+
+    return session.selected_fulfillment_option_id is not None
+
+
+def session_to_response(session: CheckoutSession) -> CheckoutSessionResponse:
+    """Convert CheckoutSession database model to API response.
+
+    Args:
+        session: CheckoutSession database model.
+
+    Returns:
+        CheckoutSessionResponse for API.
+    """
+    # Parse JSON fields
+    line_items_data: list[dict[str, Any]] = json.loads(session.line_items_json)
+    fulfillment_options_data: list[dict[str, Any]] = json.loads(
+        session.fulfillment_options_json
+    )
+    totals_data: list[dict[str, Any]] = (
+        json.loads(session.totals_json) if session.totals_json != "{}" else []
+    )
+    messages_data: list[dict[str, Any]] = json.loads(session.messages_json)
+    links_data: list[dict[str, Any]] = json.loads(session.links_json)
+
+    # Convert to response models
+    line_items = [dict_to_line_item(item) for item in line_items_data]
+    fulfillment_options: list[ShippingFulfillmentOption] = [
+        dict_to_fulfillment_option(opt) for opt in fulfillment_options_data
+    ]
+    totals = [dict_to_total(t) for t in totals_data] if totals_data else []
+    links = [dict_to_link(link) for link in links_data]
+
+    # Parse optional fields
+    buyer = None
+    if session.buyer_json:
+        buyer_data = json.loads(session.buyer_json)
+        buyer = dict_to_buyer(buyer_data)
+
+    fulfillment_address = None
+    if session.fulfillment_address_json:
+        address_data = json.loads(session.fulfillment_address_json)
+        fulfillment_address = dict_to_address(address_data)
+
+    order = None
+    if session.order_json:
+        order_data = json.loads(session.order_json)
+        order = Order(
+            id=order_data["id"],
+            checkout_session_id=order_data["checkout_session_id"],
+            permalink_url=order_data["permalink_url"],
+        )
+
+    # Convert messages
+    messages: list[MessageInfo] = [
+        MessageInfo(
+            param=msg_data["param"],
+            content_type=ContentTypeEnum(msg_data["content_type"]),
+            content=msg_data["content"],
+        )
+        for msg_data in messages_data
+    ]
+
+    return CheckoutSessionResponse(
+        id=session.id,
+        buyer=buyer,
+        payment_provider=PaymentProvider(
+            provider=PaymentProviderEnum.STRIPE,
+            supported_payment_methods=[PaymentMethodEnum.CARD],
+        ),
+        status=CheckoutStatusEnum(session.status.value),
+        currency=session.currency.lower(),
+        line_items=line_items,
+        fulfillment_address=fulfillment_address,
+        fulfillment_options=list(fulfillment_options),  # Cast for type compatibility
+        fulfillment_option_id=session.selected_fulfillment_option_id,
+        totals=totals,
+        messages=list(messages),  # Cast for type compatibility
+        links=links,
+        order=order,
+    )

--- a/src/merchant/services/post_purchase.py
+++ b/src/merchant/services/post_purchase.py
@@ -20,7 +20,7 @@ Designed for integration with Feature 11 (Webhook Integration).
 import asyncio
 import json
 import logging
-from enum import Enum
+from enum import StrEnum
 from typing import TypedDict
 
 import httpx
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-class ShippingStatus(str, Enum):
+class ShippingStatus(StrEnum):
     """Shipping status values for post-purchase communications."""
 
     ORDER_CONFIRMED = "order_confirmed"
@@ -49,7 +49,7 @@ class ShippingStatus(str, Enum):
 # =============================================================================
 
 
-class MessageTone(str, Enum):
+class MessageTone(StrEnum):
     """Available tone options for brand persona."""
 
     FRIENDLY = "friendly"  # Warm, enthusiastic, uses emojis sparingly
@@ -63,7 +63,7 @@ class MessageTone(str, Enum):
 # =============================================================================
 
 
-class SupportedLanguage(str, Enum):
+class SupportedLanguage(StrEnum):
     """Supported languages for message generation."""
 
     ENGLISH = "en"

--- a/src/merchant/services/promotion.py
+++ b/src/merchant/services/promotion.py
@@ -21,7 +21,7 @@ All prices are in CENTS (e.g., 2500 = $25.00).
 import asyncio
 import json
 import logging
-from enum import Enum
+from enum import StrEnum
 from typing import Any, TypedDict
 
 import httpx
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-class PromotionAction(str, Enum):
+class PromotionAction(StrEnum):
     """Allowed promotion actions - LLM must choose from these only.
 
     The ACP endpoint filters this list based on margin constraints
@@ -67,14 +67,14 @@ ACTION_DISCOUNT_MAP: dict[PromotionAction, float] = {
 # =============================================================================
 
 
-class InventoryPressure(str, Enum):
+class InventoryPressure(StrEnum):
     """Inventory pressure signal based on stock_count."""
 
     HIGH = "high"  # stock_count > STOCK_THRESHOLD
     LOW = "low"  # stock_count <= STOCK_THRESHOLD
 
 
-class CompetitionPosition(str, Enum):
+class CompetitionPosition(StrEnum):
     """Competition position signal based on price comparison."""
 
     ABOVE_MARKET = "above_market"  # base_price > lowest_competitor
@@ -94,7 +94,7 @@ STOCK_THRESHOLD = 50  # Units above this = high inventory pressure
 # =============================================================================
 
 
-class ReasonCode(str, Enum):
+class ReasonCode(StrEnum):
     """Standard reason codes for promotion decisions."""
 
     HIGH_INVENTORY = "HIGH_INVENTORY"

--- a/src/payment/api/schemas.py
+++ b/src/payment/api/schemas.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for PSP delegated payment endpoints."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -11,28 +11,28 @@ from pydantic import BaseModel, ConfigDict, Field
 # =============================================================================
 
 
-class CardNumberTypeEnum(str, Enum):
+class CardNumberTypeEnum(StrEnum):
     """Card number type."""
 
     FPAN = "fpan"
     DPAN = "dpan"
 
 
-class AllowanceReasonEnum(str, Enum):
+class AllowanceReasonEnum(StrEnum):
     """Allowance reason type."""
 
     ONE_TIME = "one_time"
     SUBSCRIPTION = "subscription"
 
 
-class PaymentIntentStatusEnum(str, Enum):
+class PaymentIntentStatusEnum(StrEnum):
     """Payment intent status."""
 
     PENDING = "pending"
     COMPLETED = "completed"
 
 
-class RiskSignalTypeEnum(str, Enum):
+class RiskSignalTypeEnum(StrEnum):
     """Risk signal types."""
 
     CARD_TESTING = "card_testing"
@@ -40,7 +40,7 @@ class RiskSignalTypeEnum(str, Enum):
     VELOCITY = "velocity"
 
 
-class RiskSignalActionEnum(str, Enum):
+class RiskSignalActionEnum(StrEnum):
     """Risk signal actions."""
 
     AUTHORIZED = "authorized"
@@ -199,7 +199,7 @@ class PaymentIntentResponse(BaseModel):
 # =============================================================================
 
 
-class ErrorTypeEnum(str, Enum):
+class ErrorTypeEnum(StrEnum):
     """Error response types."""
 
     INVALID_REQUEST = "invalid_request"
@@ -211,7 +211,7 @@ class ErrorTypeEnum(str, Enum):
     FORBIDDEN = "forbidden"
 
 
-class ErrorCodeEnum(str, Enum):
+class ErrorCodeEnum(StrEnum):
     """Error response codes."""
 
     CHECKOUT_SESSION_NOT_FOUND = "checkout_session_not_found"

--- a/src/payment/db/models.py
+++ b/src/payment/db/models.py
@@ -1,7 +1,7 @@
 """SQLModel database models for the PSP (Payment Service Provider)."""
 
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import ClassVar
 
 from sqlmodel import Field, SQLModel
@@ -12,14 +12,14 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
-class VaultTokenStatus(str, Enum):
+class VaultTokenStatus(StrEnum):
     """Vault token status values."""
 
     ACTIVE = "active"
     CONSUMED = "consumed"
 
 
-class PaymentIntentStatus(str, Enum):
+class PaymentIntentStatus(StrEnum):
     """Payment intent status values."""
 
     PENDING = "pending"

--- a/src/ui/app/api/webhooks/acp/route.ts
+++ b/src/ui/app/api/webhooks/acp/route.ts
@@ -209,3 +209,14 @@ export async function GET(request: NextRequest) {
     count: filteredEvents.length,
   });
 }
+
+/**
+ * DELETE endpoint to clear all stored webhook events
+ * Called on page load/refresh and tab switch to start fresh
+ */
+export async function DELETE() {
+  const count = webhookEvents.length;
+  webhookEvents.length = 0; // Clear the array in place
+  console.log(`[Webhook] Cleared ${count} stored events`);
+  return NextResponse.json({ cleared: count });
+}

--- a/src/ui/components/WebhookToAgentActivityBridge.test.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.test.tsx
@@ -27,6 +27,7 @@ class MockEventSource {
   onerror: (() => void) | null = null;
   constructor(url: string) {
     this.url = url;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     mockEventSourceInstance = this;
   }
   close() {

--- a/src/ui/components/WebhookToAgentActivityBridge.test.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, act } from "@testing-library/react";
 import { WebhookToAgentActivityBridge } from "./WebhookToAgentActivityBridge";
 
 const addPostPurchaseEvent = vi.fn();
@@ -19,12 +19,15 @@ vi.mock("@/hooks/useACPLog", () => ({
   }),
 }));
 
+let mockEventSourceInstance: MockEventSource | null = null;
+
 class MockEventSource {
   url: string;
   onmessage: ((event: MessageEvent) => void) | null = null;
   onerror: (() => void) | null = null;
   constructor(url: string) {
     this.url = url;
+    mockEventSourceInstance = this;
   }
   close() {
     // no-op
@@ -36,14 +39,17 @@ describe("WebhookToAgentActivityBridge", () => {
     addPostPurchaseEvent.mockClear();
     logEvent.mockClear();
     completeEvent.mockClear();
+    mockEventSourceInstance = null;
     global.EventSource = MockEventSource as unknown as typeof EventSource;
+    // Mock fetch for the DELETE call on mount
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("processes missed webhook events from polling", async () => {
+  it("processes shipping_update events received via SSE", async () => {
     const shippingEvent = {
       id: "evt_1",
       type: "shipping_update",
@@ -59,17 +65,33 @@ describe("WebhookToAgentActivityBridge", () => {
       },
     };
 
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ events: [shippingEvent] }),
-    });
-    global.fetch = fetchMock;
-
     render(<WebhookToAgentActivityBridge />);
 
+    // Wait for EventSource to be created
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalled();
-      expect(addPostPurchaseEvent).toHaveBeenCalled();
+      expect(mockEventSourceInstance).not.toBeNull();
+    });
+
+    // Simulate SSE message
+    act(() => {
+      mockEventSourceInstance?.onmessage?.(
+        new MessageEvent("message", { data: JSON.stringify(shippingEvent) })
+      );
+    });
+
+    await waitFor(() => {
+      expect(addPostPurchaseEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: "order_123",
+          status: "order_shipped",
+          language: "en",
+        }),
+        expect.objectContaining({
+          subject: "Your order is on the way",
+          message: "Tracking details inside",
+        }),
+        "success"
+      );
     });
   });
 });

--- a/src/ui/components/WebhookToAgentActivityBridge.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.tsx
@@ -38,7 +38,6 @@ export function WebhookToAgentActivityBridge() {
   const { addPostPurchaseEvent } = useAgentActivityLog();
   const { logEvent, completeEvent } = useACPLog();
   const seenEventIdsRef = useRef<Set<string>>(new Set());
-  const lastReceivedAtRef = useRef<string | null>(null);
 
   const addPostPurchaseEventRef = useRef(addPostPurchaseEvent);
   const logEventRef = useRef(logEvent);
@@ -53,15 +52,6 @@ export function WebhookToAgentActivityBridge() {
   const processWebhookEvent = useCallback((event: WebhookEvent) => {
     if (seenEventIdsRef.current.has(event.id)) return;
     seenEventIdsRef.current.add(event.id);
-
-    if (event.receivedAt) {
-      if (
-        !lastReceivedAtRef.current ||
-        new Date(event.receivedAt) > new Date(lastReceivedAtRef.current)
-      ) {
-        lastReceivedAtRef.current = event.receivedAt;
-      }
-    }
 
     if (event.type !== "shipping_update") return;
 
@@ -136,34 +126,22 @@ export function WebhookToAgentActivityBridge() {
     });
   }, []);
 
-  const fetchMissedEvents = useCallback(async () => {
-    try {
-      const params = new URLSearchParams();
-      if (lastReceivedAtRef.current) {
-        params.set("since", lastReceivedAtRef.current);
-      }
-      const response = await fetch(
-        `/api/webhooks/acp${params.toString() ? `?${params.toString()}` : ""}`
-      );
-      if (!response.ok) {
-        return;
-      }
-      const data = await response.json();
-      const events = Array.isArray(data.events) ? data.events : [];
-      events.forEach((event: WebhookEvent) => {
-        processWebhookEvent(event);
-      });
-    } catch {
-      // Ignore fetch errors - SSE will keep trying
-    }
-  }, [processWebhookEvent]);
-
   useEffect(() => {
     let eventSource: EventSource | null = null;
     let reconnectTimeout: NodeJS.Timeout | null = null;
+    let isMounted = true;
 
-    const connect = () => {
-      fetchMissedEvents();
+    const connect = async () => {
+      // On fresh page load, clear server-side stored events to start fresh
+      // This ensures refreshing the page resets all logs to 0
+      try {
+        await fetch("/api/webhooks/acp", { method: "DELETE" });
+      } catch {
+        // Ignore errors - server may not be running
+      }
+
+      if (!isMounted) return;
+
       eventSource = new EventSource("/api/webhooks/sse");
       eventSource.onmessage = (event: MessageEvent) => {
         try {
@@ -176,17 +154,22 @@ export function WebhookToAgentActivityBridge() {
       };
       eventSource.onerror = () => {
         eventSource?.close();
-        fetchMissedEvents();
-        reconnectTimeout = setTimeout(connect, 5000);
+        // On reconnect, don't fetch missed events - we want fresh start behavior
+        reconnectTimeout = setTimeout(() => {
+          if (isMounted) {
+            eventSource = new EventSource("/api/webhooks/sse");
+          }
+        }, 5000);
       };
     };
 
     connect();
     return () => {
+      isMounted = false;
       eventSource?.close();
       if (reconnectTimeout) clearTimeout(reconnectTimeout);
     };
-  }, [processWebhookEvent, fetchMissedEvents]);
+  }, [processWebhookEvent]);
 
   return null; // No UI - just event dispatching
 }

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -464,6 +464,10 @@ export function AgentPanel() {
       // Clear both panels when switching modes to start fresh
       acpLog.clear();
       agentActivityLog.clear();
+      // Clear server-side webhook store to ensure clean slate
+      fetch("/api/webhooks/acp", { method: "DELETE" }).catch(() => {
+        // Ignore errors - server may not be running
+      });
       // Clear any post-purchase notification when switching tabs
       setNotification(null);
       // Reset native checkout flow when switching modes

--- a/src/ui/components/agent/SearchPromptBar.tsx
+++ b/src/ui/components/agent/SearchPromptBar.tsx
@@ -39,7 +39,7 @@ export function SearchPromptBar({ value, onChange, onSubmit }: SearchPromptBarPr
           type="search"
           value={value}
           onChange={handleChange}
-          placeholder="Search for products..."
+          placeholder="show me some shoes"
           className="nv-text-input-element px-4"
           aria-label="Search query"
         />

--- a/src/ui/hooks/useMCPClient.ts
+++ b/src/ui/hooks/useMCPClient.ts
@@ -112,7 +112,7 @@ export function useMCPClient() {
               arguments: args,
             },
           }),
-          signal: AbortSignal.timeout(10000),
+          signal: AbortSignal.timeout(65000), // 65s timeout for search agent (can take 20-30s)
         });
 
         if (!response.ok) {

--- a/tests/apps_sdk/conftest.py
+++ b/tests/apps_sdk/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -70,6 +71,27 @@ def mock_merchant_api() -> Generator[None, None, None]:
     with patch(
         "src.apps_sdk.tools.cart.find_product",
         new=AsyncMock(side_effect=mock_find_product),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_checkout_http_client() -> Generator[None, None, None]:
+    """Mock HTTP client for checkout operations.
+
+    Forces the simulated checkout fallback by raising ConnectError,
+    ensuring tests don't depend on external merchant/PSP services.
+    """
+
+    async def mock_aenter(_self: Any) -> Any:
+        raise httpx.ConnectError("Mocked connection error for tests")
+
+    async def mock_aexit(_self: Any, *_args: Any) -> None:
+        pass
+
+    with (
+        patch.object(httpx.AsyncClient, "__aenter__", mock_aenter),
+        patch.object(httpx.AsyncClient, "__aexit__", mock_aexit),
     ):
         yield
 

--- a/tests/merchant/db/test_database.py
+++ b/tests/merchant/db/test_database.py
@@ -65,6 +65,7 @@ class TestDatabaseInitialization:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
 
@@ -84,6 +85,7 @@ class TestDatabaseInitialization:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
             init_db()
@@ -99,6 +101,7 @@ class TestSeedData:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
 
@@ -114,6 +117,7 @@ class TestSeedData:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
 
@@ -129,6 +133,7 @@ class TestSeedData:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
 
@@ -146,6 +151,7 @@ class TestSeedData:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
 
@@ -170,6 +176,7 @@ class TestSeedData:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
 
@@ -195,6 +202,7 @@ class TestGetSession:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_db()
 
@@ -216,6 +224,7 @@ class TestInitAndSeedDb:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 
@@ -237,6 +246,7 @@ class TestCompetitorPriceRelationship:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 
@@ -265,6 +275,7 @@ class TestCustomerAndBrowseHistorySeeding:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 
@@ -283,6 +294,7 @@ class TestCustomerAndBrowseHistorySeeding:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 
@@ -296,6 +308,7 @@ class TestCustomerAndBrowseHistorySeeding:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 
@@ -314,6 +327,7 @@ class TestCustomerAndBrowseHistorySeeding:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 
@@ -332,6 +346,7 @@ class TestCustomerAndBrowseHistorySeeding:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 
@@ -359,6 +374,7 @@ class TestCustomerAndBrowseHistorySeeding:
         with patch("src.merchant.db.database.get_settings") as mock_settings:
             mock_settings.return_value.database_url = temp_db_url
             mock_settings.return_value.debug = False
+            mock_settings.return_value.log_sql = False
 
             init_and_seed_db()
 

--- a/tests/merchant/services/test_checkout.py
+++ b/tests/merchant/services/test_checkout.py
@@ -9,9 +9,9 @@ Tests cover:
 import pytest
 
 from src.merchant.db.models import Product
-from src.merchant.services.checkout import (
-    _calculate_line_item,
-    _recalculate_line_item_from_existing,
+from src.merchant.services.helpers import (
+    calculate_line_item,
+    recalculate_line_item_from_existing,
 )
 
 # =============================================================================
@@ -72,22 +72,22 @@ def existing_line_item_no_discount() -> dict:
 
 
 # =============================================================================
-# _calculate_line_item Tests
+# calculate_line_item Tests
 # =============================================================================
 
 
 class TestCalculateLineItem:
-    """Tests for the _calculate_line_item function."""
+    """Tests for the calculate_line_item function."""
 
     def test_calculates_base_amount_correctly(self, sample_product: Product) -> None:
         """Happy path: Base amount is quantity * base_price."""
-        result = _calculate_line_item(sample_product, quantity=3)
+        result = calculate_line_item(sample_product, quantity=3)
 
         assert result["base_amount"] == 7500  # 3 * 2500
 
     def test_calculates_discount_correctly(self, sample_product: Product) -> None:
         """Happy path: Discount is quantity * discount_per_unit."""
-        result = _calculate_line_item(sample_product, quantity=2, discount_per_unit=250)
+        result = calculate_line_item(sample_product, quantity=2, discount_per_unit=250)
 
         assert result["discount"] == 500  # 2 * 250
 
@@ -95,7 +95,7 @@ class TestCalculateLineItem:
         self, sample_product: Product
     ) -> None:
         """Happy path: Subtotal is base_amount - discount."""
-        result = _calculate_line_item(sample_product, quantity=2, discount_per_unit=250)
+        result = calculate_line_item(sample_product, quantity=2, discount_per_unit=250)
 
         assert result["subtotal"] == 4500  # 5000 - 500
 
@@ -103,7 +103,7 @@ class TestCalculateLineItem:
         self, sample_product: Product
     ) -> None:
         """Happy path: Tax is 10% of subtotal."""
-        result = _calculate_line_item(sample_product, quantity=2)
+        result = calculate_line_item(sample_product, quantity=2)
 
         # base_amount = 5000, discount = 0, subtotal = 5000
         # tax = 5000 * 0.10 = 500
@@ -113,7 +113,7 @@ class TestCalculateLineItem:
         self, sample_product: Product
     ) -> None:
         """Happy path: Total is subtotal + tax."""
-        result = _calculate_line_item(sample_product, quantity=2)
+        result = calculate_line_item(sample_product, quantity=2)
 
         # subtotal = 5000, tax = 500, total = 5500
         assert result["total"] == 5500
@@ -122,7 +122,7 @@ class TestCalculateLineItem:
         self, sample_product: Product
     ) -> None:
         """Happy path: Generates a new line item ID."""
-        result = _calculate_line_item(sample_product, quantity=1)
+        result = calculate_line_item(sample_product, quantity=1)
 
         assert result["id"].startswith("li_")
 
@@ -130,7 +130,7 @@ class TestCalculateLineItem:
         self, sample_product: Product
     ) -> None:
         """Happy path: Preserves existing line item ID when provided."""
-        result = _calculate_line_item(
+        result = calculate_line_item(
             sample_product, quantity=1, line_item_id="li_preserved"
         )
 
@@ -145,7 +145,7 @@ class TestCalculateLineItem:
             "reason_codes": ["HIGH_INVENTORY"],
             "reasoning": "Test reasoning",
         }
-        result = _calculate_line_item(
+        result = calculate_line_item(
             sample_product, quantity=1, promotion_info=promotion_info
         )
 
@@ -156,7 +156,7 @@ class TestCalculateLineItem:
 
     def test_no_promotion_when_none_provided(self, sample_product: Product) -> None:
         """Edge case: No promotion key when promotion_info is None."""
-        result = _calculate_line_item(sample_product, quantity=1)
+        result = calculate_line_item(sample_product, quantity=1)
 
         assert "promotion" not in result
 
@@ -164,7 +164,7 @@ class TestCalculateLineItem:
         self, sample_product: Product
     ) -> None:
         """Edge case: Zero quantity results in zero amounts."""
-        result = _calculate_line_item(sample_product, quantity=0)
+        result = calculate_line_item(sample_product, quantity=0)
 
         assert result["base_amount"] == 0
         assert result["discount"] == 0
@@ -174,12 +174,12 @@ class TestCalculateLineItem:
 
 
 # =============================================================================
-# _recalculate_line_item_from_existing Tests
+# recalculate_line_item_from_existing Tests
 # =============================================================================
 
 
 class TestRecalculateLineItemFromExisting:
-    """Tests for the _recalculate_line_item_from_existing function.
+    """Tests for the recalculate_line_item_from_existing function.
 
     This is the key optimization: reuse existing promotion data
     instead of re-calling the promotion agent.
@@ -191,7 +191,7 @@ class TestRecalculateLineItemFromExisting:
         """Happy path: Per-unit discount is preserved when quantity changes."""
         # Original: 2 items with $5.00 total discount = $2.50 per unit
         # New: 4 items should have $10.00 total discount
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product,
             quantity=4,
             existing_line_item=existing_line_item_with_discount,
@@ -205,7 +205,7 @@ class TestRecalculateLineItemFromExisting:
         self, sample_product: Product, existing_line_item_with_discount: dict
     ) -> None:
         """Happy path: Base amount is recalculated for new quantity."""
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product,
             quantity=5,
             existing_line_item=existing_line_item_with_discount,
@@ -218,7 +218,7 @@ class TestRecalculateLineItemFromExisting:
         self, sample_product: Product, existing_line_item_with_discount: dict
     ) -> None:
         """Happy path: Subtotal, tax, and total are recalculated correctly."""
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product,
             quantity=4,
             existing_line_item=existing_line_item_with_discount,
@@ -239,7 +239,7 @@ class TestRecalculateLineItemFromExisting:
         self, sample_product: Product, existing_line_item_with_discount: dict
     ) -> None:
         """Happy path: Line item ID is preserved from existing item."""
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product,
             quantity=3,
             existing_line_item=existing_line_item_with_discount,
@@ -251,7 +251,7 @@ class TestRecalculateLineItemFromExisting:
         self, sample_product: Product, existing_line_item_with_discount: dict
     ) -> None:
         """Happy path: Promotion metadata is preserved from existing item."""
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product,
             quantity=3,
             existing_line_item=existing_line_item_with_discount,
@@ -266,7 +266,7 @@ class TestRecalculateLineItemFromExisting:
         self, sample_product: Product, existing_line_item_no_discount: dict
     ) -> None:
         """Edge case: Handles items with no discount correctly."""
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product,
             quantity=3,
             existing_line_item=existing_line_item_no_discount,
@@ -288,7 +288,7 @@ class TestRecalculateLineItemFromExisting:
             "total": 0,
         }
 
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product, quantity=2, existing_line_item=existing_item
         )
 
@@ -309,7 +309,7 @@ class TestRecalculateLineItemFromExisting:
             # No "promotion" key
         }
 
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product, quantity=2, existing_line_item=existing_item
         )
 
@@ -329,7 +329,7 @@ class TestRecalculateLineItemFromExisting:
             "total": 2750,
         }
 
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product, quantity=2, existing_line_item=existing_item
         )
 
@@ -340,7 +340,7 @@ class TestRecalculateLineItemFromExisting:
         self, sample_product: Product, existing_line_item_with_discount: dict
     ) -> None:
         """Edge case: Single quantity preserves per-unit discount exactly."""
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product,
             quantity=1,
             existing_line_item=existing_line_item_with_discount,
@@ -386,7 +386,7 @@ class TestUpdateSessionSkipsPromotionAgent:
         }
 
         # When quantity increases to 5, discount should scale proportionally
-        result = _recalculate_line_item_from_existing(
+        result = recalculate_line_item_from_existing(
             sample_product, quantity=5, existing_line_item=existing_item
         )
 
@@ -415,10 +415,10 @@ class TestUpdateSessionSkipsPromotionAgent:
             },
         }
 
-        result_qty_2 = _recalculate_line_item_from_existing(
+        result_qty_2 = recalculate_line_item_from_existing(
             sample_product, quantity=2, existing_line_item=existing_item
         )
-        result_qty_10 = _recalculate_line_item_from_existing(
+        result_qty_10 = recalculate_line_item_from_existing(
             sample_product, quantity=10, existing_line_item=existing_item
         )
 


### PR DESCRIPTION
## Summary

### MCP Client & Search UI
- Increase MCP client timeout from 10s to 65s to prevent request abortion when search agent takes 20-30s
- Update search input placeholder to "show me some shoes" for better UX guidance

### Backend Refactoring
- Extract checkout helper functions to new `helpers.py` module (~500 lines) for better code organization
- Enhance logging middleware with request correlation IDs and structured traceability
- Skip logging for health check endpoints to reduce noise
- Add context variable for request ID propagation across async calls

### Frontend Webhook Handling
- Simplify `WebhookToAgentActivityBridge` to use SSE-only (remove polling for missed events)
- Add fresh start behavior - clear server events on page load via DELETE endpoint
- Fix test to match the refactored SSE-only implementation

### Documentation
- Update README architecture diagram with Search Agent (port 8005)
- Add NIMs section (Nemotron Nano LLM, NV-EmbedQA-E5)
- Add Data Stores section (SQLite, Milvus)
- Show agent-to-NIM and NIM-to-vector-DB connections

### Test Fixes
- Fix `WebhookToAgentActivityBridge` test to match SSE-only implementation
- Add mock for checkout HTTP client in apps_sdk tests to use simulated fallback
- Update checkout service tests for refactored code

## Test plan
- [x] Frontend TypeScript check passes
- [x] Frontend ESLint passes
- [x] Frontend Prettier check passes
- [x] Frontend unit tests pass (193/193)
- [x] Backend apps_sdk tests pass (44/44)
- [x] Manual testing: Search requests no longer timeout after 10s