### PR TITLE
[frontend] Add retail metrics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ nat serve --config_file configs/search.yml --port 8005
 ```bash
 # Terminal 8: Demo UI (port 3000)
 cd src/ui
+cp env.example .env.local
 pnpm install
 pnpm dev
 ```

--- a/src/ui/app/api/proxy/phoenix/[...path]/route.ts
+++ b/src/ui/app/api/proxy/phoenix/[...path]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Phoenix API proxy route
+ * Forwards requests to the Phoenix telemetry server
+ *
+ * Environment variable: PHOENIX_API_URL (default: http://localhost:6006)
+ */
+
+const PHOENIX_API_URL = process.env.PHOENIX_API_URL ?? "http://localhost:6006";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const phoenixPath = path.join("/");
+  const searchParams = request.nextUrl.searchParams.toString();
+  const url = `${PHOENIX_API_URL}/${phoenixPath}${searchParams ? `?${searchParams}` : ""}`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Phoenix API error: ${response.statusText}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to connect to Phoenix API" },
+      { status: 502 }
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path } = await params;
+  const phoenixPath = path.join("/");
+  const url = `${PHOENIX_API_URL}/${phoenixPath}`;
+
+  try {
+    const body = await request.json();
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Phoenix API error: ${response.statusText}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to connect to Phoenix API" },
+      { status: 502 }
+    );
+  }
+}

--- a/src/ui/app/api/proxy/phoenix/[...path]/route.ts
+++ b/src/ui/app/api/proxy/phoenix/[...path]/route.ts
@@ -37,10 +37,7 @@ export async function GET(
     const data = await response.json();
     return NextResponse.json(data);
   } catch {
-    return NextResponse.json(
-      { error: "Failed to connect to Phoenix API" },
-      { status: 502 }
-    );
+    return NextResponse.json({ error: "Failed to connect to Phoenix API" }, { status: 502 });
   }
 }
 
@@ -73,9 +70,6 @@ export async function POST(
     const data = await response.json();
     return NextResponse.json(data);
   } catch {
-    return NextResponse.json(
-      { error: "Failed to connect to Phoenix API" },
-      { status: 502 }
-    );
+    return NextResponse.json({ error: "Failed to connect to Phoenix API" }, { status: 502 });
   }
 }

--- a/src/ui/app/globals.css
+++ b/src/ui/app/globals.css
@@ -845,3 +845,307 @@ body {
   border: 1px solid var(--glass-border-subtle);
   background: rgba(255, 255, 255, 0.03);
 }
+
+/* ============================================
+   Navigation Link Styles
+   ============================================
+*/
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: all 180ms ease;
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+.nav-link:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--glass-border-subtle);
+}
+
+.nav-link-active {
+  color: var(--accent-green);
+  background: var(--accent-green-bg);
+  border-color: var(--accent-green-border);
+  box-shadow: 0 0 20px var(--accent-green-glow);
+}
+
+.nav-link-active:hover {
+  color: var(--accent-green);
+  background: var(--accent-green-bg);
+  border-color: var(--accent-green-border);
+}
+
+/* ============================================
+   Metrics Dashboard Styles
+   ============================================
+*/
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 1200px) {
+  .metrics-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .metrics-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* KPI Card */
+.kpi-card {
+  background: var(--block-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--glass-radius-sm);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: all 200ms ease;
+}
+
+.kpi-card:hover {
+  background: var(--block-bg-elevated);
+  border-color: var(--glass-border);
+  transform: translateY(-2px);
+}
+
+.kpi-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.kpi-value {
+  font-size: 28px;
+  font-weight: 750;
+  color: var(--text-primary);
+  letter-spacing: -0.5px;
+}
+
+.kpi-trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.kpi-trend.up {
+  color: var(--accent-green);
+}
+
+.kpi-trend.down {
+  color: #ef4444;
+}
+
+.kpi-trend.neutral {
+  color: var(--text-muted);
+}
+
+/* Chart Container */
+.chart-container {
+  background: var(--block-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--glass-radius-sm);
+  padding: 20px;
+  min-height: 300px;
+}
+
+.chart-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Dashboard Layout */
+.dashboard-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.dashboard-row {
+  display: grid;
+  gap: 20px;
+}
+
+.dashboard-row.two-col {
+  grid-template-columns: 1fr 1fr;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-row.two-col {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Time Range Tabs */
+.time-range-tabs {
+  display: flex;
+  gap: 4px;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border-subtle);
+}
+
+.time-range-tab {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.time-range-tab:hover {
+  color: var(--text-secondary);
+}
+
+.time-range-tab.active {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* Refresh Button */
+.refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--glass-border-subtle);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 180ms ease;
+}
+
+.refresh-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  transform: rotate(45deg);
+}
+
+.refresh-btn:active {
+  transform: rotate(180deg);
+}
+
+.refresh-btn.loading {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Product Health Table */
+.product-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.product-table th {
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--glass-border-subtle);
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.product-table th:first-child {
+  border-radius: var(--glass-radius-sm) 0 0 0;
+}
+
+.product-table th:last-child {
+  border-radius: 0 var(--glass-radius-sm) 0 0;
+}
+
+.product-table td {
+  padding: 14px 16px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--glass-border-subtle);
+}
+
+.product-table tr:hover td {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.product-table tr:last-child td {
+  border-bottom: none;
+}
+
+.stock-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.stock-badge.healthy {
+  background: var(--accent-green-bg);
+  color: var(--accent-green);
+  border: 1px solid var(--accent-green-border);
+}
+
+.stock-badge.low {
+  background: var(--accent-yellow-bg);
+  color: var(--accent-yellow);
+  border: 1px solid var(--accent-yellow-border);
+}
+
+.stock-badge.critical {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.attention-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}

--- a/src/ui/app/metrics/page.tsx
+++ b/src/ui/app/metrics/page.tsx
@@ -6,7 +6,7 @@ import { MetricsProvider } from "@/hooks/useMetrics";
 import { Nebula } from "@/kui-foundations-react-external/nebula";
 
 /**
- * Metrics Dashboard page - Palantir-style analytics for retail operations
+ * Metrics Dashboard page - analytics for retail operations
  * Features NVIDIA-style Nebula animated background with gradient overlays
  */
 export default function MetricsPage() {

--- a/src/ui/app/metrics/page.tsx
+++ b/src/ui/app/metrics/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Navbar } from "@/components/layout";
+import { MetricsDashboard } from "@/components/metrics";
+import { MetricsProvider } from "@/hooks/useMetrics";
+import { Nebula } from "@/kui-foundations-react-external/nebula";
+
+/**
+ * Metrics Dashboard page - Palantir-style analytics for retail operations
+ * Features NVIDIA-style Nebula animated background with gradient overlays
+ */
+export default function MetricsPage() {
+  return (
+    <MetricsProvider>
+      <div className="min-h-screen bg-surface-base relative overflow-auto">
+        {/* Nebula Background */}
+        <div
+          className="pointer-events-none"
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            width: "100vw",
+            height: "100vh",
+            zIndex: 0,
+            overflow: "hidden",
+          }}
+        >
+          <div style={{ width: "100%", height: "100%" }}>
+            <Nebula variant="ambient" />
+          </div>
+        </div>
+
+        {/* Top Green Gradient Overlay */}
+        <div
+          className="pointer-events-none"
+          style={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "500px",
+            background: "linear-gradient(80.22deg, #BFF230 1.49%, #7CD7FE 99.95%)",
+            opacity: 0.12,
+            zIndex: 0,
+            maskImage:
+              "radial-gradient(ellipse 150% 120% at top, black 0%, black 30%, transparent 70%)",
+            WebkitMaskImage:
+              "radial-gradient(ellipse 150% 120% at top, black 0%, black 30%, transparent 70%)",
+          }}
+        />
+
+        {/* Bottom Green Gradient Overlay */}
+        <div
+          className="pointer-events-none"
+          style={{
+            position: "fixed",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: "300px",
+            background: "linear-gradient(80.22deg, #BFF230 1.49%, #7CD7FE 99.95%)",
+            opacity: 0.12,
+            zIndex: 0,
+            maskImage:
+              "radial-gradient(ellipse 120% 130% at bottom, black 0%, black 25%, transparent 60%)",
+            WebkitMaskImage:
+              "radial-gradient(ellipse 120% 130% at bottom, black 0%, black 25%, transparent 60%)",
+          }}
+        />
+
+        {/* Content Layer */}
+        <div className="relative flex flex-col min-h-screen" style={{ zIndex: 1 }}>
+          <Navbar />
+          {/* Outer container with generous gutters for premium feel */}
+          <div className="flex-1 flex flex-col" style={{ padding: "24px 40px 40px" }}>
+            <main className="glass-panel flex-1" style={{ padding: "24px" }}>
+              <MetricsDashboard />
+            </main>
+          </div>
+        </div>
+      </div>
+    </MetricsProvider>
+  );
+}

