### PR TITLE
[backend][docs] Add UCP Phase 2 checkout endpoints with capability negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,89 @@ ACP lets AI agents negotiate with merchants on behalf of users. The merchant sta
 - Complete checkout with delegated payments
 - Receive multilingual post-purchase updates
 
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph Client["Client Layer"]
+        CA[🤖 Client Agent]
+    end
+
+    subgraph Integration["Integration Options"]
+        direction LR
+        subgraph SDK["Apps SDK Layer"]
+            MCP["📦 Apps SDK MCP Server<br/>(Port 2091)"]
+            subgraph tools["Entry Point"]
+                T1["search-products<br/>(returns widget)"]
+            end
+            WIDGET["🛒 Autonomous Widget<br/>(cart, checkout, recs)"]
+        end
+
+        subgraph Native["Native ACP Layer"]
+            ACP["🔗 Direct ACP Protocol"]
+            subgraph endpoints["ACP Endpoints"]
+                E1["checkout_sessions/*"]
+            end
+        end
+    end
+
+    subgraph Backend["Backend Services"]
+        MERCHANT["🏪 Merchant API<br/>(Port 8000)"]
+        PSP["💳 PSP Service<br/>(Port 8001)"]
+        
+        subgraph merchant_features["Merchant Features"]
+            M1[Products & Sessions]
+            M2[Checkout & Promotions]
+            M3[Orders & Recommendations]
+        end
+        
+        subgraph psp_features["PSP Features"]
+            P1[Payment Delegation]
+            P2[Vault Tokens]
+            P3[Idempotency]
+        end
+    end
+
+    subgraph Agents["NAT Agents"]
+        PROMO["🎯 Promotion Agent<br/>(Port 8002)"]
+        POST["📨 Post-Purchase Agent<br/>(Port 8003)"]
+        RECS["🔍 Recommendation Agent<br/>(Port 8004)"]
+        SEARCH["🔎 Search Agent<br/>(Port 8005)"]
+    end
+
+    subgraph NIMs["NVIDIA NIMs"]
+        LLM["🧠 Nemotron Nano LLM<br/>(Port 8010)"]
+        EMBED["📐 NV-EmbedQA-E5<br/>(Port 8011)"]
+    end
+
+    subgraph Data["Data Stores"]
+        SQLITE[("🗄️ SQLite<br/>Application DB")]
+        MILVUS[("🧠 Milvus<br/>Vector DB")]
+    end
+
+    CA -->|MCP| MCP
+    CA -->|REST| ACP
+    MCP -.->|loads| WIDGET
+    WIDGET -->|MCP tools| MCP
+    MCP --> MERCHANT
+    ACP --> MERCHANT
+    MERCHANT --> PSP
+    MERCHANT --> PROMO
+    MERCHANT --> POST
+    MERCHANT --> RECS
+    MERCHANT --> SEARCH
+    MERCHANT --> SQLITE
+    PROMO --> LLM
+    POST --> LLM
+    RECS --> LLM
+    RECS --> EMBED
+    SEARCH --> LLM
+    SEARCH --> EMBED
+    EMBED --> MILVUS
+    RECS --> MILVUS
+    SEARCH --> MILVUS
+```
+
 ## Quick Start
 
 ### Prerequisites
@@ -139,13 +222,21 @@ curl http://localhost:8001/health  # PSP Service
 curl http://localhost:2091/health  # Apps SDK
 ```
 
-### UCP Discovery (Phase 1)
+### UCP Endpoints
 
 ```bash
+# Discovery (Phase 1)
 curl http://localhost:8000/.well-known/ucp
+
+# Checkout (Phase 2) - requires UCP-Agent header
+curl -X POST http://localhost:8000/checkout-sessions \
+  -H "Authorization: Bearer test-api-key" \
+  -H "UCP-Agent: profile=\"https://platform.example/profile\"" \
+  -H "Content-Type: application/json" \
+  -d '{"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]}'
 ```
 
