### PR TITLE
[backend] Add UCP Phase 1 discovery endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,7 @@ Backend:
 - API routes: `src/merchant/api/routes/`
 - Business logic: `src/merchant/services/`
 - Models: `src/merchant/db/models.py`
+- UCP discovery: `src/merchant/api/routes/ucp/discovery.py`, `src/merchant/api/ucp_schemas.py`, `src/merchant/services/ucp.py`
 
 Frontend:
 - Main UI layout: `src/ui/app/page.tsx`

--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ curl http://localhost:8001/health  # PSP Service
 curl http://localhost:2091/health  # Apps SDK
 ```
 
+### UCP Discovery (Phase 1)
+
+```bash
+curl http://localhost:8000/.well-known/ucp
+```
+
+Optional environment variables for UCP discovery:
+
+```env
+UCP_VERSION=2026-01-11
+UCP_BASE_URL=http://localhost:8000
+UCP_SERVICE_PATH=/ucp/v1
+UCP_SIGNING_KEY_ID=ucp-key-1
+UCP_SIGNING_KEY_KTY=EC
+UCP_SIGNING_KEY_CRV=P-256
+UCP_SIGNING_KEY_ALG=ES256
+UCP_SIGNING_KEY_X=
+UCP_SIGNING_KEY_Y=
+```
+
 Visit **http://localhost:3000** to see the demo UI.
 
 ## Architecture

--- a/env.example
+++ b/env.example
@@ -46,6 +46,18 @@ MERCHANT_API_KEY=merchant-api-key-12345
 WEBHOOK_URL=http://localhost:3000/api/webhooks/acp
 WEBHOOK_SECRET=whsec_demo_secret
 
+# UCP Discovery Configuration
+UCP_VERSION=2026-01-11
+UCP_BASE_URL=
+UCP_SERVICE_PATH=/ucp/v1
+UCP_BUSINESS_NAME=
+UCP_SIGNING_KEY_ID=ucp-key-1
+UCP_SIGNING_KEY_KTY=EC
+UCP_SIGNING_KEY_CRV=P-256
+UCP_SIGNING_KEY_ALG=ES256
+UCP_SIGNING_KEY_X=
+UCP_SIGNING_KEY_Y=
+
 # =============================================================================
 # PSP (Payment Service Provider) Configuration
 # =============================================================================

--- a/src/merchant/api/routes/ucp/__init__.py
+++ b/src/merchant/api/routes/ucp/__init__.py
@@ -1,0 +1,1 @@
+"""UCP API routes package."""

--- a/src/merchant/api/routes/ucp/discovery.py
+++ b/src/merchant/api/routes/ucp/discovery.py
@@ -1,0 +1,20 @@
+"""UCP discovery endpoint."""
+
+from fastapi import APIRouter, Request
+
+from src.merchant.api.ucp_schemas import UCPBusinessProfile
+from src.merchant.services.ucp import build_business_profile
+
+router = APIRouter(tags=["ucp"])
+
+
+@router.get(
+    "/.well-known/ucp",
+    response_model=UCPBusinessProfile,
+    summary="UCP Business Profile Discovery",
+    description="Returns the merchant's UCP profile with capabilities. Public endpoint.",
+)
+async def get_ucp_profile(request: Request) -> UCPBusinessProfile:
+    """Return static UCP business profile for discovery."""
+    request_base_url = str(request.base_url).rstrip("/")
+    return build_business_profile(request_base_url=request_base_url)

--- a/src/merchant/api/ucp_schemas.py
+++ b/src/merchant/api/ucp_schemas.py
@@ -1,0 +1,72 @@
+"""Pydantic schemas for UCP discovery profile."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UCPService(BaseModel):
+    """UCP service endpoint definition."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    version: str
+    transport: str  # "rest" for Phase 1
+    endpoint: str
+    spec: str | None = None
+    schema_url: str | None = Field(default=None, serialization_alias="schema")
+
+
+class UCPCapabilityVersion(BaseModel):
+    """UCP capability with version and optional extension parent."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    version: str
+    spec: str | None = None
+    schema_url: str | None = Field(default=None, serialization_alias="schema")
+    extends: str | None = None  # For extensions like fulfillment
+
+
+class UCPPaymentHandler(BaseModel):
+    """Optional payment handler definition."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    version: str
+    spec: str | None = None
+    schema_url: str | None = Field(default=None, serialization_alias="schema")
+    config: dict[str, Any] | None = None  # Optional handler config per spec
+
+
+class UCPSigningKey(BaseModel):
+    """JWK signing key for webhook verification.
+
+    Supports both EC (P-256) and OKP (Ed25519) key types per spec.
+    - EC P-256: kty="EC", crv="P-256", alg="ES256", x and y required
+    - OKP Ed25519: kty="OKP", crv="Ed25519", alg="EdDSA", x required, y omitted
+    """
+
+    kid: str  # Key ID (e.g., "business_2025")
+    kty: str  # Key type: "EC" or "OKP"
+    crv: str  # Curve: "P-256" or "Ed25519"
+    x: str  # Public key x coordinate (base64url)
+    y: str | None = None  # Public key y coordinate (base64url, EC only)
+    alg: str  # Algorithm: "ES256" or "EdDSA"
+
+
+class UCPMetadata(BaseModel):
+    """Core UCP metadata in discovery profile."""
+
+    version: str
+    services: dict[str, list[UCPService]]
+    capabilities: dict[str, list[UCPCapabilityVersion]]
+    payment_handlers: dict[str, list[UCPPaymentHandler]] | None = None
+
+
+class UCPBusinessProfile(BaseModel):
+    """Top-level UCP business profile returned by discovery."""
+
+    ucp: UCPMetadata
+    signing_keys: list[UCPSigningKey] | None = None

--- a/src/merchant/config.py
+++ b/src/merchant/config.py
@@ -33,6 +33,20 @@ class Settings(BaseSettings):
     # Merchant API Security (for client authentication)
     merchant_api_key: str = ""
 
+    # UCP Discovery Configuration
+    ucp_version: str = "2026-01-11"
+    ucp_base_url: str | None = None  # Fully qualified base URL; None derives from request
+    ucp_service_path: str = "/ucp/v1"
+    ucp_business_name: str | None = None
+
+    # UCP Signing Key (public key for webhook verification)
+    ucp_signing_key_id: str = "ucp-key-1"
+    ucp_signing_key_kty: str = "EC"  # "EC" or "OKP"
+    ucp_signing_key_crv: str = "P-256"  # "P-256" or "Ed25519"
+    ucp_signing_key_alg: str = "ES256"  # "ES256" or "EdDSA"
+    ucp_signing_key_x: str = ""  # Base64url-encoded public key x
+    ucp_signing_key_y: str = ""  # Base64url-encoded public key y (EC only)
+
     # Promotion Agent Configuration
     promotion_agent_url: str = "http://localhost:8002"
     promotion_agent_timeout: float = 10.0  # seconds (NFR-LAT target)

--- a/src/merchant/config.py
+++ b/src/merchant/config.py
@@ -35,7 +35,9 @@ class Settings(BaseSettings):
 
     # UCP Discovery Configuration
     ucp_version: str = "2026-01-11"
-    ucp_base_url: str | None = None  # Fully qualified base URL; None derives from request
+    ucp_base_url: str | None = (
+        None  # Fully qualified base URL; None derives from request
+    )
     ucp_service_path: str = "/ucp/v1"
     ucp_business_name: str | None = None
 

--- a/src/merchant/main.py
+++ b/src/merchant/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.merchant.api.routes.checkout import router as checkout_router
 from src.merchant.api.routes.health import router as health_router
 from src.merchant.api.routes.products import router as products_router
+from src.merchant.api.routes.ucp.discovery import router as ucp_discovery_router
 from src.merchant.config import get_settings
 from src.merchant.db import init_and_seed_db
 from src.merchant.middleware import ACPHeadersMiddleware, RequestLoggingMiddleware
@@ -99,3 +100,4 @@ app.add_middleware(RequestLoggingMiddleware)
 app.include_router(health_router)
 app.include_router(checkout_router)
 app.include_router(products_router)
+app.include_router(ucp_discovery_router)

--- a/src/merchant/services/ucp.py
+++ b/src/merchant/services/ucp.py
@@ -1,0 +1,86 @@
+"""UCP discovery profile helpers."""
+
+from src.merchant.api.ucp_schemas import (
+    UCPBusinessProfile,
+    UCPCapabilityVersion,
+    UCPMetadata,
+    UCPPaymentHandler,
+    UCPService,
+    UCPSigningKey,
+)
+from src.merchant.config import get_settings
+
+
+def build_business_profile(request_base_url: str | None = None) -> UCPBusinessProfile:
+    """Build static UCP business profile from configuration.
+
+    Returns a minimal discovery profile with:
+    - dev.ucp.shopping service (REST transport)
+    - dev.ucp.shopping.checkout capability
+    - dev.ucp.shopping.fulfillment extension
+    - dev.ucp.shopping.discount capability
+    - Optional static payment handler block
+    - Top-level signing_keys for webhook verification
+
+    Args:
+        request_base_url: Fallback base URL from request if ucp_base_url not configured.
+    """
+    settings = get_settings()
+
+    base_url = settings.ucp_base_url or request_base_url
+    if not base_url:
+        raise ValueError("ucp_base_url not configured and no request base URL provided")
+
+    service_endpoint = f"{base_url.rstrip('/')}{settings.ucp_service_path}"
+
+    signing_keys: list[UCPSigningKey] | None = None
+    if settings.ucp_signing_key_x:
+        signing_keys = [
+            UCPSigningKey(
+                kid=settings.ucp_signing_key_id,
+                kty=settings.ucp_signing_key_kty,
+                crv=settings.ucp_signing_key_crv,
+                x=settings.ucp_signing_key_x,
+                y=settings.ucp_signing_key_y or None,
+                alg=settings.ucp_signing_key_alg,
+            )
+        ]
+
+    return UCPBusinessProfile(
+        ucp=UCPMetadata(
+            version=settings.ucp_version,
+            services={
+                "dev.ucp.shopping": [
+                    UCPService(
+                        version=settings.ucp_version,
+                        transport="rest",
+                        endpoint=service_endpoint,
+                    )
+                ]
+            },
+            capabilities={
+                "dev.ucp.shopping.checkout": [
+                    UCPCapabilityVersion(version=settings.ucp_version)
+                ],
+                "dev.ucp.shopping.fulfillment": [
+                    UCPCapabilityVersion(
+                        version=settings.ucp_version,
+                        extends="dev.ucp.shopping.checkout",
+                    )
+                ],
+                "dev.ucp.shopping.discount": [
+                    UCPCapabilityVersion(version=settings.ucp_version)
+                ],
+            },
+            payment_handlers={
+                "com.example.processor_tokenizer": [
+                    UCPPaymentHandler(
+                        id="processor_tokenizer",
+                        version=settings.ucp_version,
+                        config=None,
+                    )
+                ]
+            },
+        ),
+        signing_keys=signing_keys,
+    )

--- a/tests/merchant/api/test_ucp_discovery.py
+++ b/tests/merchant/api/test_ucp_discovery.py
@@ -1,0 +1,103 @@
+"""Tests for UCP discovery endpoint."""
+
+from fastapi.testclient import TestClient
+
+from src.merchant.config import get_settings
+
+
+class TestUCPDiscovery:
+    def test_get_profile_returns_200(self, client: TestClient) -> None:
+        """GET /.well-known/ucp returns 200."""
+        response = client.get("/.well-known/ucp")
+        assert response.status_code == 200
+
+    def test_profile_has_ucp_metadata(self, client: TestClient) -> None:
+        """Profile contains ucp metadata with version."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        assert "ucp" in data
+        assert "version" in data["ucp"]
+
+    def test_profile_includes_shopping_service(self, client: TestClient) -> None:
+        """Profile includes dev.ucp.shopping service with fully qualified URL."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        services = data["ucp"]["services"]
+        assert "dev.ucp.shopping" in services
+        service = services["dev.ucp.shopping"][0]
+        assert service["transport"] == "rest"
+        assert service["endpoint"].startswith("http")
+
+    def test_profile_includes_checkout_capability(self, client: TestClient) -> None:
+        """Profile includes dev.ucp.shopping.checkout capability."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        capabilities = data["ucp"]["capabilities"]
+        assert "dev.ucp.shopping.checkout" in capabilities
+
+    def test_profile_includes_fulfillment_extension(self, client: TestClient) -> None:
+        """Profile includes dev.ucp.shopping.fulfillment with extends field."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        capabilities = data["ucp"]["capabilities"]
+        assert "dev.ucp.shopping.fulfillment" in capabilities
+        fulfillment = capabilities["dev.ucp.shopping.fulfillment"][0]
+        assert fulfillment.get("extends") == "dev.ucp.shopping.checkout"
+
+    def test_profile_includes_discount_capability(self, client: TestClient) -> None:
+        """Profile includes dev.ucp.shopping.discount capability."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        capabilities = data["ucp"]["capabilities"]
+        assert "dev.ucp.shopping.discount" in capabilities
+
+    def test_profile_has_signing_keys_field(self, client: TestClient) -> None:
+        """Profile includes top-level signing_keys field (may be null)."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        assert "signing_keys" in data
+
+    def test_signing_key_schema_matches_spec(
+        self, client: TestClient, monkeypatch
+    ) -> None:
+        """Signing key includes all JWK fields per spec."""
+        monkeypatch.setenv("UCP_SIGNING_KEY_X", "test_x_value")
+        monkeypatch.setenv("UCP_SIGNING_KEY_Y", "test_y_value")
+        get_settings.cache_clear()
+
+        try:
+            response = client.get("/.well-known/ucp")
+            data = response.json()
+
+            if data.get("signing_keys"):
+                key = data["signing_keys"][0]
+                assert "kid" in key
+                assert "kty" in key
+                assert "crv" in key
+                assert "x" in key
+                assert "alg" in key
+        finally:
+            get_settings.cache_clear()
+
+    def test_payment_handler_has_config_field(self, client: TestClient) -> None:
+        """Payment handler includes optional config field per spec."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        handlers = data["ucp"].get("payment_handlers", {})
+        if handlers:
+            handler_list = list(handlers.values())[0]
+            assert "config" in handler_list[0] or handler_list[0].get("config") is None
+
+    def test_discovery_requires_no_auth(self, client: TestClient) -> None:
+        """Discovery endpoint works without authentication headers."""
+        response = client.get("/.well-known/ucp")
+        assert response.status_code == 200
+
+    def test_service_endpoint_uses_request_base_url_when_not_configured(
+        self, client: TestClient
+    ) -> None:
+        """Service endpoint derived from request base URL when ucp_base_url is None."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        service = data["ucp"]["services"]["dev.ucp.shopping"][0]
+        assert "/ucp/v1" in service["endpoint"]


### PR DESCRIPTION
## Summary

- Implement UCP discovery endpoint (`GET /.well-known/ucp`) returning a static business profile per the UCP spec
- Add Pydantic schemas for UCP profile (services, capabilities, payment handlers, signing keys)
- Add configuration fields for UCP version, base URL, and JWK signing keys
- This is Phase 1 of Feature 17 (UCP Integration) - discovery only, no checkout endpoints

## Changes

| File | Description |
|------|-------------|
| `src/merchant/api/routes/ucp/discovery.py` | Discovery endpoint (public, no auth) |
| `src/merchant/api/ucp_schemas.py` | Pydantic schemas for UCP profile |
| `src/merchant/services/ucp.py` | `build_business_profile()` helper |
| `src/merchant/config.py` | 9 new UCP configuration fields |
| `src/merchant/main.py` | Register UCP discovery router |
| `tests/merchant/api/test_ucp_discovery.py` | 11 unit tests |
| `AGENTS.md`, `README.md`, `env.example` | Documentation updates |

## Profile Advertises

- `dev.ucp.shopping` service (REST transport)
- `dev.ucp.shopping.checkout` capability
- `dev.ucp.shopping.fulfillment` extension (with `extends` field)
- `dev.ucp.shopping.discount` capability

## Test Plan

- [x] All 11 UCP discovery tests pass
- [x] All 198 merchant tests pass (no regressions)
- [x] Ruff linting passes
- [x] Pyright type checking passes
- [x] Manual curl test returns 200 with correct JSON structure

```bash
curl http://localhost:8000/.well-known/ucp | python3 -m json.tool
```

## Related

- Feature 17: UCP Integration (`docs/features/feature-17-ucp-integration.md`)
- UCP Spec: `docs/specs/ucp-spec.md`

Made with [Cursor](https://cursor.com)