--- a/src/ui/components/layout/Navbar.tsx
+++ b/src/ui/components/layout/Navbar.tsx
@@ -32,10 +32,7 @@ export function Navbar() {
         }
         slotRight={
           <Flex align="center" gap="2">
-            <Link
-              href="/"
-              className={`nav-link ${pathname === "/" ? "nav-link-active" : ""}`}
-            >
+            <Link href="/" className={`nav-link ${pathname === "/" ? "nav-link-active" : ""}`}>
               <svg
                 width="16"
                 height="16"

--- a/src/ui/components/layout/Navbar.tsx
+++ b/src/ui/components/layout/Navbar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { AppBar, Text, Flex } from "@kui/foundations-react-external";
 
 /**
@@ -8,6 +10,8 @@ import { AppBar, Text, Flex } from "@kui/foundations-react-external";
  * Transparent header that blends with the Nebula background
  */
 export function Navbar() {
+  const pathname = usePathname();
+
   return (
     <div className="transparent-header">
       <AppBar
@@ -24,6 +28,50 @@ export function Navbar() {
             <Text kind="label/semibold/md" className="text-gray-100 hidden sm:block">
               Agentic Commerce
             </Text>
+          </Flex>
+        }
+        slotRight={
+          <Flex align="center" gap="2">
+            <Link
+              href="/"
+              className={`nav-link ${pathname === "/" ? "nav-link-active" : ""}`}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+                <line x1="8" y1="21" x2="16" y2="21" />
+                <line x1="12" y1="17" x2="12" y2="21" />
+              </svg>
+              <span className="hidden sm:inline">Simulator</span>
+            </Link>
+            <Link
+              href="/metrics"
+              className={`nav-link ${pathname === "/metrics" ? "nav-link-active" : ""}`}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="18" y1="20" x2="18" y2="10" />
+                <line x1="12" y1="20" x2="12" y2="4" />
+                <line x1="6" y1="20" x2="6" y2="14" />
+              </svg>
+              <span className="hidden sm:inline">Metrics</span>
+            </Link>
           </Flex>
         }
       />

--- a/src/ui/components/metrics/MetricsDashboard.tsx
+++ b/src/ui/components/metrics/MetricsDashboard.tsx
@@ -9,12 +9,20 @@ import { PromotionPanel } from "./panels/PromotionPanel";
 import { ProductHealthPanel } from "./panels/ProductHealthPanel";
 
 /**
- * Main dashboard container with Palantir-style grid layout
+ * Main dashboard container with grid layout
  */
 export function MetricsDashboard() {
   const { state, setTimeRange, refresh } = useMetrics();
-  const { timeRange, isLoading, lastUpdated, kpis, revenueData, agentPerformance, promotionBreakdown, productHealth } =
-    state;
+  const {
+    timeRange,
+    isLoading,
+    lastUpdated,
+    kpis,
+    revenueData,
+    agentPerformance,
+    promotionBreakdown,
+    productHealth,
+  } = state;
 
   return (
     <div className="dashboard-grid">

--- a/src/ui/components/metrics/MetricsDashboard.tsx
+++ b/src/ui/components/metrics/MetricsDashboard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMetrics } from "@/hooks/useMetrics";
+import { MetricsHeader } from "./MetricsHeader";
+import { KPIPanel } from "./panels/KPIPanel";
+import { RevenuePanel } from "./panels/RevenuePanel";
+import { AgentPerformancePanel } from "./panels/AgentPerformancePanel";
+import { PromotionPanel } from "./panels/PromotionPanel";
+import { ProductHealthPanel } from "./panels/ProductHealthPanel";
+
+/**
+ * Main dashboard container with Palantir-style grid layout
+ */
+export function MetricsDashboard() {
+  const { state, setTimeRange, refresh } = useMetrics();
+  const { timeRange, isLoading, lastUpdated, kpis, revenueData, agentPerformance, promotionBreakdown, productHealth } =
+    state;
+
+  return (
+    <div className="dashboard-grid">
+      {/* Header */}
+      <MetricsHeader
+        timeRange={timeRange}
+        onTimeRangeChange={setTimeRange}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        lastUpdated={lastUpdated}
+      />
+
+      {/* KPI Row */}
+      <KPIPanel kpis={kpis} isLoading={isLoading} />
+
+      {/* Revenue Chart */}
+      <RevenuePanel data={revenueData} timeRange={timeRange} isLoading={isLoading} />
+
+      {/* Two Column Row: Agent Performance & Promotions */}
+      <div className="dashboard-row two-col">
+        <AgentPerformancePanel data={agentPerformance} isLoading={isLoading} />
+        <PromotionPanel data={promotionBreakdown} isLoading={isLoading} />
+      </div>
+
+      {/* Product Health Table */}
+      <ProductHealthPanel data={productHealth} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/src/ui/components/metrics/MetricsHeader.tsx
+++ b/src/ui/components/metrics/MetricsHeader.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { TimeRange } from "@/types";
+
+interface MetricsHeaderProps {
+  timeRange: TimeRange;
+  onTimeRangeChange: (timeRange: TimeRange) => void;
+  onRefresh: () => void;
+  isLoading?: boolean;
+  lastUpdated?: Date | null;
+}
+
+const TIME_RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
+  { value: "1h", label: "1H" },
+  { value: "24h", label: "24H" },
+  { value: "7d", label: "7D" },
+  { value: "30d", label: "30D" },
+];
+
+/**
+ * Dashboard header with title, time range selector, and refresh button
+ */
+export function MetricsHeader({
+  timeRange,
+  onTimeRangeChange,
+  onRefresh,
+  isLoading,
+  lastUpdated,
+}: MetricsHeaderProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        marginBottom: "24px",
+        flexWrap: "wrap",
+        gap: "16px",
+      }}
+    >
+      <div>
+        <h1
+          style={{
+            fontSize: "24px",
+            fontWeight: 750,
+            color: "rgba(255, 255, 255, 0.95)",
+            margin: 0,
+            letterSpacing: "-0.5px",
+          }}
+        >
+          Retail Metrics Dashboard
+        </h1>
+        {lastUpdated && (
+          <p
+            style={{
+              fontSize: "12px",
+              color: "rgba(255, 255, 255, 0.5)",
+              margin: "4px 0 0 0",
+            }}
+          >
+            Last updated: {lastUpdated.toLocaleTimeString()}
+          </p>
+        )}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        {/* Time Range Tabs */}
+        <div className="time-range-tabs">
+          {TIME_RANGE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              className={`time-range-tab ${timeRange === option.value ? "active" : ""}`}
+              onClick={() => onTimeRangeChange(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Refresh Button */}
+        <button
+          className={`refresh-btn ${isLoading ? "loading" : ""}`}
+          onClick={onRefresh}
+          disabled={isLoading}
+          aria-label="Refresh metrics"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="23 4 23 10 17 10" />
+            <polyline points="1 20 1 14 7 14" />
+            <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/metrics/cards/KPICard.tsx
+++ b/src/ui/components/metrics/cards/KPICard.tsx
@@ -32,7 +32,14 @@ function formatValue(value: number, format: KPIData["format"]): string {
 function TrendIcon({ trend }: { trend: "up" | "down" | "neutral" }) {
   if (trend === "neutral") {
     return (
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
         <line x1="5" y1="12" x2="19" y2="12" />
       </svg>
     );
@@ -66,8 +73,7 @@ export function KPICard({ data }: KPICardProps) {
   const { label, value, format, trend, trendValue } = data;
 
   // For latency, a decrease is positive
-  const isPositiveTrend =
-    format === "duration" ? (trendValue ?? 0) < 0 : (trendValue ?? 0) > 0;
+  const isPositiveTrend = format === "duration" ? (trendValue ?? 0) < 0 : (trendValue ?? 0) > 0;
 
   const trendClass = trend
     ? isPositiveTrend

--- a/src/ui/components/metrics/cards/KPICard.tsx
+++ b/src/ui/components/metrics/cards/KPICard.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { KPIData } from "@/types";
+
+/**
+ * Format a value based on its format type
+ */
+function formatValue(value: number, format: KPIData["format"]): string {
+  switch (format) {
+    case "currency":
+      // Value is in cents, convert to dollars
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }).format(value / 100);
+    case "number":
+      return new Intl.NumberFormat("en-US").format(value);
+    case "percent":
+      return `${value.toFixed(1)}%`;
+    case "duration":
+      return `${value}ms`;
+    default:
+      return String(value);
+  }
+}
+
+/**
+ * Trend arrow icon
+ */
+function TrendIcon({ trend }: { trend: "up" | "down" | "neutral" }) {
+  if (trend === "neutral") {
+    return (
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <line x1="5" y1="12" x2="19" y2="12" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ transform: trend === "down" ? "rotate(180deg)" : undefined }}
+    >
+      <polyline points="18 15 12 9 6 15" />
+    </svg>
+  );
+}
+
+interface KPICardProps {
+  data: KPIData;
+}
+
+/**
+ * Individual KPI card display with glass-morphic styling
+ */
+export function KPICard({ data }: KPICardProps) {
+  const { label, value, format, trend, trendValue } = data;
+
+  // For latency, a decrease is positive
+  const isPositiveTrend =
+    format === "duration" ? (trendValue ?? 0) < 0 : (trendValue ?? 0) > 0;
+
+  const trendClass = trend
+    ? isPositiveTrend
+      ? "up"
+      : trend === "neutral"
+        ? "neutral"
+        : "down"
+    : "neutral";
+
+  return (
+    <div className="kpi-card">
+      <span className="kpi-label">{label}</span>
+      <span className="kpi-value">{formatValue(value, format)}</span>
+      {trend && trendValue !== undefined && (
+        <span className={`kpi-trend ${trendClass}`}>
+          <TrendIcon trend={isPositiveTrend ? "up" : "down"} />
+          {Math.abs(trendValue).toFixed(1)}%
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/metrics/charts/ChartTooltip.tsx
+++ b/src/ui/components/metrics/charts/ChartTooltip.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+interface TooltipPayload {
+  name: string;
+  value: number;
+  color?: string;
+  dataKey?: string;
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  label?: string;
+  formatValue?: (value: number, dataKey?: string) => string;
+  labelFormatter?: (label: string) => string;
+}
+
+/**
+ * Custom tooltip component for Recharts with glass-morphic styling
+ */
+export function ChartTooltip({
+  active,
+  payload,
+  label,
+  formatValue = (v) => String(v),
+  labelFormatter = (l) => l,
+}: ChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        background: "linear-gradient(180deg, rgba(12, 12, 12, 0.95), rgba(12, 12, 12, 0.9))",
+        border: "1px solid rgba(255, 255, 255, 0.15)",
+        borderRadius: "12px",
+        padding: "12px 14px",
+        backdropFilter: "blur(12px)",
+        boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
+      }}
+    >
+      {label && (
+        <p
+          style={{
+            margin: "0 0 8px 0",
+            fontSize: "11px",
+            fontWeight: 600,
+            color: "rgba(255, 255, 255, 0.6)",
+            textTransform: "uppercase",
+            letterSpacing: "0.5px",
+          }}
+        >
+          {labelFormatter(label)}
+        </p>
+      )}
+      {payload.map((entry, index) => (
+        <div
+          key={index}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            marginTop: index > 0 ? "6px" : 0,
+          }}
+        >
+          <span
+            style={{
+              width: "8px",
+              height: "8px",
+              borderRadius: "50%",
+              background: entry.color ?? "#76b900",
+            }}
+          />
+          <span
+            style={{
+              fontSize: "12px",
+              color: "rgba(255, 255, 255, 0.7)",
+            }}
+          >
+            {entry.name}:
+          </span>
+          <span
+            style={{
+              fontSize: "13px",
+              fontWeight: 700,
+              color: "rgba(255, 255, 255, 0.95)",
+            }}
+          >
+            {formatValue(entry.value, entry.dataKey)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/components/metrics/charts/GlassAreaChart.tsx
+++ b/src/ui/components/metrics/charts/GlassAreaChart.tsx
@@ -67,11 +67,7 @@ export function GlassAreaChart({
             dx={-10}
             width={60}
           />
-          <Tooltip
-            content={
-              <ChartTooltip formatValue={(v) => formatValue(v)} />
-            }
-          />
+          <Tooltip content={<ChartTooltip formatValue={(v) => formatValue(v)} />} />
           <Area
             type="monotone"
             dataKey={dataKey}

--- a/src/ui/components/metrics/charts/GlassAreaChart.tsx
+++ b/src/ui/components/metrics/charts/GlassAreaChart.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { ChartTooltip } from "./ChartTooltip";
+
+interface GlassAreaChartProps {
+  data: Record<string, unknown>[];
+  dataKey: string;
+  xAxisKey: string;
+  title?: string;
+  formatValue?: (value: number) => string;
+  formatXAxis?: (value: string) => string;
+  color?: string;
+  gradientId?: string;
+}
+
+/**
+ * Glass-styled area chart wrapper for Recharts
+ */
+export function GlassAreaChart({
+  data,
+  dataKey,
+  xAxisKey,
+  title,
+  formatValue = (v) => String(v),
+  formatXAxis = (v) => v,
+  color = "#76b900",
+  gradientId = "areaGradient",
+}: GlassAreaChartProps) {
+  return (
+    <div className="chart-container">
+      {title && <h3 className="chart-title">{title}</h3>}
+      <ResponsiveContainer width="100%" height={280}>
+        <AreaChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor={color} stopOpacity={0.4} />
+              <stop offset="95%" stopColor={color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="rgba(255, 255, 255, 0.06)"
+            vertical={false}
+          />
+          <XAxis
+            dataKey={xAxisKey}
+            tickFormatter={formatXAxis}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "rgba(255, 255, 255, 0.5)", fontSize: 11 }}
+            dy={10}
+          />
+          <YAxis
+            tickFormatter={formatValue}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "rgba(255, 255, 255, 0.5)", fontSize: 11 }}
+            dx={-10}
+            width={60}
+          />
+          <Tooltip
+            content={
+              <ChartTooltip formatValue={(v) => formatValue(v)} />
+            }
+          />
+          <Area
+            type="monotone"
+            dataKey={dataKey}
+            stroke={color}
+            strokeWidth={2}
+            fillOpacity={1}
+            fill={`url(#${gradientId})`}
+            animationDuration={800}
+            name="Revenue"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/ui/components/metrics/charts/GlassBarChart.tsx
+++ b/src/ui/components/metrics/charts/GlassBarChart.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import { ChartTooltip } from "./ChartTooltip";
+
+interface GlassBarChartProps<T> {
+  data: T[];
+  dataKey: keyof T;
+  xAxisKey: keyof T;
+  title?: string;
+  formatValue?: (value: number, dataKey?: string) => string;
+  colors?: string[];
+  layout?: "vertical" | "horizontal";
+  barSize?: number;
+}
+
+const DEFAULT_COLORS = ["#76b900", "#5a9200", "#3d6200", "#ffd36b"];
+
+/**
+ * Glass-styled bar chart wrapper for Recharts
+ */
+export function GlassBarChart<T extends Record<string, unknown>>({
+  data,
+  dataKey,
+  xAxisKey,
+  title,
+  formatValue = (v) => String(v),
+  colors = DEFAULT_COLORS,
+  layout = "horizontal",
+  barSize = 32,
+}: GlassBarChartProps<T>) {
+  return (
+    <div className="chart-container">
+      {title && <h3 className="chart-title">{title}</h3>}
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart
+          data={data}
+          layout={layout}
+          margin={{ top: 10, right: 10, left: layout === "vertical" ? 100 : 0, bottom: 0 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="rgba(255, 255, 255, 0.06)"
+            horizontal={layout === "horizontal"}
+            vertical={layout === "vertical"}
+          />
+          {layout === "horizontal" ? (
+            <>
+              <XAxis
+                dataKey={xAxisKey as string}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "rgba(255, 255, 255, 0.5)", fontSize: 11 }}
+                dy={10}
+              />
+              <YAxis
+                tickFormatter={(v) => formatValue(v)}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "rgba(255, 255, 255, 0.5)", fontSize: 11 }}
+                dx={-10}
+                width={50}
+              />
+            </>
+          ) : (
+            <>
+              <XAxis
+                type="number"
+                tickFormatter={(v) => formatValue(v)}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "rgba(255, 255, 255, 0.5)", fontSize: 11 }}
+              />
+              <YAxis
+                type="category"
+                dataKey={xAxisKey as string}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "rgba(255, 255, 255, 0.6)", fontSize: 12 }}
+                width={90}
+              />
+            </>
+          )}
+          <Tooltip content={<ChartTooltip formatValue={formatValue} />} />
+          <Bar
+            dataKey={dataKey as string}
+            barSize={barSize}
+            radius={[4, 4, 4, 4]}
+            animationDuration={800}
+          >
+            {data.map((_, index) => (
+              <Cell key={`cell-${index}`} fill={colors[index % colors.length]!} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/ui/components/metrics/charts/GlassPieChart.tsx
+++ b/src/ui/components/metrics/charts/GlassPieChart.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { ChartTooltip } from "./ChartTooltip";
+
+interface PieDataItem {
+  label: string;
+  value: number;
+  color: string;
+}
+
+interface GlassPieChartProps {
+  data: PieDataItem[];
+  title?: string;
+  formatValue?: (value: number) => string;
+  innerRadius?: number;
+  outerRadius?: number;
+}
+
+/**
+ * Glass-styled donut/pie chart wrapper for Recharts
+ */
+export function GlassPieChart({
+  data,
+  title,
+  formatValue = (v) => String(v),
+  innerRadius = 60,
+  outerRadius = 100,
+}: GlassPieChartProps) {
+  const total = data.reduce((sum, item) => sum + item.value, 0);
+
+  return (
+    <div className="chart-container">
+      {title && <h3 className="chart-title">{title}</h3>}
+      <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+        <ResponsiveContainer width="50%" height={240}>
+          <PieChart>
+            <Pie
+              data={data}
+              cx="50%"
+              cy="50%"
+              innerRadius={innerRadius}
+              outerRadius={outerRadius}
+              paddingAngle={2}
+              dataKey="value"
+              nameKey="label"
+              animationDuration={800}
+            >
+              {data.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.color} stroke="transparent" />
+              ))}
+            </Pie>
+            <Tooltip content={<ChartTooltip formatValue={formatValue} />} />
+          </PieChart>
+        </ResponsiveContainer>
+        <div style={{ flex: 1 }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "12px",
+            }}
+          >
+            {data.map((item, index) => {
+              const percentage = total > 0 ? ((item.value / total) * 100).toFixed(1) : 0;
+              return (
+                <div
+                  key={index}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "10px",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: "10px",
+                      height: "10px",
+                      borderRadius: "3px",
+                      background: item.color,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span
+                    style={{
+                      flex: 1,
+                      fontSize: "12px",
+                      color: "rgba(255, 255, 255, 0.7)",
+                    }}
+                  >
+                    {item.label}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: "12px",
+                      fontWeight: 700,
+                      color: "rgba(255, 255, 255, 0.9)",
+                    }}
+                  >
+                    {percentage}%
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/metrics/index.ts
+++ b/src/ui/components/metrics/index.ts
@@ -1,0 +1,19 @@
+// Main components
+export { MetricsDashboard } from "./MetricsDashboard";
+export { MetricsHeader } from "./MetricsHeader";
+
+// Cards
+export { KPICard } from "./cards/KPICard";
+
+// Charts
+export { ChartTooltip } from "./charts/ChartTooltip";
+export { GlassAreaChart } from "./charts/GlassAreaChart";
+export { GlassBarChart } from "./charts/GlassBarChart";
+export { GlassPieChart } from "./charts/GlassPieChart";
+
+// Panels
+export { KPIPanel } from "./panels/KPIPanel";
+export { RevenuePanel } from "./panels/RevenuePanel";
+export { AgentPerformancePanel } from "./panels/AgentPerformancePanel";
+export { PromotionPanel } from "./panels/PromotionPanel";
+export { ProductHealthPanel } from "./panels/ProductHealthPanel";

--- a/src/ui/components/metrics/panels/AgentPerformancePanel.tsx
+++ b/src/ui/components/metrics/panels/AgentPerformancePanel.tsx
@@ -50,7 +50,10 @@ export function AgentPerformancePanel({ data, isLoading }: AgentPerformancePanel
           </p>
           <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
             {data.map((agent) => (
-              <div key={agent.agentType} style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+              <div
+                key={agent.agentType}
+                style={{ display: "flex", alignItems: "center", gap: "12px" }}
+              >
                 <span
                   style={{
                     fontSize: "11px",
@@ -114,7 +117,10 @@ export function AgentPerformancePanel({ data, isLoading }: AgentPerformancePanel
               const maxLatency = Math.max(...data.map((d) => d.avgLatency));
               const widthPercent = (agent.avgLatency / maxLatency) * 100;
               return (
-                <div key={agent.agentType} style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+                <div
+                  key={agent.agentType}
+                  style={{ display: "flex", alignItems: "center", gap: "12px" }}
+                >
                   <span
                     style={{
                       fontSize: "11px",

--- a/src/ui/components/metrics/panels/AgentPerformancePanel.tsx
+++ b/src/ui/components/metrics/panels/AgentPerformancePanel.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import type { AgentPerformanceData } from "@/types";
+
+interface AgentPerformancePanelProps {
+  data: AgentPerformanceData[];
+  isLoading?: boolean;
+}
+
+/**
+ * Agent performance bar chart panel
+ */
+export function AgentPerformancePanel({ data, isLoading }: AgentPerformancePanelProps) {
+  if (isLoading) {
+    return (
+      <div className="chart-container">
+        <div className="chart-title">
+          <div className="glass-line w50" style={{ height: "14px", marginTop: 0 }} />
+        </div>
+        <div
+          style={{
+            height: "280px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <div className="glass-line w85" style={{ height: "200px", width: "100%" }} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chart-container">
+      <h3 className="chart-title">Agent Performance</h3>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px" }}>
+        {/* Success Rate Chart */}
+        <div>
+          <p
+            style={{
+              fontSize: "11px",
+              color: "rgba(255, 255, 255, 0.5)",
+              marginBottom: "8px",
+              textTransform: "uppercase",
+              letterSpacing: "0.5px",
+            }}
+          >
+            Success Rate
+          </p>
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            {data.map((agent) => (
+              <div key={agent.agentType} style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+                <span
+                  style={{
+                    fontSize: "11px",
+                    color: "rgba(255, 255, 255, 0.6)",
+                    width: "90px",
+                    flexShrink: 0,
+                  }}
+                >
+                  {agent.label.replace(" Agent", "")}
+                </span>
+                <div
+                  style={{
+                    flex: 1,
+                    height: "12px",
+                    background: "rgba(255, 255, 255, 0.06)",
+                    borderRadius: "6px",
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${agent.successRate}%`,
+                      height: "100%",
+                      background: `linear-gradient(90deg, #76b900, #5a9200)`,
+                      borderRadius: "6px",
+                      transition: "width 800ms ease",
+                    }}
+                  />
+                </div>
+                <span
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 700,
+                    color: "rgba(255, 255, 255, 0.9)",
+                    width: "48px",
+                    textAlign: "right",
+                  }}
+                >
+                  {agent.successRate.toFixed(1)}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Latency Chart */}
+        <div>
+          <p
+            style={{
+              fontSize: "11px",
+              color: "rgba(255, 255, 255, 0.5)",
+              marginBottom: "8px",
+              textTransform: "uppercase",
+              letterSpacing: "0.5px",
+            }}
+          >
+            Avg Latency
+          </p>
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            {data.map((agent) => {
+              const maxLatency = Math.max(...data.map((d) => d.avgLatency));
+              const widthPercent = (agent.avgLatency / maxLatency) * 100;
+              return (
+                <div key={agent.agentType} style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+                  <span
+                    style={{
+                      fontSize: "11px",
+                      color: "rgba(255, 255, 255, 0.6)",
+                      width: "90px",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {agent.label.replace(" Agent", "")}
+                  </span>
+                  <div
+                    style={{
+                      flex: 1,
+                      height: "12px",
+                      background: "rgba(255, 255, 255, 0.06)",
+                      borderRadius: "6px",
+                      overflow: "hidden",
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: `${widthPercent}%`,
+                        height: "100%",
+                        background: `linear-gradient(90deg, #ffd36b, #e6b84d)`,
+                        borderRadius: "6px",
+                        transition: "width 800ms ease",
+                      }}
+                    />
+                  </div>
+                  <span
+                    style={{
+                      fontSize: "12px",
+                      fontWeight: 700,
+                      color: "rgba(255, 255, 255, 0.9)",
+                      width: "48px",
+                      textAlign: "right",
+                    }}
+                  >
+                    {agent.avgLatency}ms
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Stats Summary */}
+      <div
+        style={{
+          marginTop: "20px",
+          paddingTop: "16px",
+          borderTop: "1px solid rgba(255, 255, 255, 0.08)",
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: "12px",
+        }}
+      >
+        {data.map((agent) => (
+          <div
+            key={agent.agentType}
+            style={{
+              textAlign: "center",
+            }}
+          >
+            <p
+              style={{
+                fontSize: "10px",
+                color: "rgba(255, 255, 255, 0.5)",
+                marginBottom: "4px",
+                textTransform: "uppercase",
+              }}
+            >
+              {agent.label.replace(" Agent", "")}
+            </p>
+            <p
+              style={{
+                fontSize: "16px",
+                fontWeight: 700,
+                color: "rgba(255, 255, 255, 0.9)",
+              }}
+            >
+              {agent.totalCalls.toLocaleString()}
+            </p>
+            <p
+              style={{
+                fontSize: "10px",
+                color: "rgba(255, 255, 255, 0.5)",
+              }}
+            >
+              calls ({agent.errors} errors)
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/metrics/panels/KPIPanel.tsx
+++ b/src/ui/components/metrics/panels/KPIPanel.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { KPIData } from "@/types";
+import { KPICard } from "../cards/KPICard";
+
+interface KPIPanelProps {
+  kpis: KPIData[];
+  isLoading?: boolean;
+}
+
+/**
+ * Row of KPI cards
+ */
+export function KPIPanel({ kpis, isLoading }: KPIPanelProps) {
+  if (isLoading) {
+    return (
+      <div className="metrics-grid">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="kpi-card">
+            <div className="glass-line w50" style={{ height: "12px", marginTop: 0 }} />
+            <div className="glass-line w85" style={{ height: "32px", marginTop: "8px" }} />
+            <div className="glass-line w50" style={{ height: "14px", marginTop: "8px" }} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="metrics-grid">
+      {kpis.map((kpi) => (
+        <KPICard key={kpi.id} data={kpi} />
+      ))}
+    </div>
+  );
+}

--- a/src/ui/components/metrics/panels/ProductHealthPanel.tsx
+++ b/src/ui/components/metrics/panels/ProductHealthPanel.tsx
@@ -42,8 +42,17 @@ function PricePositionIndicator({ position }: { position: ProductHealthData["pri
   switch (position) {
     case "above":
       return (
-        <span style={{ color: "#ef4444", display: "inline-flex", alignItems: "center", gap: "4px" }}>
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <span
+          style={{ color: "#ef4444", display: "inline-flex", alignItems: "center", gap: "4px" }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
             <polyline points="18 15 12 9 6 15" />
           </svg>
           Above
@@ -51,8 +60,17 @@ function PricePositionIndicator({ position }: { position: ProductHealthData["pri
       );
     case "below":
       return (
-        <span style={{ color: "#76b900", display: "inline-flex", alignItems: "center", gap: "4px" }}>
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <span
+          style={{ color: "#76b900", display: "inline-flex", alignItems: "center", gap: "4px" }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
             <polyline points="6 9 12 15 18 9" />
           </svg>
           Below
@@ -60,8 +78,22 @@ function PricePositionIndicator({ position }: { position: ProductHealthData["pri
       );
     case "at":
       return (
-        <span style={{ color: "rgba(255, 255, 255, 0.6)", display: "inline-flex", alignItems: "center", gap: "4px" }}>
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <span
+          style={{
+            color: "rgba(255, 255, 255, 0.6)",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "4px",
+          }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
           At Market
@@ -82,11 +114,7 @@ export function ProductHealthPanel({ data, isLoading }: ProductHealthPanelProps)
         <h3 className="chart-title">Product Health</h3>
         <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
           {[1, 2, 3, 4, 5].map((i) => (
-            <div
-              key={i}
-              className="glass-line w85"
-              style={{ height: "48px", marginTop: 0 }}
-            />
+            <div key={i} className="glass-line w85" style={{ height: "48px", marginTop: 0 }} />
           ))}
         </div>
       </div>
@@ -110,9 +138,7 @@ export function ProductHealthPanel({ data, isLoading }: ProductHealthPanelProps)
         <tbody>
           {data.map((product) => (
             <tr key={product.id}>
-              <td style={{ fontWeight: 600, color: "rgba(255, 255, 255, 0.9)" }}>
-                {product.name}
-              </td>
+              <td style={{ fontWeight: 600, color: "rgba(255, 255, 255, 0.9)" }}>{product.name}</td>
               <td style={{ fontFamily: "monospace", fontSize: "11px" }}>{product.sku}</td>
               <td>
                 <span className={getStockStatusClass(product.stockStatus)}>

--- a/src/ui/components/metrics/panels/ProductHealthPanel.tsx
+++ b/src/ui/components/metrics/panels/ProductHealthPanel.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import type { ProductHealthData } from "@/types";
+
+interface ProductHealthPanelProps {
+  data: ProductHealthData[];
+  isLoading?: boolean;
+}
+
+/**
+ * Format currency value from cents to dollars
+ */
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value / 100);
+}
+
+/**
+ * Get stock status badge class
+ */
+function getStockStatusClass(status: ProductHealthData["stockStatus"]): string {
+  switch (status) {
+    case "healthy":
+      return "stock-badge healthy";
+    case "low":
+      return "stock-badge low";
+    case "critical":
+      return "stock-badge critical";
+    default:
+      return "stock-badge";
+  }
+}
+
+/**
+ * Get price position indicator
+ */
+function PricePositionIndicator({ position }: { position: ProductHealthData["pricePosition"] }) {
+  switch (position) {
+    case "above":
+      return (
+        <span style={{ color: "#ef4444", display: "inline-flex", alignItems: "center", gap: "4px" }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="18 15 12 9 6 15" />
+          </svg>
+          Above
+        </span>
+      );
+    case "below":
+      return (
+        <span style={{ color: "#76b900", display: "inline-flex", alignItems: "center", gap: "4px" }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+          Below
+        </span>
+      );
+    case "at":
+      return (
+        <span style={{ color: "rgba(255, 255, 255, 0.6)", display: "inline-flex", alignItems: "center", gap: "4px" }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          At Market
+        </span>
+      );
+    default:
+      return <span style={{ color: "rgba(255, 255, 255, 0.4)" }}>Unknown</span>;
+  }
+}
+
+/**
+ * Product health table panel
+ */
+export function ProductHealthPanel({ data, isLoading }: ProductHealthPanelProps) {
+  if (isLoading) {
+    return (
+      <div className="chart-container">
+        <h3 className="chart-title">Product Health</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div
+              key={i}
+              className="glass-line w85"
+              style={{ height: "48px", marginTop: 0 }}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chart-container" style={{ overflow: "auto" }}>
+      <h3 className="chart-title">Product Health</h3>
+      <table className="product-table">
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>SKU</th>
+            <th>Stock</th>
+            <th>Our Price</th>
+            <th>vs. Market</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((product) => (
+            <tr key={product.id}>
+              <td style={{ fontWeight: 600, color: "rgba(255, 255, 255, 0.9)" }}>
+                {product.name}
+              </td>
+              <td style={{ fontFamily: "monospace", fontSize: "11px" }}>{product.sku}</td>
+              <td>
+                <span className={getStockStatusClass(product.stockStatus)}>
+                  {product.stockLevel} units
+                </span>
+              </td>
+              <td style={{ fontWeight: 600 }}>{formatCurrency(product.basePrice)}</td>
+              <td>
+                <PricePositionIndicator position={product.pricePosition} />
+              </td>
+              <td>
+                {product.needsAttention ? (
+                  <span className="attention-flag">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <line x1="12" y1="8" x2="12" y2="12" />
+                      <line x1="12" y1="16" x2="12.01" y2="16" />
+                    </svg>
+                    {product.attentionReason}
+                  </span>
+                ) : (
+                  <span style={{ color: "#76b900", fontSize: "12px", fontWeight: 600 }}>
+                    Healthy
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/ui/components/metrics/panels/PromotionPanel.tsx
+++ b/src/ui/components/metrics/panels/PromotionPanel.tsx
@@ -61,7 +61,9 @@ export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
 
   // Calculate total savings
   const totalSavings = data.reduce((sum, item) => sum + item.totalSavings, 0);
-  const totalPromotions = data.filter((d) => d.type !== "NO_PROMO").reduce((sum, d) => sum + d.count, 0);
+  const totalPromotions = data
+    .filter((d) => d.type !== "NO_PROMO")
+    .reduce((sum, d) => sum + d.count, 0);
 
   return (
     <div className="chart-container">
@@ -82,7 +84,13 @@ export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
         }}
       >
         <div style={{ textAlign: "center" }}>
-          <p style={{ fontSize: "10px", color: "rgba(255, 255, 255, 0.5)", textTransform: "uppercase" }}>
+          <p
+            style={{
+              fontSize: "10px",
+              color: "rgba(255, 255, 255, 0.5)",
+              textTransform: "uppercase",
+            }}
+          >
             Total Promotions
           </p>
           <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
@@ -90,7 +98,13 @@ export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
           </p>
         </div>
         <div style={{ textAlign: "center" }}>
-          <p style={{ fontSize: "10px", color: "rgba(255, 255, 255, 0.5)", textTransform: "uppercase" }}>
+          <p
+            style={{
+              fontSize: "10px",
+              color: "rgba(255, 255, 255, 0.5)",
+              textTransform: "uppercase",
+            }}
+          >
             Total Savings
           </p>
           <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>

--- a/src/ui/components/metrics/panels/PromotionPanel.tsx
+++ b/src/ui/components/metrics/panels/PromotionPanel.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { PromotionBreakdownData } from "@/types";
+import { GlassPieChart } from "../charts/GlassPieChart";
+
+interface PromotionPanelProps {
+  data: PromotionBreakdownData[];
+  isLoading?: boolean;
+}
+
+/**
+ * Format currency value from cents to dollars
+ */
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value / 100);
+}
+
+/**
+ * Promotion breakdown donut chart panel
+ */
+export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
+  if (isLoading) {
+    return (
+      <div className="chart-container">
+        <div className="chart-title">
+          <div className="glass-line w50" style={{ height: "14px", marginTop: 0 }} />
+        </div>
+        <div
+          style={{
+            height: "240px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            style={{
+              width: "200px",
+              height: "200px",
+              borderRadius: "50%",
+              background: "rgba(255, 255, 255, 0.04)",
+              border: "1px solid rgba(255, 255, 255, 0.08)",
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Transform data for pie chart
+  const pieData = data.map((item) => ({
+    label: item.label,
+    value: item.count,
+    color: item.color,
+  }));
+
+  // Calculate total savings
+  const totalSavings = data.reduce((sum, item) => sum + item.totalSavings, 0);
+  const totalPromotions = data.filter((d) => d.type !== "NO_PROMO").reduce((sum, d) => sum + d.count, 0);
+
+  return (
+    <div className="chart-container">
+      <h3 className="chart-title">Promotion Breakdown</h3>
+      <GlassPieChart
+        data={pieData}
+        formatValue={(v) => `${v} promotions`}
+        innerRadius={50}
+        outerRadius={85}
+      />
+      <div
+        style={{
+          marginTop: "16px",
+          paddingTop: "16px",
+          borderTop: "1px solid rgba(255, 255, 255, 0.08)",
+          display: "flex",
+          justifyContent: "space-around",
+        }}
+      >
+        <div style={{ textAlign: "center" }}>
+          <p style={{ fontSize: "10px", color: "rgba(255, 255, 255, 0.5)", textTransform: "uppercase" }}>
+            Total Promotions
+          </p>
+          <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
+            {totalPromotions.toLocaleString()}
+          </p>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <p style={{ fontSize: "10px", color: "rgba(255, 255, 255, 0.5)", textTransform: "uppercase" }}>
+            Total Savings
+          </p>
+          <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
+            {formatCurrency(totalSavings)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/metrics/panels/RevenuePanel.tsx
+++ b/src/ui/components/metrics/panels/RevenuePanel.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type { RevenueDataPoint, TimeRange } from "@/types";
+import { GlassAreaChart } from "../charts/GlassAreaChart";
+
+interface RevenuePanelProps {
+  data: RevenueDataPoint[];
+  timeRange: TimeRange;
+  isLoading?: boolean;
+}
+
+/**
+ * Format currency value from cents to dollars
+ */
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value / 100);
+}
+
+/**
+ * Format timestamp for X axis based on time range
+ */
+function formatTimestamp(timestamp: string, timeRange: TimeRange): string {
+  const date = new Date(timestamp);
+
+  switch (timeRange) {
+    case "1h":
+      return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    case "24h":
+      return date.toLocaleTimeString("en-US", { hour: "numeric" });
+    case "7d":
+      return date.toLocaleDateString("en-US", { weekday: "short" });
+    case "30d":
+      return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    default:
+      return date.toLocaleTimeString("en-US", { hour: "numeric" });
+  }
+}
+
+/**
+ * Revenue over time area chart panel
+ */
+export function RevenuePanel({ data, timeRange, isLoading }: RevenuePanelProps) {
+  if (isLoading) {
+    return (
+      <div className="chart-container">
+        <div className="chart-title">
+          <div className="glass-line w50" style={{ height: "14px", marginTop: 0 }} />
+        </div>
+        <div
+          style={{
+            height: "280px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <div className="glass-line w85" style={{ height: "200px", width: "100%" }} />
+        </div>
+      </div>
+    );
+  }
+
+  // Cast data to Record<string, unknown>[] for GlassAreaChart compatibility
+  const chartData = data as unknown as Record<string, unknown>[];
+
+  return (
+    <GlassAreaChart
+      data={chartData}
+      dataKey="revenue"
+      xAxisKey="timestamp"
+      title="Revenue Over Time"
+      formatValue={formatCurrency}
+      formatXAxis={(ts) => formatTimestamp(ts, timeRange)}
+      color="#76b900"
+      gradientId="revenueGradient"
+    />
+  );
+}

--- a/src/ui/hooks/useMetrics.tsx
+++ b/src/ui/hooks/useMetrics.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useReducer,
+  useCallback,
+  useMemo,
+  useEffect,
+  type ReactNode,
+} from "react";
+import type { TimeRange, MetricsState, MetricsAction } from "@/types";
+import { useMockMetrics } from "./useMockMetrics";
+
+const initialState: MetricsState = {
+  timeRange: "24h",
+  isLoading: false,
+  lastUpdated: null,
+  kpis: [],
+  revenueData: [],
+  agentPerformance: [],
+  promotionBreakdown: [],
+  productHealth: [],
+};
+
+function metricsReducer(state: MetricsState, action: MetricsAction): MetricsState {
+  switch (action.type) {
+    case "SET_TIME_RANGE":
+      return {
+        ...state,
+        timeRange: action.timeRange,
+      };
+    case "SET_LOADING":
+      return {
+        ...state,
+        isLoading: action.isLoading,
+      };
+    case "UPDATE_METRICS":
+      return {
+        ...state,
+        ...action.metrics,
+        lastUpdated: new Date(),
+      };
+    case "REFRESH":
+      return {
+        ...state,
+        lastUpdated: new Date(),
+      };
+    default:
+      return state;
+  }
+}
+
+interface MetricsContextType {
+  state: MetricsState;
+  setTimeRange: (timeRange: TimeRange) => void;
+  refresh: () => void;
+}
+
+const MetricsContext = createContext<MetricsContextType | null>(null);
+
+/**
+ * Provider component for metrics state management
+ */
+export function MetricsProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(metricsReducer, initialState);
+
+  // Get mock data based on current time range
+  const mockData = useMockMetrics(state.timeRange);
+
+  // Update metrics when time range changes or on mount
+  useEffect(() => {
+    dispatch({ type: "SET_LOADING", isLoading: true });
+
+    // Simulate API delay for realistic feel
+    const timer = setTimeout(() => {
+      dispatch({
+        type: "UPDATE_METRICS",
+        metrics: {
+          kpis: mockData.kpis,
+          revenueData: mockData.revenueData,
+          agentPerformance: mockData.agentPerformance,
+          promotionBreakdown: mockData.promotionBreakdown,
+          productHealth: mockData.productHealth,
+          isLoading: false,
+        },
+      });
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [
+    state.timeRange,
+    mockData.kpis,
+    mockData.revenueData,
+    mockData.agentPerformance,
+    mockData.promotionBreakdown,
+    mockData.productHealth,
+  ]);
+
+  const setTimeRange = useCallback((timeRange: TimeRange) => {
+    dispatch({ type: "SET_TIME_RANGE", timeRange });
+  }, []);
+
+  const refresh = useCallback(() => {
+    dispatch({ type: "SET_LOADING", isLoading: true });
+
+    // Simulate refresh delay
+    setTimeout(() => {
+      dispatch({ type: "REFRESH" });
+      dispatch({ type: "SET_LOADING", isLoading: false });
+    }, 500);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      state,
+      setTimeRange,
+      refresh,
+    }),
+    [state, setTimeRange, refresh]
+  );
+
+  return <MetricsContext.Provider value={contextValue}>{children}</MetricsContext.Provider>;
+}
+
+/**
+ * Hook to access metrics context
+ */
+export function useMetrics() {
+  const context = useContext(MetricsContext);
+  if (!context) {
+    throw new Error("useMetrics must be used within MetricsProvider");
+  }
+  return context;
+}

--- a/src/ui/hooks/useMockMetrics.tsx
+++ b/src/ui/hooks/useMockMetrics.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useMemo } from "react";
+import type {
+  TimeRange,
+  KPIData,
+  RevenueDataPoint,
+  AgentPerformanceData,
+  PromotionBreakdownData,
+  ProductHealthData,
+} from "@/types";
+
+/**
+ * Generate mock KPI data for demo purposes
+ */
+function generateKPIs(): KPIData[] {
+  return [
+    {
+      id: "revenue",
+      label: "Revenue",
+      value: 12847500, // in cents = $128,475.00
+      previousValue: 11234200,
+      format: "currency",
+      trend: "up",
+      trendValue: 14.3,
+    },
+    {
+      id: "orders",
+      label: "Orders",
+      value: 847,
+      previousValue: 792,
+      format: "number",
+      trend: "up",
+      trendValue: 6.9,
+    },
+    {
+      id: "conversion",
+      label: "Conv. Rate",
+      value: 3.42,
+      previousValue: 3.18,
+      format: "percent",
+      trend: "up",
+      trendValue: 7.5,
+    },
+    {
+      id: "aov",
+      label: "Avg Order",
+      value: 15170, // in cents = $151.70
+      previousValue: 14186,
+      format: "currency",
+      trend: "up",
+      trendValue: 6.9,
+    },
+    {
+      id: "latency",
+      label: "Agent Latency",
+      value: 245, // in ms
+      previousValue: 312,
+      format: "duration",
+      trend: "up",
+      trendValue: -21.5,
+    },
+  ];
+}
+
+/**
+ * Generate mock revenue data for the time range
+ */
+function generateRevenueData(timeRange: TimeRange): RevenueDataPoint[] {
+  const now = new Date();
+  const data: RevenueDataPoint[] = [];
+
+  let points: number;
+  let intervalMs: number;
+
+  switch (timeRange) {
+    case "1h":
+      points = 12;
+      intervalMs = 5 * 60 * 1000; // 5 minutes
+      break;
+    case "24h":
+      points = 24;
+      intervalMs = 60 * 60 * 1000; // 1 hour
+      break;
+    case "7d":
+      points = 7;
+      intervalMs = 24 * 60 * 60 * 1000; // 1 day
+      break;
+    case "30d":
+      points = 30;
+      intervalMs = 24 * 60 * 60 * 1000; // 1 day
+      break;
+    default:
+      points = 24;
+      intervalMs = 60 * 60 * 1000;
+  }
+
+  for (let i = points - 1; i >= 0; i--) {
+    const timestamp = new Date(now.getTime() - i * intervalMs);
+    const baseRevenue = 3500 + Math.random() * 2500;
+    const baseOrders = Math.floor(20 + Math.random() * 15);
+
+    data.push({
+      timestamp: timestamp.toISOString(),
+      revenue: Math.round(baseRevenue * 100), // in cents
+      orders: baseOrders,
+    });
+  }
+
+  return data;
+}
+
+/**
+ * Generate mock agent performance data
+ */
+function generateAgentPerformance(): AgentPerformanceData[] {
+  return [
+    {
+      agentType: "promotion",
+      label: "Promotion Agent",
+      successRate: 94.2,
+      avgLatency: 187,
+      totalCalls: 1247,
+      errors: 73,
+    },
+    {
+      agentType: "recommendation",
+      label: "Recommendation Agent",
+      successRate: 98.7,
+      avgLatency: 312,
+      totalCalls: 892,
+      errors: 12,
+    },
+    {
+      agentType: "post_purchase",
+      label: "Post-Purchase Agent",
+      successRate: 99.1,
+      avgLatency: 156,
+      totalCalls: 634,
+      errors: 6,
+    },
+    {
+      agentType: "search",
+      label: "Search Agent",
+      successRate: 97.8,
+      avgLatency: 89,
+      totalCalls: 2156,
+      errors: 47,
+    },
+  ];
+}
+
+/**
+ * Generate mock promotion breakdown data
+ */
+function generatePromotionBreakdown(): PromotionBreakdownData[] {
+  return [
+    {
+      type: "DISCOUNT_10_PCT",
+      label: "10% Discount",
+      count: 312,
+      totalSavings: 4687500, // in cents
+      color: "#76b900",
+    },
+    {
+      type: "DISCOUNT_15_PCT",
+      label: "15% Discount",
+      count: 187,
+      totalSavings: 5812300,
+      color: "#5a9200",
+    },
+    {
+      type: "DISCOUNT_20_PCT",
+      label: "20% Discount",
+      count: 94,
+      totalSavings: 3921800,
+      color: "#3d6200",
+    },
+    {
+      type: "NO_PROMO",
+      label: "No Promotion",
+      count: 254,
+      totalSavings: 0,
+      color: "rgba(255, 255, 255, 0.2)",
+    },
+  ];
+}
+
+/**
+ * Generate mock product health data
+ */
+function generateProductHealth(): ProductHealthData[] {
+  return [
+    {
+      id: "1",
+      name: "Premium Leather Running Shoes",
+      sku: "SHO-RUN-001",
+      stockLevel: 12,
+      stockStatus: "low",
+      basePrice: 12999, // $129.99
+      competitorPrice: 13499,
+      pricePosition: "below",
+      needsAttention: true,
+      attentionReason: "Low stock",
+    },
+    {
+      id: "2",
+      name: "Classic Denim Jacket",
+      sku: "JKT-DNM-042",
+      stockLevel: 45,
+      stockStatus: "healthy",
+      basePrice: 8999,
+      competitorPrice: 8999,
+      pricePosition: "at",
+      needsAttention: false,
+    },
+    {
+      id: "3",
+      name: "Vintage Logo T-Shirt",
+      sku: "TSH-VNT-108",
+      stockLevel: 78,
+      stockStatus: "healthy",
+      basePrice: 3499,
+      competitorPrice: 2999,
+      pricePosition: "above",
+      needsAttention: true,
+      attentionReason: "Above market price",
+    },
+    {
+      id: "4",
+      name: "Waterproof Hiking Boots",
+      sku: "SHO-HIK-023",
+      stockLevel: 3,
+      stockStatus: "critical",
+      basePrice: 18999,
+      competitorPrice: 18999,
+      pricePosition: "at",
+      needsAttention: true,
+      attentionReason: "Critical stock",
+    },
+    {
+      id: "5",
+      name: "Lightweight Windbreaker Jacket",
+      sku: "JKT-WND-067",
+      stockLevel: 156,
+      stockStatus: "healthy",
+      basePrice: 5999,
+      competitorPrice: 6499,
+      pricePosition: "below",
+      needsAttention: false,
+    },
+  ];
+}
+
+/**
+ * Hook to generate mock metrics data for demo purposes
+ */
+export function useMockMetrics(timeRange: TimeRange) {
+  const kpis = useMemo(() => generateKPIs(), []);
+  const revenueData = useMemo(() => generateRevenueData(timeRange), [timeRange]);
+  const agentPerformance = useMemo(() => generateAgentPerformance(), []);
+  const promotionBreakdown = useMemo(() => generatePromotionBreakdown(), []);
+  const productHealth = useMemo(() => generateProductHealth(), []);
+
+  return {
+    kpis,
+    revenueData,
+    agentPerformance,
+    promotionBreakdown,
+    productHealth,
+  };
+}

--- a/src/ui/hooks/usePhoenixTelemetry.tsx
+++ b/src/ui/hooks/usePhoenixTelemetry.tsx
@@ -148,9 +148,7 @@ function calculateAgentPerformance(traces: PhoenixTraceData[]): AgentPerformance
     const errors = agentTraces.filter((t) => t.status === "error").length;
     const successRate = totalCalls > 0 ? ((totalCalls - errors) / totalCalls) * 100 : 100;
     const avgLatency =
-      totalCalls > 0
-        ? agentTraces.reduce((sum, t) => sum + t.duration, 0) / totalCalls
-        : 0;
+      totalCalls > 0 ? agentTraces.reduce((sum, t) => sum + t.duration, 0) / totalCalls : 0;
 
     const labelMap: Record<AgentType, string> = {
       promotion: "Promotion Agent",

--- a/src/ui/hooks/usePhoenixTelemetry.tsx
+++ b/src/ui/hooks/usePhoenixTelemetry.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import type { PhoenixTraceData, AgentPerformanceData, AgentType } from "@/types";
+
+interface PhoenixProject {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+interface PhoenixSpan {
+  context: {
+    trace_id: string;
+    span_id: string;
+  };
+  name: string;
+  start_time: string;
+  end_time: string;
+  status_code: string;
+  attributes?: Record<string, unknown>;
+}
+
+interface UsePhoenixTelemetryResult {
+  isLoading: boolean;
+  error: string | null;
+  projects: PhoenixProject[];
+  traces: PhoenixTraceData[];
+  agentPerformance: AgentPerformanceData[];
+  fetchProjects: () => Promise<void>;
+  fetchTraces: (projectId: string, limit?: number) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Hook to fetch telemetry data from Phoenix via the proxy route
+ */
+export function usePhoenixTelemetry(): UsePhoenixTelemetryResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<PhoenixProject[]>([]);
+  const [traces, setTraces] = useState<PhoenixTraceData[]>([]);
+  const [agentPerformance, setAgentPerformance] = useState<AgentPerformanceData[]>([]);
+
+  const fetchProjects = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/proxy/phoenix/v1/projects");
+      if (!response.ok) {
+        throw new Error("Failed to fetch Phoenix projects");
+      }
+      const data = await response.json();
+      setProjects(data.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setProjects([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const fetchTraces = useCallback(async (projectId: string, limit = 100) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/proxy/phoenix/v1/projects/${projectId}/traces?limit=${limit}`
+      );
+      if (!response.ok) {
+        throw new Error("Failed to fetch Phoenix traces");
+      }
+      const data = await response.json();
+      const spans: PhoenixSpan[] = data.data ?? [];
+
+      // Transform spans to traces
+      const transformedTraces: PhoenixTraceData[] = spans.map((span) => {
+        const trace: PhoenixTraceData = {
+          traceId: span.context.trace_id,
+          spanId: span.context.span_id,
+          name: span.name,
+          startTime: span.start_time,
+          endTime: span.end_time,
+          duration: new Date(span.end_time).getTime() - new Date(span.start_time).getTime(),
+          status: span.status_code === "OK" ? "ok" : "error",
+        };
+        if (span.attributes) {
+          trace.attributes = span.attributes;
+        }
+        return trace;
+      });
+
+      setTraces(transformedTraces);
+
+      // Calculate agent performance from traces
+      const performance = calculateAgentPerformance(transformedTraces);
+      setAgentPerformance(performance);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setTraces([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const firstProject = projects[0];
+    if (projects.length > 0 && firstProject) {
+      await fetchTraces(firstProject.id);
+    } else {
+      await fetchProjects();
+    }
+  }, [projects, fetchProjects, fetchTraces]);
+
+  // Auto-fetch on mount
+  useEffect(() => {
+    void fetchProjects();
+  }, [fetchProjects]);
+
+  return {
+    isLoading,
+    error,
+    projects,
+    traces,
+    agentPerformance,
+    fetchProjects,
+    fetchTraces,
+    refresh,
+  };
+}
+
+/**
+ * Calculate agent performance metrics from traces
+ */
+function calculateAgentPerformance(traces: PhoenixTraceData[]): AgentPerformanceData[] {
+  const agentTypes: AgentType[] = ["promotion", "recommendation", "post_purchase", "search"];
+
+  return agentTypes.map((agentType) => {
+    // Filter traces for this agent type
+    const agentTraces = traces.filter((trace) => {
+      const name = trace.name.toLowerCase();
+      return name.includes(agentType) || name.includes(agentType.replace("_", "-"));
+    });
+
+    const totalCalls = agentTraces.length;
+    const errors = agentTraces.filter((t) => t.status === "error").length;
+    const successRate = totalCalls > 0 ? ((totalCalls - errors) / totalCalls) * 100 : 100;
+    const avgLatency =
+      totalCalls > 0
+        ? agentTraces.reduce((sum, t) => sum + t.duration, 0) / totalCalls
+        : 0;
+
+    const labelMap: Record<AgentType, string> = {
+      promotion: "Promotion Agent",
+      recommendation: "Recommendation Agent",
+      post_purchase: "Post-Purchase Agent",
+      search: "Search Agent",
+    };
+
+    return {
+      agentType,
+      label: labelMap[agentType],
+      successRate: Math.round(successRate * 10) / 10,
+      avgLatency: Math.round(avgLatency),
+      totalCalls,
+      errors,
+    };
+  });
+}

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -45,6 +45,7 @@
     "react": "^19.0.0",
     "react-day-picker": "^9.11.0",
     "react-dom": "^19.0.0",
+    "recharts": "^3.7.0",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/src/ui/pnpm-lock.yaml
+++ b/src/ui/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.3(react@19.2.3)
+      recharts:
+        specifier: ^3.7.0
+        version: 3.7.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-is@17.0.2)(react@19.2.3)(redux@5.0.1)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -1261,6 +1264,17 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1395,6 +1409,12 @@ packages:
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1527,6 +1547,33 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1546,6 +1593,9 @@ packages:
 
   '@types/react@19.2.9':
     resolution: {integrity: sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.53.1':
     resolution: {integrity: sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==}
@@ -1935,6 +1985,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1976,6 +2070,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2072,6 +2169,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.44.0:
+    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -2210,6 +2310,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2387,6 +2490,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.3:
+    resolution: {integrity: sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2402,6 +2511,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2890,6 +3003,18 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -2928,9 +3053,25 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.7.0:
+    resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2939,6 +3080,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3134,6 +3278,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3255,6 +3402,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -4412,6 +4562,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.3
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
@@ -4492,6 +4654,10 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -4624,6 +4790,30 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.6
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -4641,6 +4831,8 @@ snapshots:
   '@types/react@19.2.9':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5062,6 +5254,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-urls@5.0.0:
@@ -5098,6 +5328,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -5252,6 +5484,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.44.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -5487,6 +5721,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -5662,6 +5898,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.3: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5676,6 +5916,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -6150,6 +6392,15 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-redux@9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.9
+      redux: 5.0.1
+
   react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.9)(react@19.2.3):
@@ -6181,10 +6432,36 @@ snapshots:
 
   react@19.2.3: {}
 
+  recharts@3.7.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-is@17.0.2)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.44.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.9)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6205,6 +6482,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -6476,6 +6755,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -6622,6 +6903,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@2.1.9(@types/node@22.19.7)(lightningcss@1.30.2):
     dependencies:

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -922,3 +922,119 @@ export const DEFAULT_BILLING_ADDRESS: BillingAddressFormData = {
   address: "123 Main St, San Francisco, CA 94102",
   preferredLanguage: "en",
 };
+
+// =============================================================================
+// Metrics Dashboard Types
+// =============================================================================
+
+/**
+ * Time range options for the metrics dashboard
+ */
+export type TimeRange = "1h" | "24h" | "7d" | "30d";
+
+/**
+ * KPI metric data structure
+ */
+export interface KPIData {
+  id: string;
+  label: string;
+  value: number;
+  previousValue?: number;
+  format: "currency" | "number" | "percent" | "duration";
+  trend?: "up" | "down" | "neutral";
+  trendValue?: number;
+}
+
+/**
+ * Chart data point for time series
+ */
+export interface ChartDataPoint {
+  timestamp: string;
+  value: number;
+  label?: string;
+}
+
+/**
+ * Revenue chart data point with additional fields
+ */
+export interface RevenueDataPoint {
+  timestamp: string;
+  revenue: number;
+  orders: number;
+}
+
+/**
+ * Agent performance metrics
+ */
+export interface AgentPerformanceData {
+  agentType: AgentType;
+  label: string;
+  successRate: number;
+  avgLatency: number;
+  totalCalls: number;
+  errors: number;
+}
+
+/**
+ * Promotion breakdown data for pie chart
+ */
+export interface PromotionBreakdownData {
+  type: string;
+  label: string;
+  count: number;
+  totalSavings: number;
+  color: string;
+}
+
+/**
+ * Product health data for table
+ */
+export interface ProductHealthData {
+  id: string;
+  name: string;
+  sku: string;
+  stockLevel: number;
+  stockStatus: "healthy" | "low" | "critical";
+  basePrice: number;
+  competitorPrice?: number;
+  pricePosition: "above" | "at" | "below" | "unknown";
+  needsAttention: boolean;
+  attentionReason?: string;
+}
+
+/**
+ * Phoenix trace data from telemetry
+ */
+export interface PhoenixTraceData {
+  traceId: string;
+  spanId: string;
+  name: string;
+  startTime: string;
+  endTime: string;
+  duration: number;
+  status: "ok" | "error";
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * Overall metrics state
+ */
+export interface MetricsState {
+  timeRange: TimeRange;
+  isLoading: boolean;
+  lastUpdated: Date | null;
+  kpis: KPIData[];
+  revenueData: RevenueDataPoint[];
+  agentPerformance: AgentPerformanceData[];
+  promotionBreakdown: PromotionBreakdownData[];
+  productHealth: ProductHealthData[];
+}
+
+/**
+ * Metrics context actions
+ */
+export type MetricsAction =
+  | { type: "SET_TIME_RANGE"; timeRange: TimeRange }
+  | { type: "SET_LOADING"; isLoading: boolean }
+  | { type: "UPDATE_METRICS"; metrics: Partial<MetricsState> }
+  | { type: "REFRESH" };


### PR DESCRIPTION
## Summary
- Add new `/metrics` route with comprehensive analytics dashboard
- Add navigation links (Simulator/Metrics) to Navbar with active state styling
- Add missing `env.local` setup instruction to README

## Features
- **5 KPI Cards**: Revenue, Orders, Conversion Rate, Avg Order Value, Agent Latency
- **Revenue Chart**: Time-series area chart with time range selector (1H/24H/7D/30D)
- **Agent Performance**: Success rates and latency visualization for all 4 agent types
- **Promotion Breakdown**: Donut chart showing discount distribution and total savings
- **Product Health Table**: Stock levels, pricing vs competitors, attention flags

## Technical Details
- Glass-morphic styling consistent with existing design system
- NVIDIA green (#76b900) theming throughout
- Recharts library for data visualization
- Phoenix API proxy route for future telemetry integration
- Mock data hooks for standalone demo capability
- Fully typed with TypeScript

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes  
- [x] `pnpm run test` - all 193 tests pass
- [x] Dev server serves `/` and `/metrics` correctly
- [x] Manual testing of dashboard navigation
- [x] Verify charts render with mock data
- [x] Test time range selector functionality
- [x] Verify responsive layout

🤖 Generated with [Claude Code](https://claude.ai/code)