-Optional environment variables for UCP discovery:
+Optional environment variables for UCP:
 
 ```env
 UCP_VERSION=2026-01-11
@@ -161,94 +252,11 @@ UCP_SIGNING_KEY_Y=
 
 Visit **http://localhost:3000** to see the demo UI.
 
-## Architecture
-
-```mermaid
-flowchart TB
-    subgraph Client["Client Layer"]
-        CA[🤖 Client Agent]
-    end
-
-    subgraph Integration["Integration Options"]
-        direction LR
-        subgraph SDK["Apps SDK Layer"]
-            MCP["📦 Apps SDK MCP Server<br/>(Port 2091)"]
-            subgraph tools["Entry Point"]
-                T1["search-products<br/>(returns widget)"]
-            end
-            WIDGET["🛒 Autonomous Widget<br/>(cart, checkout, recs)"]
-        end
-
-        subgraph Native["Native ACP Layer"]
-            ACP["🔗 Direct ACP Protocol"]
-            subgraph endpoints["ACP Endpoints"]
-                E1["checkout_sessions/*"]
-            end
-        end
-    end
-
-    subgraph Backend["Backend Services"]
-        MERCHANT["🏪 Merchant API<br/>(Port 8000)"]
-        PSP["💳 PSP Service<br/>(Port 8001)"]
-        
-        subgraph merchant_features["Merchant Features"]
-            M1[Products & Sessions]
-            M2[Checkout & Promotions]
-            M3[Orders & Recommendations]
-        end
-        
-        subgraph psp_features["PSP Features"]
-            P1[Payment Delegation]
-            P2[Vault Tokens]
-            P3[Idempotency]
-        end
-    end
-
-    subgraph Agents["NAT Agents"]
-        PROMO["🎯 Promotion Agent<br/>(Port 8002)"]
-        POST["📨 Post-Purchase Agent<br/>(Port 8003)"]
-        RECS["🔍 Recommendation Agent<br/>(Port 8004)"]
-        SEARCH["🔎 Search Agent<br/>(Port 8005)"]
-    end
-
-    subgraph NIMs["NVIDIA NIMs"]
-        LLM["🧠 Nemotron Nano LLM<br/>(Port 8010)"]
-        EMBED["📐 NV-EmbedQA-E5<br/>(Port 8011)"]
-    end
-
-    subgraph Data["Data Stores"]
-        SQLITE[("🗄️ SQLite<br/>Application DB")]
-        MILVUS[("🧠 Milvus<br/>Vector DB")]
-    end
-
-    CA -->|MCP| MCP
-    CA -->|REST| ACP
-    MCP -.->|loads| WIDGET
-    WIDGET -->|MCP tools| MCP
-    MCP --> MERCHANT
-    ACP --> MERCHANT
-    MERCHANT --> PSP
-    MERCHANT --> PROMO
-    MERCHANT --> POST
-    MERCHANT --> RECS
-    MERCHANT --> SEARCH
-    MERCHANT --> SQLITE
-    PROMO --> LLM
-    POST --> LLM
-    RECS --> LLM
-    RECS --> EMBED
-    SEARCH --> LLM
-    SEARCH --> EMBED
-    EMBED --> MILVUS
-    RECS --> MILVUS
-    SEARCH --> MILVUS
-```
-
 ## Services
 
 | Service | Port | Description |
 |---------|------|-------------|
-| Merchant API | 8000 | ACP checkout, products, orders |
+| Merchant API | 8000 | ACP/UCP checkout, products, orders |
 | PSP Service | 8001 | Payment delegation, vault tokens |
 | Apps SDK | 2091 | MCP server for AI agents |
 | Promotion Agent | 8002 | Discount strategy (NAT) |
@@ -344,7 +352,7 @@ The project uses three Docker Compose files:
 | Route | Service | Description |
 |-------|---------|-------------|
 | `/` | UI | Demo frontend |
-| `/api/*` | Merchant API | ACP checkout, products, orders |
+| `/api/*` | Merchant API | ACP/UCP checkout, products, orders |
 | `/psp/*` | PSP Service | Payment delegation |
 | `/apps-sdk/*` | Apps SDK | MCP server for AI agents |
 
@@ -448,7 +456,8 @@ docker compose -f docker-compose.infra.yml down
 |----------|-------------|
 | [Architecture](docs/architecture.md) | System design and data flow |
 | [Features](docs/features.md) | Feature breakdown and status |
-| [ACP Spec](docs/specs/acp-spec.md) | Protocol specification |
+| [ACP Spec](docs/specs/acp-spec.md) | ACP protocol specification |
+| [UCP Spec](docs/specs/ucp-spec.md) | UCP protocol specification |
 | [Apps SDK](src/apps_sdk/README.md) | MCP server documentation |
 | [NAT Agents](src/agents/README.md) | Agent configuration guide |
 

--- a/docs/features/feature-17-ucp-integration.md
+++ b/docs/features/feature-17-ucp-integration.md
@@ -23,10 +23,30 @@ This feature adds UCP-compliant endpoints that share the same intelligent agent 
 | Phase | Description | Status |
 |-------|-------------|--------|
 | **Phase 1** | Discovery Endpoint (`GET /.well-known/ucp`) | ✅ Complete |
-| **Phase 2** | Checkout Endpoints (REST) | 🔲 Planned |
+| **Phase 2** | Checkout Endpoints (REST) + Checkout-Only Capability Negotiation | ✅ Complete |
 | **Phase 3** | A2A Transport (JSON-RPC 2.0) | 🔲 Planned |
-| **Phase 4** | Capability Negotiation | 🔲 Planned |
+| **Phase 4** | Full Capability Negotiation (extension pruning) | 🔲 Planned |
 | **Phase 5** | Frontend Protocol Toggle | 🔲 Planned |
+| **Phase 6** | Fulfillment Extension (`dev.ucp.shopping.fulfillment`) | 🔲 Planned |
+
+### Phase 2 Scope Notes
+
+Phase 2 includes **real capability negotiation** but limited to `dev.ucp.shopping.checkout` only:
+- Fetch platform profile from `UCP-Agent` header
+- Compute intersection for checkout capability
+- In-memory profile caching (5-15 min TTL)
+- Minimal response shape: `ucp`, `id`, `status`, `currency`, `line_items`, `totals`, `messages`
+- Skip `fulfillment`, `payment`, `order`, `links`, `continue_url` until later phases
+
+### Phase 6: Fulfillment Extension (Deferred)
+
+The `dev.ucp.shopping.fulfillment` extension requires modeling:
+- **Destinations**: Shipping addresses with UCP schema (`street_address`, `address_locality`, etc.)
+- **Fulfillment Groups**: Business-generated packages grouping line items
+- **Fulfillment Options**: Selectable shipping options with pricing (`totals[]`)
+- **Option Selection**: `selected_destination_id`, `selected_option_id` handling
+
+This is deferred until Phase 6 to keep Phase 2 scope tight and avoid advertising unsupported capability surface.
 
 ### Phase 1 Deliverables (Complete)
 
@@ -40,6 +60,21 @@ This feature adds UCP-compliant endpoints that share the same intelligent agent 
 | `tests/merchant/api/test_ucp_discovery.py` | 11 unit tests |
 | `AGENTS.md`, `README.md`, `env.example` | Documentation updates |
 
+- Ruff linting and Pyright type checking passed
+
+### Phase 2 Deliverables (Complete)
+
+| File | Description |
+|------|-------------|
+| `src/merchant/api/routes/ucp/checkout.py` | UCP checkout REST endpoints (create, get, update, complete, cancel) |
+| `src/merchant/api/ucp_schemas.py` | Extended with checkout request/response schemas |
+| `src/merchant/services/ucp.py` | Capability negotiation, profile caching, transformations |
+| `src/merchant/db/models.py` | Added `protocol` field to CheckoutSession |
+| `tests/merchant/api/test_ucp_checkout.py` | Unit tests for endpoints and negotiation |
+
+- Real capability negotiation (checkout-only)
+- In-memory profile caching (10 min TTL)
+- Spec-aligned error codes (400, 422, 424)
 - Ruff linting and Pyright type checking passed
 
 ---
@@ -115,6 +150,9 @@ This feature adds UCP-compliant endpoints that share the same intelligent agent 
 - UCP Embedded transport (iframe-based)
 - UCP MCP transport (Model Context Protocol for UCP - Apps SDK uses MCP separately)
 - AP2 Mandates extension (cryptographic authorization)
+
+### Deferred to Phase 6
+- **Fulfillment Extension** (`dev.ucp.shopping.fulfillment`) - Requires modeling destinations, groups, and option selection per UCP spec. Will be negotiated and returned in responses once implemented.
 
 ---
 
@@ -399,7 +437,7 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. UCP oper
 
 1. **Create UCP Router Module** (`src/merchant/api/routes/ucp/`)
    - [x] `discovery.py` - UCP profile endpoint ✅ Phase 1
-   - [ ] `checkout.py` - UCP checkout endpoints (REST)
+   - [x] `checkout.py` - UCP checkout endpoints (REST)
    - [ ] `a2a.py` - A2A transport endpoints (JSON-RPC 2.0)
    - [ ] `negotiation.py` - Capability negotiation logic
 
@@ -416,27 +454,27 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. UCP oper
    - [x] Signing keys for webhooks
 
 4. **Implement Capability Negotiation**
-   - [ ] Platform profile fetching (HTTP GET)
-   - [ ] Profile caching strategy
-   - [ ] Intersection algorithm
+   - [x] Platform profile fetching (HTTP GET)
+   - [x] Profile caching strategy
+   - [x] Intersection algorithm
    - [ ] Extension pruning logic
-   - [ ] Version validation
+   - [x] Version validation
 
 5. **Create UCP Checkout Endpoints (REST)**
-   - [ ] POST `/checkout-sessions` (create)
-   - [ ] GET `/checkout-sessions/{id}` (get)
-   - [ ] PUT `/checkout-sessions/{id}` (update)
-   - [ ] POST `/checkout-sessions/{id}/complete` (complete)
-   - [ ] POST `/checkout-sessions/{id}/cancel` (cancel)
+   - [x] POST `/checkout-sessions` (create)
+   - [x] GET `/checkout-sessions/{id}` (get)
+   - [x] PUT `/checkout-sessions/{id}` (update)
+   - [x] POST `/checkout-sessions/{id}/complete` (complete)
+   - [x] POST `/checkout-sessions/{id}/cancel` (cancel)
 
 6. **Add Protocol Abstraction Layer**
-   - [ ] Normalize UCP requests to internal format
-   - [ ] Transform internal format to UCP responses
-   - [ ] Inject negotiated capabilities in responses
-   - [ ] Handle UCP-specific status values
+   - [x] Normalize UCP requests to internal format
+   - [x] Transform internal format to UCP responses
+   - [x] Inject negotiated capabilities in responses
+   - [x] Handle UCP-specific status values
 
 7. **Update Database Schema**
-   - [ ] Add `protocol` field to checkout_sessions table ("acp" | "ucp")
+   - [x] Add `protocol` field to checkout_sessions table ("acp" | "ucp")
    - [ ] Add `negotiated_capabilities` JSONB field
    - [ ] Migration script for existing sessions
 
@@ -474,7 +512,7 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. UCP oper
 
 1. **Unit Tests** (`tests/merchant/test_ucp_*.py`)
    - [x] `test_ucp_discovery.py` - Discovery endpoint tests ✅ Phase 1
-   - [ ] `test_ucp_checkout.py` - UCP checkout CRUD tests
+   - [x] `test_ucp_checkout.py` - UCP checkout CRUD tests
    - [ ] `test_ucp_a2a.py` - A2A transport tests (JSON-RPC 2.0)
    - [ ] `test_ucp_negotiation.py` - Capability negotiation tests
    - [ ] Happy path, edge cases, failure cases for each
@@ -496,21 +534,21 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. UCP oper
 ### Unit Tests
 
 1. **Capability Negotiation Tests**
-   - [ ] Test intersection with matching capabilities
+   - [x] Test intersection with matching capabilities
    - [ ] Test extension pruning (orphaned extensions)
-   - [ ] Test version compatibility validation
-   - [ ] Test platform profile fetching errors
+   - [x] Test version compatibility validation
+   - [x] Test platform profile fetching errors
 
 2. **UCP Endpoint Tests**
-   - [ ] Test create checkout with UCP headers
-   - [ ] Test update checkout (PUT method)
-   - [ ] Test complete checkout with payment handlers
-   - [ ] Test cancel checkout
+   - [x] Test create checkout with UCP headers
+   - [x] Test update checkout (PUT method)
+   - [x] Test complete checkout with payment handlers
+   - [x] Test cancel checkout
 
 3. **Protocol Transformation Tests**
-   - [ ] Test UCP → internal format normalization
-   - [ ] Test internal → UCP format transformation
-   - [ ] Test status value mapping
+   - [x] Test UCP → internal format normalization
+   - [x] Test internal → UCP format transformation
+   - [x] Test status value mapping
    - [ ] Test error message severity mapping
 
 ### Integration Tests

--- a/docs/project-brief.md
+++ b/docs/project-brief.md
@@ -2,22 +2,25 @@
 
 ## 1. Executive Summary
 
-* **Product Concept**: A headless commerce middleware and reference architecture that enables merchants to integrate with the **Agentic Commerce Protocol (ACP)** while layering in "Merchant Intelligence" via the **NVIDIA NeMo Agent Toolkit (NAT)**.
+* **Product Concept**: A headless commerce middleware and reference architecture that enables merchants to integrate with the **Agentic Commerce Protocol (ACP)** and **Universal Commerce Protocol (UCP)** while layering in "Merchant Intelligence" via the **NVIDIA NeMo Agent Toolkit (NAT)**.
 * **Primary Problem**: Standard e-commerce backends are passive and cannot effectively "negotiate" or "reason" during a conversational checkout with AI agents.
 * **Proposed Solution**: A Python **3.12+**-based (FastAPI) middleware that acts as a relational, intelligent bridge between agentic clients and existing merchant data.
 * **Key Value Proposition**: Demonstrates a "Glass Box" approach to agentic commerce, where business logic (discounts, recommendations, loyalty) is optimized by autonomous agents in real-time.
-* **Demo Client (Client Agent Simulator)**: A static simulator with 4 pre-populated products that can:
-  * Accept search prompts (e.g., "find some t-shirts") and display product cards
-  * Allow users to click a product to initiate ACP checkout
+* **Protocol Support**: Dual-protocol architecture supporting both ACP and UCP:
+  * **ACP**: OpenAI's Agentic Commerce Protocol for delegated payments
+  * **UCP**: Industry-standard Universal Commerce Protocol with capability negotiation
+* **Demo Client (Client Agent Simulator)**: A static simulator with pre-populated products that can:
+  * Accept search prompts (e.g., "find some t-shirts") and display product cards via RAG-powered Search Agent
+  * Allow users to click a product to initiate ACP/UCP checkout
   * Uses a **PSP** component for delegated payments (vault token `vt_...` → payment intent `pi_...`).
 
 ## 2. UI Vision
 
-The demo will feature a **multi-panel Protocol Inspector** that provides real-time visibility into the agentic commerce flow:
+The demo features a **multi-panel Protocol Inspector** that provides real-time visibility into the agentic commerce flow:
 
-* **Left Panel (Agent/Client Simulation)**: Shows the simulated customer experience with search input, 4 product cards, and checkout flow
-* **Middle Panel (Business/Retailer View)**: Displays what's happening on the merchant's side including JSON payloads, session state, and ACP protocol interactions
-* **Right Panel (Chain of Thought - Optional)**: Shows real-time agent reasoning traces from NeMo Agent Toolkit when agents are triggered
+* **Left Panel (Client Agent Simulation)**: Shows the simulated customer experience with search input, product cards, and checkout flow
+* **Middle Panel (Merchant Server View)**: Displays merchant-side activity including JSON payloads, session state, and **ACP/UCP protocol tabs** to toggle between protocols
+* **Right Panel (Agent Activity)**: Shows real-time agent reasoning traces from NeMo Agent Toolkit when agents are triggered (promotion decisions, recommendations, etc.)
 
 This "glass box" approach makes the invisible mechanics of agentic commerce visible and educational.
 
@@ -27,12 +30,13 @@ The Client Agent panel includes a **tab switcher** to toggle between two checkou
 
 | Mode | Description |
 |------|-------------|
-| **Native ACP** | Client agent controls UI, single product checkout, standard flow |
+| **Native** | Client agent controls UI, single product checkout, ACP/UCP protocol toggle |
 | **Apps SDK** | Merchant controls UI via iframe, multi-item cart, ARAG recommendations |
 
 The Apps SDK mode demonstrates how merchants can maintain complete UI control while leveraging the same ACP payment infrastructure. Key features:
 
-* **Merchant-Owned Iframe**: HTML served from `/merchant-app`, fully controlled by merchant
+* **Merchant-Owned Iframe**: HTML widget served from Apps SDK MCP server, fully controlled by merchant
+* **RAG Product Search**: Natural language product search powered by Search Agent
 * **ARAG Recommendations**: 3 personalized cross-sell items in carousel format
 * **Shopping Cart**: Add multiple items before checkout (vs single product in native)
 * **Loyalty Points**: Pre-authenticated user with points balance display
@@ -46,13 +50,14 @@ The Apps SDK mode demonstrates how merchants can maintain complete UI control wh
 
 ## 4. Proposed Solution & Intelligent Agents
 
-The solution implements the 5 standard ACP endpoints and orchestrates three specialized NAT agents:
+The solution implements ACP checkout endpoints, UCP checkout endpoints with capability negotiation, and orchestrates four specialized NAT agents:
 
-| Agent | Core Task | Intelligence Architecture |
-| --- | --- | --- |
-| **Promotion Agent** | Dynamic Discounting | 3-layer hybrid: queries `products` vs `competitor_prices` to beat market rates while protecting `min_margin`. |
-| **Recommendation Agent** | Personalized Cross-sell | **ARAG multi-agent architecture**: 4 specialized agents (User Understanding, NLI, Context Summary, Item Ranker) with RAG retrieval for up to 42% improvement over vanilla RAG. Based on [SIGIR 2025 research](https://arxiv.org/pdf/2506.21931). |
-| **Post-Purchase Agent** | Lifecycle Loyalty | Sends multilingual (EN/ES/FR) shipping pulses to a **global webhook** using the **Brand Persona**. |
+| Agent | Port | Core Task | Intelligence Architecture |
+| --- | --- | --- | --- |
+| **Promotion Agent** | 8002 | Dynamic Discounting | 3-layer hybrid: queries `products` vs `competitor_prices` to beat market rates while protecting `min_margin`. |
+| **Post-Purchase Agent** | 8003 | Lifecycle Loyalty | Sends multilingual (EN/ES/FR) shipping pulses to a **global webhook** using the **Brand Persona**. |
+| **Recommendation Agent** | 8004 | Personalized Cross-sell | **ARAG multi-agent architecture**: 4 specialized agents (User Understanding, NLI, Context Summary, Item Ranker) with RAG retrieval for up to 42% improvement over vanilla RAG. Based on [SIGIR 2025 research](https://arxiv.org/pdf/2506.21931). |
+| **Search Agent** | 8005 | Product Discovery | **RAG architecture**: Semantic product search with Milvus vector store for natural language queries (e.g., "find me a warm jacket"). |
 
 ### ARAG Recommendation Architecture
 
@@ -77,29 +82,32 @@ The Post-Purchase Agent uses a configurable Brand Persona:
 
 ## 5. Target Users
 
-* **Primary (Developers/Architects)**: Technical teams seeking a reference implementation of ACP with advanced AI-native logic.
+* **Primary (Developers/Architects)**: Technical teams seeking a reference implementation of ACP/UCP with advanced AI-native logic.
 * **Secondary (E-commerce Stakeholders)**: Business owners evaluating how AI agents can protect margins and build loyalty autonomously.
 
 ## 6. MVP Scope
 
 * **Core Features (Must Have)**:
-* Full ACP-compliant REST API (`/checkout_sessions` Create/Update/Complete/Cancel/Get).
-* Three NAT workflows wrapped in FastAPI.
+* **Dual Protocol Support**:
+  * Full ACP-compliant REST API (`/checkout_sessions` Create/Update/Complete/Cancel/Get)
+  * UCP REST endpoints (`/checkout-sessions` with capability negotiation, `/.well-known/ucp` discovery)
+* Four NAT agent workflows wrapped in FastAPI (Promotion, Post-Purchase, Recommendation, Search).
 * **Multi-Panel Protocol Inspector UI**: A "Glass Box" dashboard in Next.js with three views:
-  * **Agent/Client Panel**: Shows the simulated customer experience with search and product cards
-  * **Business/Retailer Panel**: Shows merchant-side JSON payloads and ACP protocol state
-  * **Chain of Thought Panel (Optional)**: Shows real-time NeMo agent reasoning traces
-* **SQLite Database**: Relational storage for 4 pre-populated products, competitors, and order persistence.
+  * **Client Agent Panel**: Shows the simulated customer experience with search and product cards
+  * **Merchant Server Panel**: Shows merchant-side JSON payloads with **ACP/UCP protocol tabs**
+  * **Agent Activity Panel**: Shows real-time NeMo agent reasoning traces
+* **SQLite Database**: Relational storage for products, competitors, and order persistence.
 * **Client Agent Simulator**: 
-  * Search flow: User enters prompt → displays 4 product cards
-  * Checkout flow: User clicks product → initiates `POST /checkout_sessions`
+  * Search flow: User enters prompt → Search Agent returns relevant products
+  * Checkout flow: User clicks product → initiates checkout via selected protocol
 * **PSP (Delegated payments)**:
   * `POST /agentic_commerce/delegate_payment` → `vt_...` (idempotent via `Idempotency-Key`)
   * `POST /agentic_commerce/create_and_process_payment_intent` → `pi_...`, token becomes `consumed`
 * **Global Webhook**: Single endpoint for post-purchase event delivery
 * **Apps SDK Integration (Merchant Iframe)**:
-  * Tab switcher to toggle between "Native ACP" and "Apps SDK" modes
+  * Tab switcher to toggle between "Native" and "Apps SDK" modes
   * Merchant-owned iframe embedded in Client Agent panel
+  * RAG product search via Search Agent for natural language queries
   * 3 personalized recommendations from ARAG agent in carousel format
   * Shopping cart supporting multiple items (vs single product in native)
   * Pre-authenticated user with loyalty points display
@@ -108,7 +116,7 @@ The Post-Purchase Agent uses a configurable Brand Persona:
     * Standalone: Local development with simulated `window.openai` bridge
     * ChatGPT Integration: Real ChatGPT testing via ngrok tunnel
     * Production: Deployed MCP server accessible from ChatGPT Apps Directory
-  * MCP server with `get-recommendations`, `add-to-cart`, `checkout` tools
+  * MCP server with `search-products`, `get-recommendations`, `add-to-cart`, `checkout` tools
   * Widget bundles served via `openai/outputTemplate` metadata
 
 * **Out of Scope**:
@@ -118,10 +126,22 @@ The Post-Purchase Agent uses a configurable Brand Persona:
 
 ## 7. Technical Considerations
 
-* **Stack**: Python **3.12+**, FastAPI, Uvicorn, SQLite, Next.js, Tailwind CSS, shadcn/ui.
+* **Stack**: Python **3.12+**, FastAPI, Uvicorn, SQLite, Next.js 15+, React 19, Tailwind CSS, Kaizen UI.
+* **Service Ports**:
+  * Merchant API: 8000 (ACP/UCP checkout, products, orders)
+  * PSP Service: 8001 (payment delegation, vault tokens)
+  * Promotion Agent: 8002
+  * Post-Purchase Agent: 8003
+  * Recommendation Agent: 8004 (ARAG)
+  * Search Agent: 8005 (RAG)
+  * Apps SDK MCP Server: 2091
+  * UI: 3000
 * **Latency Management**: Target <10s for typical operations to ensure responsive user experience.
-* **Relational Logic**: Agents will leverage tool-calling to execute SQL queries for business reasoning.
+* **Relational Logic**: Agents leverage tool-calling to execute SQL queries for business reasoning.
+* **Vector Store**: Milvus for semantic product search embeddings (Search Agent).
 * **NIM Deployment**: Configurable via environment variable (NVIDIA hosted API or local Docker container).
-* **Security**: ACP endpoints require **API key authentication** (e.g., `Authorization: Bearer <API_KEY>` or `X-API-Key: <API_KEY>`). Use strict request validation and parameterized SQL tools.
+* **Security**: 
+  * ACP endpoints require **API key authentication** (`X-API-Key` header)
+  * UCP endpoints use **`UCP-Agent` header** for capability negotiation
 * **PSP data model (demo)**: `vault_tokens` (vt_), `payment_intents` (pi_), `idempotency_store` to support request replay protection.
 * **Webhook**: Single global webhook URL configured at application level for post-purchase events.

--- a/src/merchant/api/routes/ucp/checkout.py
+++ b/src/merchant/api/routes/ucp/checkout.py
@@ -1,0 +1,285 @@
+"""UCP checkout REST endpoints (Phase 2)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any
+
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlmodel import Session
+
+from src.merchant.api.dependencies import verify_api_key
+from src.merchant.api.ucp_schemas import (
+    UCPCheckoutResponse,
+    UCPCompleteCheckoutRequest,
+    UCPCreateCheckoutRequest,
+    UCPUpdateCheckoutRequest,
+)
+from src.merchant.config import get_settings
+from src.merchant.db.database import get_session
+from src.merchant.services.checkout import (
+    InvalidStateTransitionError,
+    ProductNotFoundError,
+    SessionNotFoundError,
+    cancel_checkout_session,
+    complete_checkout_session,
+    create_checkout_session,
+    get_checkout_session,
+    update_checkout_session,
+)
+from src.merchant.services.ucp import (
+    build_business_profile,
+    compute_capability_intersection,
+    convert_ucp_buyer,
+    fetch_platform_profile,
+    normalize_ucp_create_request,
+    normalize_ucp_update_request,
+    parse_ucp_agent_header,
+    transform_to_ucp_response,
+)
+
+router = APIRouter(
+    prefix="/checkout-sessions",
+    tags=["ucp"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+def _validate_platform_version(platform_profile: dict[str, Any]) -> None:
+    ucp_block = platform_profile.get("ucp", {})
+    platform_version = ucp_block.get("version")
+    if not isinstance(platform_version, str):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Platform profile malformed",
+        )
+
+    try:
+        parsed_platform_version = datetime.strptime(platform_version, "%Y-%m-%d").date()
+        parsed_business_version = datetime.strptime(
+            get_settings().ucp_version, "%Y-%m-%d"
+        ).date()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Platform profile malformed",
+        ) from exc
+
+    if parsed_platform_version > parsed_business_version:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Platform profile version unsupported",
+        )
+
+
+async def _negotiate_capabilities(
+    request: Request, ucp_agent: str | None
+) -> dict[str, Any]:
+    if not ucp_agent:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing UCP-Agent header",
+        )
+
+    try:
+        profile_url = parse_ucp_agent_header(ucp_agent)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    try:
+        platform_profile = await fetch_platform_profile(profile_url)
+    except httpx.RequestError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_424_FAILED_DEPENDENCY,
+            detail="Platform profile unreachable",
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Platform profile malformed",
+        ) from exc
+
+    _validate_platform_version(platform_profile)
+
+    business_profile = build_business_profile(
+        request_base_url=str(request.base_url).rstrip("/")
+    )
+    negotiated = compute_capability_intersection(business_profile, platform_profile)
+
+    if not negotiated:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Platform does not support checkout capability",
+        )
+
+    return negotiated
+
+
+def _handle_service_error(error: Exception) -> HTTPException:
+    if isinstance(error, SessionNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Checkout session not found",
+        )
+
+    if isinstance(error, ProductNotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=error.message,
+        )
+
+    if isinstance(error, InvalidStateTransitionError):
+        return HTTPException(
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
+            detail=error.message,
+        )
+
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=str(error),
+    )
+
+
+@router.post(
+    "",
+    response_model=UCPCheckoutResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create UCP Checkout Session",
+)
+async def create_ucp_checkout(
+    request_body: UCPCreateCheckoutRequest,
+    request: Request,
+    ucp_agent: Annotated[str | None, Header(alias="UCP-Agent")] = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+    db: Session = Depends(get_session),
+) -> UCPCheckoutResponse:
+    """Create a UCP checkout session."""
+    _ = idempotency_key
+    negotiated = await _negotiate_capabilities(request, ucp_agent)
+
+    internal_request = normalize_ucp_create_request(request_body)
+    try:
+        acp_response = await create_checkout_session(
+            db, internal_request, protocol="ucp"
+        )
+    except (
+        ProductNotFoundError,
+        SessionNotFoundError,
+        InvalidStateTransitionError,
+    ) as e:
+        raise _handle_service_error(e) from e
+
+    return transform_to_ucp_response(acp_response, negotiated)
+
+
+@router.get(
+    "/{session_id}",
+    response_model=UCPCheckoutResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get UCP Checkout Session",
+)
+async def get_ucp_checkout(
+    session_id: str,
+    request: Request,
+    ucp_agent: Annotated[str | None, Header(alias="UCP-Agent")] = None,
+    db: Session = Depends(get_session),
+) -> UCPCheckoutResponse:
+    """Get a UCP checkout session by ID."""
+    negotiated = await _negotiate_capabilities(request, ucp_agent)
+
+    try:
+        acp_response = get_checkout_session(db, session_id)
+    except SessionNotFoundError as e:
+        raise _handle_service_error(e) from e
+
+    return transform_to_ucp_response(acp_response, negotiated)
+
+
+@router.put(
+    "/{session_id}",
+    response_model=UCPCheckoutResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update UCP Checkout Session",
+)
+async def update_ucp_checkout(
+    session_id: str,
+    request_body: UCPUpdateCheckoutRequest,
+    request: Request,
+    ucp_agent: Annotated[str | None, Header(alias="UCP-Agent")] = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+    db: Session = Depends(get_session),
+) -> UCPCheckoutResponse:
+    """Update a UCP checkout session."""
+    _ = idempotency_key
+    negotiated = await _negotiate_capabilities(request, ucp_agent)
+
+    internal_request = normalize_ucp_update_request(request_body)
+    try:
+        acp_response = await update_checkout_session(db, session_id, internal_request)
+    except (
+        ProductNotFoundError,
+        SessionNotFoundError,
+        InvalidStateTransitionError,
+    ) as e:
+        raise _handle_service_error(e) from e
+
+    return transform_to_ucp_response(acp_response, negotiated)
+
+
+@router.post(
+    "/{session_id}/complete",
+    response_model=UCPCheckoutResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Complete UCP Checkout Session",
+)
+async def complete_ucp_checkout(
+    session_id: str,
+    request_body: UCPCompleteCheckoutRequest,
+    request: Request,
+    ucp_agent: Annotated[str | None, Header(alias="UCP-Agent")] = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+    db: Session = Depends(get_session),
+) -> UCPCheckoutResponse:
+    """Complete a UCP checkout session."""
+    _ = idempotency_key
+    negotiated = await _negotiate_capabilities(request, ucp_agent)
+
+    buyer = convert_ucp_buyer(request_body.buyer)
+
+    try:
+        acp_response = complete_checkout_session(
+            db, session_id, request_body.payment_data, buyer
+        )
+    except (SessionNotFoundError, InvalidStateTransitionError) as e:
+        raise _handle_service_error(e) from e
+
+    return transform_to_ucp_response(acp_response, negotiated)
+
+
+@router.post(
+    "/{session_id}/cancel",
+    response_model=UCPCheckoutResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Cancel UCP Checkout Session",
+)
+async def cancel_ucp_checkout(
+    session_id: str,
+    request: Request,
+    ucp_agent: Annotated[str | None, Header(alias="UCP-Agent")] = None,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+    db: Session = Depends(get_session),
+) -> UCPCheckoutResponse:
+    """Cancel a UCP checkout session."""
+    _ = idempotency_key
+    negotiated = await _negotiate_capabilities(request, ucp_agent)
+
+    try:
+        acp_response = cancel_checkout_session(db, session_id)
+    except (SessionNotFoundError, InvalidStateTransitionError) as e:
+        raise _handle_service_error(e) from e
+
+    return transform_to_ucp_response(acp_response, negotiated)

--- a/src/merchant/api/ucp_schemas.py
+++ b/src/merchant/api/ucp_schemas.py
@@ -1,8 +1,13 @@
-"""Pydantic schemas for UCP discovery profile."""
+"""Pydantic schemas for UCP discovery profile and checkout responses."""
 
-from typing import Any
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from src.merchant.api.schemas import PaymentDataInput
 
 
 class UCPService(BaseModel):
@@ -70,3 +75,149 @@ class UCPBusinessProfile(BaseModel):
 
     ucp: UCPMetadata
     signing_keys: list[UCPSigningKey] | None = None
+
+
+# =============================================================================
+# UCP Checkout Schemas (Phase 2 - minimal fields)
+# =============================================================================
+
+
+class UCPCheckoutStatus(StrEnum):
+    """UCP checkout status values (Phase 2 subset)."""
+
+    INCOMPLETE = "incomplete"
+    READY_FOR_COMPLETE = "ready_for_complete"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+
+
+class UCPTotalType(StrEnum):
+    """UCP total types (Phase 2 subset)."""
+
+    SUBTOTAL = "subtotal"
+    DISCOUNT = "discount"
+    ITEMS_DISCOUNT = "items_discount"
+    TAX = "tax"
+    TOTAL = "total"
+
+
+class UCPMessageType(StrEnum):
+    """UCP message types."""
+
+    INFO = "info"
+    ERROR = "error"
+    WARNING = "warning"
+
+
+class UCPItemInput(BaseModel):
+    """UCP item input for checkout requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., description="Product ID")
+
+
+class UCPLineItemInput(BaseModel):
+    """UCP line item input."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    item: UCPItemInput = Field(..., description="Item reference")
+    quantity: Annotated[int, Field(gt=0, description="Quantity")]
+
+
+class UCPBuyerInput(BaseModel):
+    """UCP buyer information input."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    first_name: str = Field(..., description="First name")
+    last_name: str | None = Field(default=None, description="Last name")
+    email: str = Field(..., description="Email address")
+    phone: str | None = Field(default=None, description="Phone number in E.164 format")
+
+
+class UCPCreateCheckoutRequest(BaseModel):
+    """Request body for creating a UCP checkout session."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    line_items: Annotated[
+        list[UCPLineItemInput], Field(min_length=1, description="Line items")
+    ]
+    buyer: UCPBuyerInput | None = Field(default=None, description="Buyer info")
+
+
+class UCPUpdateCheckoutRequest(BaseModel):
+    """Request body for updating a UCP checkout session (full replacement)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    line_items: Annotated[
+        list[UCPLineItemInput], Field(min_length=1, description="Line items")
+    ]
+    buyer: UCPBuyerInput | None = Field(default=None, description="Buyer info")
+
+
+class UCPCompleteCheckoutRequest(BaseModel):
+    """Request body for completing a UCP checkout session (Phase 2)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    buyer: UCPBuyerInput | None = Field(default=None, description="Buyer info")
+    payment_data: PaymentDataInput = Field(..., description="Payment data")
+
+
+class UCPItem(BaseModel):
+    """UCP item details in response."""
+
+    id: str = Field(..., description="Product ID")
+    title: str = Field(..., description="Product title")
+    price: Annotated[int, Field(ge=0, description="Unit price in minor units")]
+
+
+class UCPTotal(BaseModel):
+    """UCP total line item."""
+
+    type: UCPTotalType = Field(..., description="Total category")
+    label: str = Field(..., description="Display label")
+    amount: Annotated[int, Field(ge=0, description="Amount in minor units")]
+
+
+class UCPLineItem(BaseModel):
+    """UCP line item in response."""
+
+    id: str = Field(..., description="Line item ID")
+    item: UCPItem = Field(..., description="Item details")
+    quantity: Annotated[int, Field(gt=0, description="Quantity")]
+    totals: list[UCPTotal] = Field(..., description="Line item totals")
+
+
+class UCPMessage(BaseModel):
+    """UCP message for checkout responses."""
+
+    type: UCPMessageType = Field(..., description="Message type")
+    code: str | None = Field(default=None, description="Optional error code")
+    path: str | None = Field(default=None, description="JSONPath for related field")
+    content: str = Field(..., description="Message content")
+
+
+class UCPResponseMetadata(BaseModel):
+    """UCP response metadata with negotiated capabilities."""
+
+    version: str
+    capabilities: dict[str, list[UCPCapabilityVersion]]
+
+
+class UCPCheckoutResponse(BaseModel):
+    """UCP checkout response (Phase 2 minimal fields)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    ucp: UCPResponseMetadata
+    id: str
+    status: UCPCheckoutStatus
+    currency: str
+    line_items: list[UCPLineItem]
+    totals: list[UCPTotal]
+    messages: Annotated[list[UCPMessage], Field(default_factory=list)]

--- a/src/merchant/db/models.py
+++ b/src/merchant/db/models.py
@@ -127,6 +127,7 @@ class CheckoutSession(SQLModel, table=True):
 
     Attributes:
         id: Unique session identifier (e.g., "checkout_abc123")
+        protocol: Protocol origin ("acp" or "ucp")
         status: Current checkout status
         currency: ISO 4217 currency code (default: USD)
         locale: BCP 47 language tag (default: en-US)
@@ -148,6 +149,7 @@ class CheckoutSession(SQLModel, table=True):
     __tablename__: ClassVar[str] = "checkout_session"  # type: ignore[assignment]
 
     id: str = Field(primary_key=True)
+    protocol: str = Field(default="acp")
     status: CheckoutStatus = Field(default=CheckoutStatus.NOT_READY_FOR_PAYMENT)
     currency: str = Field(default="USD")
     locale: str = Field(default="en-US")

--- a/src/merchant/main.py
+++ b/src/merchant/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.merchant.api.routes.checkout import router as checkout_router
 from src.merchant.api.routes.health import router as health_router
 from src.merchant.api.routes.products import router as products_router
+from src.merchant.api.routes.ucp.checkout import router as ucp_checkout_router
 from src.merchant.api.routes.ucp.discovery import router as ucp_discovery_router
 from src.merchant.config import get_settings
 from src.merchant.db import init_and_seed_db
@@ -101,3 +102,4 @@ app.include_router(health_router)
 app.include_router(checkout_router)
 app.include_router(products_router)
 app.include_router(ucp_discovery_router)
+app.include_router(ucp_checkout_router)

--- a/src/merchant/services/checkout.py
+++ b/src/merchant/services/checkout.py
@@ -91,7 +91,7 @@ class InvalidStateTransitionError(CheckoutServiceError):
 
 
 async def create_checkout_session(
-    db: Session, request: CreateCheckoutRequest
+    db: Session, request: CreateCheckoutRequest, protocol: str = "acp"
 ) -> CheckoutSessionResponse:
     """Create a new checkout session.
 
@@ -168,6 +168,7 @@ async def create_checkout_session(
     # Create database record
     checkout_session = CheckoutSession(
         id=session_id,
+        protocol=protocol,
         status=CheckoutStatus.NOT_READY_FOR_PAYMENT,
         currency=DEFAULT_CURRENCY.upper(),
         line_items_json=json.dumps(line_items),

--- a/src/merchant/services/helpers.py
+++ b/src/merchant/services/helpers.py
@@ -476,8 +476,7 @@ def check_ready_for_payment(session: CheckoutSession) -> bool:
     A session is ready for payment when:
     - At least one line item exists
     - Buyer info is provided
-    - Fulfillment address is provided
-    - Fulfillment option is selected
+    - Fulfillment details are provided (ACP only)
 
     Args:
         session: CheckoutSession database model.
@@ -491,6 +490,9 @@ def check_ready_for_payment(session: CheckoutSession) -> bool:
 
     if session.buyer_json is None:
         return False
+
+    if session.protocol == "ucp":
+        return True
 
     if session.fulfillment_address_json is None:
         return False

--- a/src/merchant/services/ucp.py
+++ b/src/merchant/services/ucp.py
@@ -1,14 +1,51 @@
-"""UCP discovery profile helpers."""
+"""UCP discovery profile helpers and checkout utilities."""
 
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import httpx
+
+from src.merchant.api.schemas import (
+    BuyerInput,
+    CheckoutSessionResponse,
+    CreateCheckoutRequest,
+    ItemInput,
+    LineItem,
+    MessageError,
+    MessageInfo,
+    Total,
+    TotalTypeEnum,
+    UpdateCheckoutRequest,
+)
 from src.merchant.api.ucp_schemas import (
     UCPBusinessProfile,
+    UCPBuyerInput,
     UCPCapabilityVersion,
+    UCPCheckoutResponse,
+    UCPCheckoutStatus,
+    UCPCreateCheckoutRequest,
+    UCPItem,
+    UCPLineItem,
+    UCPMessage,
+    UCPMessageType,
     UCPMetadata,
     UCPPaymentHandler,
+    UCPResponseMetadata,
     UCPService,
     UCPSigningKey,
+    UCPTotal,
+    UCPTotalType,
+    UCPUpdateCheckoutRequest,
 )
 from src.merchant.config import get_settings
+
+CACHE_TTL = timedelta(minutes=10)
+CHECKOUT_CAPABILITY = "dev.ucp.shopping.checkout"
+_profile_cache: dict[str, tuple[dict[str, Any], datetime]] = {}
 
 
 def build_business_profile(request_base_url: str | None = None) -> UCPBusinessProfile:
@@ -84,3 +121,205 @@ def build_business_profile(request_base_url: str | None = None) -> UCPBusinessPr
         ),
         signing_keys=signing_keys,
     )
+
+
+def clear_profile_cache() -> None:
+    """Clear the in-memory platform profile cache (used in tests)."""
+    _profile_cache.clear()
+
+
+def parse_ucp_agent_header(header: str) -> str:
+    """Parse RFC 8941 dictionary to extract profile URL."""
+    match = re.search(r'profile="([^"]+)"', header)
+    if not match:
+        raise ValueError("Invalid UCP-Agent header: missing profile")
+    return match.group(1)
+
+
+async def fetch_platform_profile(profile_url: str) -> dict[str, Any]:
+    """Fetch platform profile with caching (10 min TTL)."""
+    now = datetime.now(UTC)
+    cached = _profile_cache.get(profile_url)
+    if cached and now < cached[1]:
+        return cached[0]
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        response = await client.get(profile_url)
+        response.raise_for_status()
+        try:
+            profile = response.json()
+        except json.JSONDecodeError as exc:
+            raise ValueError("Platform profile invalid JSON") from exc
+
+    if not isinstance(profile, dict):
+        raise ValueError("Platform profile invalid JSON")
+
+    profile = cast(dict[str, Any], profile)
+
+    ucp_block = profile.get("ucp")
+    if not isinstance(ucp_block, dict):
+        raise ValueError("Profile missing 'ucp' key")
+
+    ucp_block = cast(dict[str, Any], ucp_block)
+    capabilities = ucp_block.get("capabilities")
+    if not isinstance(capabilities, dict):
+        raise ValueError("Profile missing 'ucp.capabilities' key")
+
+    _profile_cache[profile_url] = (profile, now + CACHE_TTL)
+    return profile
+
+
+def compute_capability_intersection(
+    business_profile: UCPBusinessProfile, platform_profile: dict[str, Any]
+) -> dict[str, list[UCPCapabilityVersion]]:
+    """Compute capability intersection (checkout-only, Phase 2)."""
+    business_caps = business_profile.ucp.capabilities
+    platform_caps = platform_profile.get("ucp", {}).get("capabilities", {})
+
+    if not isinstance(platform_caps, dict):
+        raise ValueError("Profile missing 'ucp.capabilities' key")
+
+    if CHECKOUT_CAPABILITY in business_caps and CHECKOUT_CAPABILITY in platform_caps:
+        return {CHECKOUT_CAPABILITY: business_caps[CHECKOUT_CAPABILITY]}
+
+    return {}
+
+
+def normalize_ucp_create_request(
+    request: UCPCreateCheckoutRequest,
+) -> CreateCheckoutRequest:
+    """Convert UCP create request to internal ACP format."""
+    return CreateCheckoutRequest(
+        items=[
+            ItemInput(id=line_item.item.id, quantity=line_item.quantity)
+            for line_item in request.line_items
+        ],
+        buyer=convert_ucp_buyer(request.buyer),
+    )
+
+
+def normalize_ucp_update_request(
+    request: UCPUpdateCheckoutRequest,
+) -> UpdateCheckoutRequest:
+    """Convert UCP update request to internal ACP format."""
+    return UpdateCheckoutRequest(
+        items=[
+            ItemInput(id=line_item.item.id, quantity=line_item.quantity)
+            for line_item in request.line_items
+        ],
+        buyer=convert_ucp_buyer(request.buyer),
+    )
+
+
+def transform_to_ucp_response(
+    acp_response: CheckoutSessionResponse,
+    negotiated_capabilities: dict[str, list[UCPCapabilityVersion]],
+) -> UCPCheckoutResponse:
+    """Convert ACP response to UCP format with negotiated capabilities."""
+    return UCPCheckoutResponse(
+        ucp=UCPResponseMetadata(
+            version=get_settings().ucp_version,
+            capabilities=negotiated_capabilities,
+        ),
+        id=acp_response.id,
+        status=_map_ucp_status(acp_response.status.value),
+        currency=acp_response.currency.upper(),
+        line_items=[
+            _convert_line_item(line_item) for line_item in acp_response.line_items
+        ],
+        totals=_convert_totals(acp_response.totals),
+        messages=_convert_messages(acp_response.messages),
+    )
+
+
+def convert_ucp_buyer(buyer: UCPBuyerInput | None) -> BuyerInput | None:
+    if buyer is None:
+        return None
+    return BuyerInput(
+        first_name=buyer.first_name,
+        last_name=buyer.last_name,
+        email=buyer.email,
+        phone_number=buyer.phone,
+    )
+
+
+def _map_ucp_status(status: str) -> UCPCheckoutStatus:
+    mapping = {
+        "not_ready_for_payment": UCPCheckoutStatus.INCOMPLETE,
+        "ready_for_payment": UCPCheckoutStatus.READY_FOR_COMPLETE,
+        "completed": UCPCheckoutStatus.COMPLETED,
+        "canceled": UCPCheckoutStatus.CANCELED,
+    }
+    return mapping[status]
+
+
+def _convert_line_item(line_item: LineItem) -> UCPLineItem:
+    quantity = line_item.item.quantity
+    unit_price = line_item.base_amount // quantity if quantity else 0
+    return UCPLineItem(
+        id=line_item.id,
+        item=UCPItem(
+            id=line_item.item.id,
+            title=line_item.name or line_item.item.id,
+            price=unit_price,
+        ),
+        quantity=quantity,
+        totals=[
+            UCPTotal(
+                type=UCPTotalType.SUBTOTAL,
+                label="Subtotal",
+                amount=line_item.subtotal,
+            ),
+            UCPTotal(type=UCPTotalType.TAX, label="Tax", amount=line_item.tax),
+            UCPTotal(type=UCPTotalType.TOTAL, label="Total", amount=line_item.total),
+        ],
+    )
+
+
+def _convert_totals(totals: list[Total]) -> list[UCPTotal]:
+    type_mapping = {
+        TotalTypeEnum.SUBTOTAL: UCPTotalType.SUBTOTAL,
+        TotalTypeEnum.DISCOUNT: UCPTotalType.DISCOUNT,
+        TotalTypeEnum.ITEMS_DISCOUNT: UCPTotalType.ITEMS_DISCOUNT,
+        TotalTypeEnum.TAX: UCPTotalType.TAX,
+        TotalTypeEnum.TOTAL: UCPTotalType.TOTAL,
+    }
+
+    converted: list[UCPTotal] = []
+    for total in totals:
+        mapped_type = type_mapping.get(total.type)
+        if mapped_type is None:
+            continue
+        converted.append(
+            UCPTotal(
+                type=mapped_type,
+                label=total.display_text,
+                amount=total.amount,
+            )
+        )
+    return converted
+
+
+def _convert_messages(messages: list[MessageInfo | MessageError]) -> list[UCPMessage]:
+    converted: list[UCPMessage] = []
+    for message in messages:
+        if isinstance(message, MessageError):
+            converted.append(
+                UCPMessage(
+                    type=UCPMessageType.ERROR,
+                    code=message.code.value,
+                    path=message.param,
+                    content=message.content,
+                )
+            )
+            continue
+
+        converted.append(
+            UCPMessage(
+                type=UCPMessageType.INFO,
+                path=message.param,
+                content=message.content,
+            )
+        )
+
+    return converted

--- a/tests/merchant/api/test_ucp_checkout.py
+++ b/tests/merchant/api/test_ucp_checkout.py
@@ -1,0 +1,360 @@
+"""Tests for UCP checkout REST endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from src.merchant.api.routes.ucp import checkout as ucp_checkout_routes
+from src.merchant.config import get_settings
+from src.merchant.db.database import get_engine, reset_engine
+from src.merchant.db.models import CheckoutSession
+from src.merchant.services import ucp as ucp_service
+
+
+@pytest.fixture(autouse=True)
+def clear_ucp_profile_cache() -> None:
+    ucp_service.clear_profile_cache()
+
+
+@pytest.fixture(autouse=True)
+def use_temp_database(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "ucp_checkout_test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    get_settings.cache_clear()
+    reset_engine()
+    yield
+    reset_engine()
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def platform_profile() -> dict[str, Any]:
+    return {
+        "ucp": {
+            "version": get_settings().ucp_version,
+            "capabilities": {
+                "dev.ucp.shopping.checkout": [{"version": get_settings().ucp_version}]
+            },
+        }
+    }
+
+
+@pytest.fixture
+def ucp_headers() -> dict[str, str]:
+    return {"UCP-Agent": 'profile="https://platform.example/profile"'}
+
+
+@pytest.fixture
+def mock_platform_profile(monkeypatch, platform_profile) -> None:
+    async def _mock_fetch_profile(_url: str) -> dict[str, Any]:
+        return platform_profile
+
+    monkeypatch.setattr(
+        ucp_checkout_routes, "fetch_platform_profile", _mock_fetch_profile
+    )
+
+
+class TestUCPCheckoutEndpoints:
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_create_ucp_checkout_returns_201(
+        self,
+        auth_client: TestClient,
+        ucp_headers: dict[str, str],
+    ) -> None:
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["status"] == "incomplete"
+        assert data["ucp"]["version"] == get_settings().ucp_version
+        assert "dev.ucp.shopping.checkout" in data["ucp"]["capabilities"]
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_create_ucp_checkout_stores_protocol(
+        self,
+        auth_client: TestClient,
+        ucp_headers: dict[str, str],
+    ) -> None:
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+        session_id = response.json()["id"]
+
+        with Session(get_engine()) as session:
+            stored = session.exec(
+                select(CheckoutSession).where(CheckoutSession.id == session_id)
+            ).first()
+        assert stored is not None
+        assert stored.protocol == "ucp"
+
+    def test_missing_ucp_agent_returns_400(self, auth_client: TestClient) -> None:
+        response = auth_client.post(
+            "/checkout-sessions",
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+
+        assert response.status_code == 400
+        assert "UCP-Agent" in response.json()["detail"]
+
+    def test_malformed_ucp_agent_returns_400(self, auth_client: TestClient) -> None:
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers={"UCP-Agent": "profile=missing-quotes"},
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+
+        assert response.status_code == 400
+
+    def test_profile_unreachable_returns_424(
+        self, auth_client: TestClient, ucp_headers: dict[str, str], monkeypatch
+    ) -> None:
+        async def _raise_request_error(_url: str) -> dict[str, Any]:
+            raise httpx.RequestError("boom")
+
+        monkeypatch.setattr(
+            ucp_checkout_routes, "fetch_platform_profile", _raise_request_error
+        )
+
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+
+        assert response.status_code == 424
+
+    def test_profile_malformed_returns_422(
+        self, auth_client: TestClient, ucp_headers: dict[str, str], monkeypatch
+    ) -> None:
+        async def _raise_value_error(_url: str) -> dict[str, Any]:
+            raise ValueError("bad profile")
+
+        monkeypatch.setattr(
+            ucp_checkout_routes, "fetch_platform_profile", _raise_value_error
+        )
+
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+
+        assert response.status_code == 422
+
+    def test_no_capability_intersection_returns_400(
+        self, auth_client: TestClient, ucp_headers: dict[str, str], monkeypatch
+    ) -> None:
+        async def _mock_fetch_profile(_url: str) -> dict[str, Any]:
+            return {
+                "ucp": {
+                    "version": get_settings().ucp_version,
+                    "capabilities": {},
+                }
+            }
+
+        monkeypatch.setattr(
+            ucp_checkout_routes, "fetch_platform_profile", _mock_fetch_profile
+        )
+
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+
+        assert response.status_code == 400
+
+    def test_platform_version_unsupported_returns_400(
+        self, auth_client: TestClient, ucp_headers: dict[str, str], monkeypatch
+    ) -> None:
+        async def _mock_fetch_profile(_url: str) -> dict[str, Any]:
+            return {
+                "ucp": {
+                    "version": "2027-01-01",
+                    "capabilities": {
+                        "dev.ucp.shopping.checkout": [{"version": "2027-01-01"}]
+                    },
+                }
+            }
+
+        monkeypatch.setattr(
+            ucp_checkout_routes, "fetch_platform_profile", _mock_fetch_profile
+        )
+
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+
+        assert response.status_code == 400
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_get_ucp_checkout_returns_200(
+        self,
+        auth_client: TestClient,
+        ucp_headers: dict[str, str],
+    ) -> None:
+        create_response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        response = auth_client.get(
+            f"/checkout-sessions/{session_id}", headers=ucp_headers
+        )
+
+        assert response.status_code == 200
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_update_ucp_checkout_transitions_ready(
+        self,
+        auth_client: TestClient,
+        ucp_headers: dict[str, str],
+    ) -> None:
+        create_response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        response = auth_client.put(
+            f"/checkout-sessions/{session_id}",
+            headers=ucp_headers,
+            json={
+                "line_items": [{"item": {"id": "prod_1"}, "quantity": 1}],
+                "buyer": {"first_name": "Test", "email": "test@example.com"},
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "ready_for_complete"
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_complete_ucp_checkout_returns_completed(
+        self,
+        auth_client: TestClient,
+        ucp_headers: dict[str, str],
+    ) -> None:
+        create_response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        auth_client.put(
+            f"/checkout-sessions/{session_id}",
+            headers=ucp_headers,
+            json={
+                "line_items": [{"item": {"id": "prod_1"}, "quantity": 1}],
+                "buyer": {"first_name": "Test", "email": "test@example.com"},
+            },
+        )
+
+        response = auth_client.post(
+            f"/checkout-sessions/{session_id}/complete",
+            headers=ucp_headers,
+            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "completed"
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_cancel_ucp_checkout_returns_canceled(
+        self,
+        auth_client: TestClient,
+        ucp_headers: dict[str, str],
+    ) -> None:
+        create_response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        response = auth_client.post(
+            f"/checkout-sessions/{session_id}/cancel", headers=ucp_headers
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "canceled"
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_ucp_response_omits_deferred_fields(
+        self,
+        auth_client: TestClient,
+        ucp_headers: dict[str, str],
+    ) -> None:
+        response = auth_client.post(
+            "/checkout-sessions",
+            headers=ucp_headers,
+            json={"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert "fulfillment" not in data
+        assert "payment" not in data
+        assert "order" not in data
+        assert "links" not in data
+        assert "continue_url" not in data
+
+
+@pytest.mark.asyncio
+async def test_fetch_platform_profile_caches(monkeypatch) -> None:
+    ucp_service.clear_profile_cache()
+    calls: list[str] = []
+    profile = {
+        "ucp": {
+            "version": get_settings().ucp_version,
+            "capabilities": {
+                "dev.ucp.shopping.checkout": [{"version": get_settings().ucp_version}]
+            },
+        }
+    }
+
+    class MockResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return profile
+
+    class MockAsyncClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def get(self, url: str) -> MockResponse:
+            calls.append(url)
+            return MockResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
+
+    first = await ucp_service.fetch_platform_profile("https://platform.example/profile")
+    second = await ucp_service.fetch_platform_profile(
+        "https://platform.example/profile"
+    )
+
+    assert first == second
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary

- Implements UCP Phase 2 REST checkout endpoints (create, get, update, complete, cancel) at `/checkout-sessions`
- Adds capability negotiation via `UCP-Agent` header with platform profile fetching and caching
- Introduces protocol abstraction with `protocol` field on `CheckoutSession` model for dual ACP/UCP support
- Updates documentation (README, project-brief, feature-17) with UCP integration details

## Changes

### Backend (`src/merchant/`)
- **New**: `api/routes/ucp/checkout.py` - UCP REST endpoints with capability negotiation
- **Updated**: `api/ucp_schemas.py` - Request/response models for UCP checkout
- **Updated**: `services/ucp.py` - Platform profile fetching, capability intersection, request normalization
- **Updated**: `services/checkout.py` - Protocol parameter support in session creation
- **Updated**: `services/helpers.py` - UCP-aware `ready_for_complete` status check
- **Updated**: `db/models.py` - Added `protocol` field to `CheckoutSession`
- **Updated**: `main.py` - Registered UCP checkout router

### Tests
- **New**: `tests/merchant/api/test_ucp_checkout.py` - Comprehensive tests for UCP endpoints

### Documentation
- Updated `docs/features/feature-17-ucp-integration.md` - Marked Phase 2 tasks complete
- Updated `README.md` - Added UCP checkout examples and architecture updates
- Updated `docs/project-brief.md` - Added UCP support, Search Agent, service ports

## Test Plan

- [x] Run `uv run pytest tests/merchant/api/test_ucp_checkout.py -v` - All tests pass
- [x] Run `uv run ruff check src/merchant/` - No linting errors
- [x] Run `uv run pyright src/merchant/` - No type errors
- [x] Manual testing with curl against running Merchant API

## Related

- Feature: `docs/features/feature-17-ucp-integration.md`
- Spec: `docs/specs/ucp-spec.md`


Made with [Cursor](https://cursor.com)