### PR TITLE
[backend][docs] Add UCP Phase 3 A2A transport with JSON-RPC 2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,5 @@
 ---
-description: 
-alwaysApply: false
----
-
----
-description: 
+description: Fast-start guide for coding agents working in Retail-Agentic-Commerce.
 alwaysApply: false
 ---
 
@@ -12,200 +7,101 @@ alwaysApply: false
 
 This document is the fast-start guide for GPT Codex and other coding agents.
 
-## How to Use This Doc
+Deep context and diagnostic examples live in `docs/agent-playbook.md`.
 
-Read this top to bottom once per session. Prefer:
-1. Skills (mandatory workflows and standards)
-2. Quick Map (where to look first)
-3. Commands (how to run and verify)
+## Session Workflow (Mandatory)
+
+Use this sequence for every task:
+1. Read this file once.
+2. Identify task type and read required specs/docs before coding.
+3. Read mandatory skill files in `.cursor/skills/`.
+4. Implement minimal, spec-aligned changes.
+5. Run required verification and report evidence.
 
 ## Documentation-First Development (CRITICAL)
 
-**ALWAYS read and follow documentation BEFORE implementing features, making modifications, or reviewing code.**
+**ALWAYS read and follow documentation BEFORE implementing features, modifying code, or reviewing behavior.**
 
-This project implements the Agentic Commerce Protocol (ACP). The architecture and data flows are defined in specifications that MUST be followed. Do not make assumptions about how components should interact.
+This project implements ACP/UCP flows with strict architecture contracts. Do not infer behavior from existing code alone.
 
 ### Mandatory Documentation Review
 
-Before ANY work, read the relevant documentation:
-
 | Task Type | Required Reading |
 |-----------|------------------|
-| ACP endpoints/flows | `docs/specs/acp-spec.md` |
-| Feature implementation | `docs/features/feature-XX-*.md` |
-| System architecture | `docs/architecture.md` |
-| Agent integration | `src/agents/README.md` |
-| NAT Agents (NeMo Agent Toolkit) | `docs/NEMO_AGENT_TOOLKIT_DOCUMENTATION.md` |
-| UCP Protocol | `docs/specs/ucp-spec.md` |
-| Apps SDK | `docs/specs/apps-sdk-spec.md` |
+| ACP endpoints, checkout, delegation, webhooks | `docs/specs/acp-spec.md` |
+| UCP flows, discovery, A2A transport | `docs/specs/ucp-spec.md` |
+| Apps SDK MCP tools and widget behavior | `docs/specs/apps-sdk-spec.md` |
+| NAT agent config/orchestration | `docs/NEMO_AGENT_TOOLKIT_DOCUMENTATION.md` |
+| Agent integration details | `src/agents/README.md` |
+| System architecture and data flow | `docs/architecture.md` |
+| Feature-specific behavior | `docs/features/index.md` and `docs/features/feature-XX-*.md` |
 
-### Specification Documents Reference (CRITICAL)
-
-The following specification documents are the **authoritative source of truth** for their respective domains. **ALWAYS consult these documents** before implementing, modifying, or debugging related functionality.
+### Specification Source of Truth
 
 #### ACP Specification (`docs/specs/acp-spec.md`)
+Use when working on checkout sessions, payment delegation, and webhook contracts.
 
-**Use when:** Working on ACP protocol, checkout flows, payment delegation, webhooks, or any merchant-client interactions.
-
-The ACP (Agentic Commerce Protocol) spec defines:
-- Protocol data types and schemas (CheckoutSession, PaymentDelegation, LineItem, etc.)
-- API endpoints and their contracts
-- Webhook event formats and signatures
-- Authentication and security requirements
-- Flow sequences (checkout creation → payment delegation → completion)
-
-**Key sections to reference:**
-- Data types: CheckoutSession, PaymentDelegation, LineItem, ShippingOption
-- Endpoints: `/checkout_sessions`, `/agentic_commerce/delegate_payment`, webhooks
-- Webhook architecture: Who sends webhooks (Merchant → Client Agent)
-- Security: API key authentication, HMAC signatures
+Validate:
+- Data types: `CheckoutSession`, `PaymentDelegation`, `LineItem`, `ShippingOption`
+- Endpoints: `/checkout_sessions`, `/agentic_commerce/delegate_payment`, webhook routes
+- Security: API key auth + signature requirements
+- Flow ownership: who calls what, and in what order
 
 #### UCP Specification (`docs/specs/ucp-spec.md`)
+Use when working on discovery, capability negotiation, UCP status lifecycle, or A2A JSON-RPC.
 
-**Use when:** Working on UCP protocol, discovery endpoint, A2A transport, capability negotiation, or UCP-specific checkout flows. Note: UCP integration focuses on the native merchant backend flow only. The Apps SDK mode continues to use ACP exclusively.
-
-The UCP (Universal Commerce Protocol) spec defines:
-- Protocol comparison with ACP
-- UCP-specific status values and error handling
-- Capability negotiation and platform profiles
-- Discovery endpoint (`/.well-known/ucp`)
-- A2A transport (JSON-RPC 2.0 for agent-to-agent communication)
-- Payment handlers architecture (Trust Triangle model)
-
-**Key sections to reference:**
-- Status values: `incomplete`, `requires_escalation`, `ready_for_complete`, `complete_in_progress`, `completed`, `canceled`
+Validate:
+- Statuses: `incomplete`, `requires_escalation`, `ready_for_complete`, `complete_in_progress`, `completed`, `canceled`
 - Headers: `UCP-Agent`, `API-Version`, `Idempotency-Key`
-- A2A methods: `a2a.ucp.checkout.create`, `.get`, `.update`, `.complete`, `.cancel`
-- Discovery: Business profile, capabilities, payment handlers
+- A2A methods: `a2a.ucp.checkout.create|get|update|complete|cancel`
+- Discovery contract: `/.well-known/ucp`
 
-**Protocol Toggle:** The Merchant Activity Panel has ACP/UCP tabs. Switching toggles which backend protocol is used while the client agent flow remains unchanged.
+Note: Merchant Activity ACP/UCP tabs switch backend protocol behavior. Apps SDK mode remains ACP-only.
 
 #### Apps SDK Specification (`docs/specs/apps-sdk-spec.md`)
+Use when working on MCP tool schemas, widget lifecycle, cart/checkout tools, and recommendation/search behavior.
 
-**Use when:** Working on Apps SDK MCP server, widget tools, recommendations, cart operations, or product search.
-
-The Apps SDK spec defines:
-- MCP (Model Context Protocol) tools and their schemas
-- Widget architecture and UI components
-- Tool implementations (get-recommendations, add-to-cart, checkout, search-products)
-- Integration with Merchant API and NAT agents
-- Autonomous vs user-initiated behaviors
-
-**Key sections to reference:**
-- Tool schemas: Input/output contracts for each MCP tool
-- Widget lifecycle: Initialization, state management, event handling
-- Backend integration: How tools communicate with Merchant API
-- Recommendation flow: NAT agent integration for product recommendations
+Validate:
+- Tool input/output schema contracts
+- Widget state and event handling
+- Merchant API integration boundaries
+- NAT integration behavior
 
 #### NeMo Agent Toolkit Documentation (`docs/NEMO_AGENT_TOOLKIT_DOCUMENTATION.md`)
+Use when working on NAT YAML configs, multi-agent orchestration, tool registration, and `nat run`/`nat serve` workflows.
 
-**Use when:** Working on NAT agents, YAML configurations, multi-agent orchestration, or RAG/ARAG patterns.
+### Documentation-First Checklist
 
-The NAT documentation defines:
-- Agent YAML configuration syntax and options
-- Multi-agent patterns (ARAG with specialized agents)
-- Tool definitions and integrations
-- Prompt engineering for agents
-- Serving agents via `nat serve`
+Before coding:
+- [ ] Read the relevant spec sections.
+- [ ] Identify who should call the endpoint/function.
+- [ ] Trace end-to-end data flow.
+- [ ] Compare current code to documented architecture.
+- [ ] Ask user if spec and code conflict.
 
-**Key sections to reference:**
-- YAML configuration: Structure for promotion, post-purchase, recommendation agents
-- Multi-agent orchestration: UUA, NLI, CSA, Ranker agents
-- Tool registration: How to add custom tools to agents
-- Testing: `nat run` for testing agent configurations
+### Architecture Verification Order
 
-#### How to Use Specifications
+When debugging:
+1. What does documentation say should happen?
+2. Does implementation match docs?
+3. If not, is documentation outdated or code wrong?
+4. Only then investigate environment/configuration issues.
 
-1. **Before implementing:** Read the relevant spec section to understand expected behavior
-2. **When debugging:** Check if implementation matches spec (spec is source of truth)
-3. **When confused:** Spec clarifies who calls what, data formats, and flow sequences
-4. **When reviewing code:** Validate that code follows spec contracts
+## Cursor Skills (Mandatory)
 
-### The Documentation-First Checklist
-
-Before writing or modifying code:
-
-- [ ] **Read the specification** - What does the documentation say this component should do?
-- [ ] **Identify the caller** - WHO should call this endpoint/function? (UI? Merchant? PSP?)
-- [ ] **Trace the data flow** - WHERE does data originate and WHERE does it go?
-- [ ] **Check existing implementation** - Does the current code match the specification?
-- [ ] **Ask if uncertain** - If the spec is unclear, ASK the user before proceeding
-
-### Never Make Assumptions
-
-**WRONG approach:**
-- "The UI is calling this endpoint, so it must be correct"
-- "This error is a deployment issue, let me add a workaround"
-- "The code exists, so it must be wired up correctly"
-
-**CORRECT approach:**
-- "Let me check the ACP spec to see WHO should call this endpoint"
-- "Let me verify this implementation matches the documented architecture"
-- "The service exists but is it actually called? Let me trace the flow"
-
-### Ask Clarifying Questions
-
-When documentation is ambiguous or you're uncertain, ASK before implementing:
-
-1. "The spec says X, but the code does Y. Which is correct?"
-2. "I see this service exists but isn't called. Should I integrate it?"
-3. "The architecture shows Merchant → Client flow, but the code has Client → Client. Is this intentional?"
-
-### Real Example: Webhook Architecture Mistake
-
-This project had a bug where the UI was calling its own webhook endpoint instead of the merchant calling it:
-
-**What the ACP spec says (docs/specs/acp-spec.md, line 948):**
-> "Merchants send webhook events to OpenAI for order lifecycle updates"
-
-**What Feature 11 docs show (docs/features/feature-11-webhook-integration.md):**
-```
-Merchant Backend                    Client Agent (UI)
-      │                                   │
-      │  POST /api/webhooks/acp           │
-      │ ─────────────────────────────────▶│
-```
-
-**What the code was doing (WRONG):**
-```
-UI calls /api/agents/post-purchase → UI calls /api/webhooks/acp (itself)
-```
-
-**The mistake:** Instead of reading the documentation to understand the correct architecture, the error was treated as a "deployment configuration issue" and workarounds were attempted (skipping signature verification). The documentation clearly showed the correct flow, but it wasn't consulted.
-
-**The lesson:** When something doesn't work, FIRST check if the implementation matches the documented architecture. Don't assume the code is correct and try to "fix" symptoms.
-
-### Architecture Verification Questions
-
-When debugging issues, ask these questions IN ORDER:
-
-1. **What does the documentation say should happen?**
-2. **Does the current implementation match the documentation?**
-3. **If not, is the documentation wrong or the code wrong?**
-4. **Only after confirming architecture is correct:** Is this a configuration/deployment issue?
-
-### Key Principle
-
-**The documentation is the source of truth.** If the code doesn't match the documentation:
-- The code is likely wrong (fix the code)
-- OR the documentation needs updating (discuss with user first)
-- NEVER assume the code is right and work around it
+Before changing code, read:
+- `.cursor/skills/features/SKILL.md` for Python backend standards
+- `.cursor/skills/ui/SKILL.md` for frontend standards
 
 ## Project Overview
 
 Agentic Commerce Protocol (ACP) reference implementation:
-- **Backend**: Python 3.12+ FastAPI with SQLModel
-- **Frontend**: Next.js 15+ with React 19, Tailwind CSS, Kaizen UI
+- Backend: Python 3.12+, FastAPI, SQLModel
+- Frontend: Next.js 15+, React 19, Tailwind, Kaizen UI
 
 Core docs:
 - `docs/features.md` for feature status and acceptance criteria
 - `docs/architecture.md` for system design
-
-## Cursor Skills (Mandatory)
-
-Before changing code, read the skill files in `.cursor/skills/`:
-- **`.cursor/skills/features/SKILL.md`** - Python backend standards (Ruff, Pyright, pytest)
-- **`.cursor/skills/ui/SKILL.md`** - Frontend standards (React, Next.js, browser validation)
 
 ## Quick Map (Where to Look First)
 
@@ -213,79 +109,81 @@ Backend:
 - API routes: `src/merchant/api/routes/`
 - Business logic: `src/merchant/services/`
 - Models: `src/merchant/db/models.py`
-- UCP discovery: `src/merchant/api/routes/ucp/discovery.py`, `src/merchant/api/ucp_schemas.py`, `src/merchant/services/ucp.py`
+- UCP discovery: `src/merchant/api/routes/ucp/discovery.py`
+- UCP schemas: `src/merchant/api/ucp_schemas.py`
+- UCP services: `src/merchant/services/ucp.py`
 
 Frontend:
-- Main UI layout: `src/ui/app/page.tsx`
+- Main layout: `src/ui/app/page.tsx`
 - Panels: `src/ui/components/agent/`, `src/ui/components/business/`, `src/ui/components/agent-activity/`
-- Checkout state machine: `src/ui/hooks/useCheckoutFlow.ts`
-- Protocol loggers: `src/ui/hooks/useACPLog.tsx`, `src/ui/hooks/useAgentActivityLog.tsx`
+- Checkout flow state machine: `src/ui/hooks/useCheckoutFlow.ts`
+- Protocol logs: `src/ui/hooks/useACPLog.tsx`, `src/ui/hooks/useAgentActivityLog.tsx`
+- API client: `src/ui/lib/api-client.ts`
 
-## Runtime Commands
+Agent configs:
+- `src/agents/configs/promotion.yml`
+- `src/agents/configs/post-purchase.yml`
+- `src/agents/configs/recommendation-ultrafast.yml`
+- `src/agents/configs/search.yml`
 
-### Backend
+## Runtime Commands (Canonical)
+
+### Backend services
 ```bash
-# Merchant API
+# Merchant API (port 8000)
 uvicorn src.merchant.main:app --reload
 
-# PSP
+# PSP (port 8001)
 uvicorn src.payment.main:app --reload --port 8001
 
-# Apps SDK MCP Server
+# Apps SDK MCP server (port 2091)
 uvicorn src.apps_sdk.main:app --reload --port 2091
 ```
 
 ### Frontend
 ```bash
+# UI (port 3000)
 cd src/ui
 pnpm install
 pnpm run dev
 ```
 
-### Apps SDK Widget (for development)
+### Apps SDK widget
 ```bash
 cd src/apps_sdk/web
 pnpm install
-pnpm dev  # Runs on port 3001
+pnpm dev  # port 3001
 ```
 
-## UI-Backend Integration
-
-Key files:
-- `src/ui/lib/api-client.ts` - API client
-- `src/ui/hooks/useCheckoutFlow.ts` - Checkout flow state machine
-- `src/ui/hooks/useACPLog.tsx` - ACP protocol event logging
-- `src/ui/hooks/useAgentActivityLog.tsx` - Agent decision tracking
-- `src/ui/types/index.ts` - ACP and agent types
-
-Checkout flow:
-1. Select product → `createCheckoutSession()` → POST /checkout_sessions
-2. Select shipping → `updateCheckoutSession()` → POST /checkout_sessions/{id}
-3. Delegate payment → `delegatePayment()` → POST /agentic_commerce/delegate_payment
-4. Complete checkout → `completeCheckout()` → POST /checkout_sessions/{id}/complete
-
-Three-panel layout (Feature 10):
-- **Client Agent Panel**: product selection + checkout modal
-- **Merchant Server Panel**: ACP protocol events and session state
-- **Agent Activity Panel**: promotion agent decisions, input signals, reasoning
-
-Environment (`src/ui/.env.local`):
-```env
-# Server-side only (used by proxy routes, NOT exposed to browser)
-MERCHANT_API_URL=http://localhost:8000
-MERCHANT_API_KEY=test-api-key
-PSP_API_URL=http://localhost:8001
-PSP_API_KEY=psp-api-key-12345
-
-# Client-side (safe to expose)
-NEXT_PUBLIC_API_VERSION=2026-01-16
-```
-
-## Quality Gates
-
-Frontend:
+### NAT agents
 ```bash
-cd src/ui
+cd src/agents
+uv pip install -e ".[dev]" --prerelease=allow
+
+# Promotion agent (port 8002)
+nat serve --config_file configs/promotion.yml --port 8002
+
+# Post-purchase agent (port 8003)
+nat serve --config_file configs/post-purchase.yml --port 8003
+
+# Recommendation agent (port 8004)
+nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+
+# Search agent (port 8005)
+nat serve --config_file configs/search.yml --port 8005
+```
+
+### Health checks
+```bash
+curl http://localhost:8000/health
+curl http://localhost:8001/health
+curl http://localhost:2091/health
+```
+
+## Quality Gates (Canonical)
+
+Frontend (`src/ui/`):
+```bash
 pnpm test:run
 pnpm lint
 pnpm format:check
@@ -300,23 +198,82 @@ pyright src/
 pytest tests/ -v
 ```
 
+If changes affect runtime behavior, run relevant integration checks in addition to static checks.
+
+## UI-Backend Integration Notes
+
+Checkout flow:
+1. Product selection -> `createCheckoutSession()` -> `POST /checkout_sessions`
+2. Shipping selection -> `updateCheckoutSession()` -> `POST /checkout_sessions/{id}`
+3. Payment delegation -> `delegatePayment()` -> `POST /agentic_commerce/delegate_payment`
+4. Completion -> `completeCheckout()` -> `POST /checkout_sessions/{id}/complete`
+
+Three-panel layout:
+- Client Agent Panel: product selection + checkout modal
+- Merchant Server Panel: protocol events + session state
+- Agent Activity Panel: promotion reasoning and signals
+
+Frontend env (`src/ui/.env.local`):
+```env
+# Server-side only
+MERCHANT_API_URL=http://localhost:8000
+MERCHANT_API_KEY=test-api-key
+PSP_API_URL=http://localhost:8001
+PSP_API_KEY=psp-api-key-12345
+
+# Client-side safe
+NEXT_PUBLIC_API_VERSION=2026-01-16
+```
+
+## Code Change Verification (CRITICAL)
+
+**Do not claim behavior works without runtime evidence.**
+
+For deeper verification anti-patterns and troubleshooting examples, see `docs/agent-playbook.md`.
+
+### When runtime verification is required
+- API/HTTP behavior changed
+- Async state flow changed
+- Backend-to-frontend data usage changed
+- New integration path was added
+
+### Minimum evidence to report
+- Commands executed
+- HTTP status codes or test outcomes
+- Relevant server log evidence (terminal output or container logs)
+- Error behavior verification when applicable
+
+### Endpoint test template
+```bash
+curl -s -w "\nHTTP_CODE:%{http_code}" -X POST http://localhost:PORT/endpoint \
+  -H "Content-Type: application/json" \
+  -d '{"test":"data"}'
+```
+
+### Verification checklist
+- [ ] Real calls executed (not mocked path)
+- [ ] Response data is actually consumed by downstream code/UI
+- [ ] Loading/pending behavior is correct
+- [ ] Error path is handled correctly
+- [ ] No stale/fallback data masking failures
+
 ## Code Standards
 
 Python:
-- Type hints required for public APIs
-- Ruff enforces formatting and linting
-- Add tests for each change
+- Type hints for public and non-trivial APIs
+- Ruff lint/format compliance
+- Add/update tests with behavior changes
 
 Frontend:
 - Strict TypeScript
 - ESLint + Prettier compliance
-- Use Kaizen UI and Tailwind
-- Validate UI changes with browser MCP tools when available
+- Use Kaizen UI and Tailwind conventions
+- Validate UI changes in browser tools when available
 
 ## PR Instructions
 
 Title format:
-```
+```text
 [component] Brief description of change
 ```
 
@@ -330,304 +287,9 @@ PR description should include:
 - Test plan
 - Related issue/feature (if any)
 
-## Project Structure
+## Maintenance Rules For This File
 
-```
-src/
-├── agents/             # NAT Agents (NVIDIA NeMo Agent Toolkit)
-│   ├── pyproject.toml  # Shared dependencies for all agents
-│   ├── README.md       # Agent documentation
-│   └── configs/        # Agent workflow configurations
-│       ├── promotion.yml        # Promotion strategy arbiter (port 8002)
-│       ├── post-purchase.yml    # Multilingual shipping messages (port 8003)
-│       ├── recommendation.yml   # ARAG multi-agent recommendations (full version)
-│       ├── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
-│       └── search.yml           # RAG product search (port 8005)
-│
-├── apps_sdk/           # Apps SDK MCP Server (port 2091)
-│   ├── main.py         # FastAPI + MCP server entry point
-│   ├── config.py       # Environment configuration
-│   ├── tools/          # MCP tool implementations
-│   │   ├── recommendations.py  # get-recommendations tool
-│   │   ├── cart.py             # add-to-cart, get-cart tools
-│   │   └── checkout.py         # checkout tool (ACP integration)
-│   ├── web/            # React + Vite widget source
-│   │   └── src/        # Widget components and hooks
-│   └── dist/           # Built widget HTML bundles
-│
-├── merchant/           # Merchant API (FastAPI backend, port 8000)
-│   ├── main.py         # Application entry point
-│   ├── config.py       # Environment configuration
-│   ├── api/            # API routes and schemas
-│   ├── db/             # Database models and utilities
-│   └── services/       # Business logic layer
-│       ├── promotion.py       # Promotion agent integration (3-layer)
-│       └── post_purchase.py   # Post-purchase agent integration
-│
-├── payment/            # PSP Service (FastAPI backend, port 8001)
-│   ├── main.py         # PSP application entry point
-│   ├── config.py       # PSP environment configuration (PSP_API_KEY)
-│   ├── api/            # PSP API routes (delegate_payment, payment_intent)
-│   ├── db/             # PSP models (VaultToken, PaymentIntent, IdempotencyRecord)
-│   └── services/       # PSP business logic (vault tokens, idempotency)
-│
-└── ui/                 # Next.js frontend (port 3000)
-    ├── app/            # Next.js App Router pages
-    ├── components/     # React components
-    │   ├── agent/      # Client Agent panel
-    │   ├── agent-activity/ # Agent Activity panel
-    │   ├── business/   # Merchant Server panel
-    │   └── layout/     # Layout components (Navbar, etc.)
-    ├── hooks/          # Custom React hooks (useCheckoutFlow, useACPLog, useAgentActivityLog)
-    ├── types/          # TypeScript type definitions (ACP types, agent types)
-    └── data/           # Mock data for development
-
-tests/
-├── merchant/           # Merchant API test files
-└── payment/            # PSP service test files
-
-docs/                   # Project documentation
-├──NEMO_AGENT_TOOLKIT_DOCUMENTATION.md # Nemo Agent Toolkit Documentation
-.cursor/skills/         # AI assistant skill definitions
-```
-
-## Helper Commands
-
-Merchant API:
-- Start server: `uvicorn src.merchant.main:app --reload`
-- Run tests: `pytest tests/merchant/ -v`
-- Health: `curl http://localhost:8000/health`
-
-PSP Service:
-- Start server: `uvicorn src.payment.main:app --reload --port 8001`
-- Run tests: `pytest tests/payment/ -v`
-- Health: `curl http://localhost:8001/health`
-
-Apps SDK MCP Server:
-- Start server: `uvicorn src.apps_sdk.main:app --reload --port 2091`
-- Health: `curl http://localhost:2091/health`
-- Widget URL: `http://localhost:2091/widget/merchant-app.html`
-
-Apps SDK Widget (from `src/apps_sdk/web/`):
-- Install: `pnpm install`
-- Dev server: `pnpm dev` (port 3001)
-- Build: `pnpm build` (outputs to `../dist/`)
-
-NAT Agents (from `src/agents/`):
-- Install: `uv pip install -e ".[dev]" --prerelease=allow`
-- Start Promotion Agent: `nat serve --config_file configs/promotion.yml --port 8002`
-- Start Post-Purchase Agent: `nat serve --config_file configs/post-purchase.yml --port 8003`
-- Start Recommendation Agent (ARAG): `nat serve --config_file configs/recommendation-ultrafast.yml --port 8004`
-- Start Search Agent (RAG): `nat serve --config_file configs/search.yml --port 8005`
-- Apps SDK `search-products` relies on Search Agent; no local fallback.
-- Test Promotion: `nat run --config_file configs/promotion.yml --input '{...}'`
-- Test Post-Purchase: `nat run --config_file configs/post-purchase.yml --input '{...}'`
-
-Note: Recommendation Agent uses ARAG (Agentic RAG) with 4 specialized agents
-(UUA, NLI, CSA, Ranker) orchestrated in a single YAML via NAT's multi-agent pattern.
-See `src/agents/README.md` for full configuration.
-
-Frontend (from `src/ui/`):
-- Start UI: `pnpm run dev`
-- Run tests: `pnpm test:run`
-- Lint: `pnpm lint`
-- Format check: `pnpm format:check`
-- Type check: `pnpm typecheck`
-
-## Code Change Verification (CRITICAL)
-
-**NEVER claim code works without actually testing it.**
-
-When making code changes, especially to API endpoints or integrations, you MUST verify with real tests.
-
-### Verification Process
-
-1. **Test endpoints with curl** (include HTTP status code):
-   ```bash
-   curl -s -w "\nHTTP_CODE:%{http_code}" -X POST http://localhost:PORT/endpoint \
-     -H "Content-Type: application/json" \
-     -d '{"test": "data"}'
-   ```
-
-2. **Check server logs** for errors:
-   - Read terminal files in the terminals folder
-   - Look for ERROR, Exception, NameError, ImportError
-   - Verify downstream calls are made (e.g., Merchant API calls)
-
-3. **Rebuild if frontend changes**:
-   ```bash
-   # UI frontend
-   cd src/ui && pnpm build
-   
-   # Apps SDK widget
-   cd src/apps_sdk/web && pnpm build
-   ```
-
-4. **Report verification results** to user:
-   - Actual commands run
-   - HTTP status codes received
-   - Server log evidence
-   - Any errors found and fixed
-
-### Example Verification
-
-```bash
-# Test ACP session creation
-curl -s -w "\nHTTP_CODE:%{http_code}" -X POST http://localhost:2091/acp/sessions \
-  -H "Content-Type: application/json" \
-  -d '{"items": [{"id": "prod_1", "quantity": 2}]}'
-# Expected: HTTP_CODE:200 with session ID
-
-# Check server log shows Merchant API call:
-# HTTP Request: POST http://localhost:8000/checkout_sessions "HTTP/1.1 200 OK"
-```
-
-### Red Flags
-
-- **500 Error**: Missing imports, undefined variables
-- **400 Error**: Request format mismatch
-- **Connection Refused**: Service not running
-- **No log output**: Code path not executed
-
-**DO NOT** just read code and say "this should work" - always test and show evidence.
-
-## Critical Verification Diligence (MUST READ)
-
-**Passing static checks (TypeScript, linting, tests, code review) does NOT mean code works correctly.**
-
-Many bugs are invisible to static analysis. You MUST verify actual runtime behavior through real testing, not just reading code and assuming it works.
-
-### Verification Blind Spots
-
-These pass all static checks but contain bugs:
-
-| Blind Spot | What You See | Reality |
-|------------|--------------|---------|
-| **Mock/Hardcoded Data** | Code calls a function that "returns data" | Function returns hardcoded values, not real API calls |
-| **Fire-and-Forget Async** | `fetchData()` is called | Call is made but result is never awaited or used |
-| **Stale State Display** | UI updates when state changes | UI shows OLD data while waiting for NEW data |
-| **Unused Results** | Backend call is made | Response is ignored; UI uses local calculation instead |
-| **Dead Code Paths** | Function exists and looks correct | Function is never actually called in the flow |
-| **Wrong Data Source** | Display shows correct-looking values | Values come from local state, not backend response |
-
-### Questions to Ask Before Claiming "It Works"
-
-1. **Is this REAL or MOCK?**
-   - Trace the data from UI back to source
-   - Is there an actual HTTP call? Check network tab or server logs
-   - Are there hardcoded values, default fallbacks, or mock returns?
-
-2. **Is this USED or IGNORED?**
-   - If backend returns data, is that data actually used in the UI?
-   - Or does the UI calculate/derive values locally and ignore the response?
-
-3. **What happens DURING async operations?**
-   - What does user see while waiting for response?
-   - Is stale data shown without indication?
-   - Can mismatched data appear (e.g., new quantity but old total)?
-
-4. **What happens on FAILURE?**
-   - If the backend call fails, does the UI handle it?
-   - Are optimistic updates rolled back?
-
-5. **Is the CODE PATH actually executed?**
-   - Just because code exists doesn't mean it runs
-   - Add console.log or check server logs to confirm execution
-
-### Verification Methods (In Order of Reliability)
-
-1. **Server Logs** - Most reliable. Shows actual HTTP calls made.
-   ```bash
-   # Check terminal for: "POST /endpoint HTTP/1.1 200 OK"
-   ```
-
-2. **Network Tab** - Shows real requests from browser/client.
-
-3. **Console Logs** - Add logging at key points to trace execution.
-
-4. **Manual User Testing** - Actually use the UI as a user would.
-
-5. **curl/HTTP Tests** - Verify endpoints respond correctly.
-
-6. **Code Reading** - LEAST reliable alone. Must be combined with above.
-
-### Common Deceptive Patterns
-
-**Pattern 1: Looks like API call, is actually local**
-```tsx
-// DECEPTIVE: Looks like it uses backend data
-const total = calculateTotal(items);  // Actually local calculation!
-
-// CORRECT: Actually uses backend response
-const total = backendResponse.totals.find(t => t.type === 'total').amount;
-```
-
-**Pattern 2: Backend called but result ignored**
-```tsx
-// DECEPTIVE: Makes call but ignores result
-await updateBackend(newItems);
-setDisplayTotal(localCalculation(newItems));  // BUG: should use response!
-
-// CORRECT: Uses backend result
-const response = await updateBackend(newItems);
-setDisplayTotal(response.total);
-```
-
-**Pattern 3: Async without proper waiting**
-```tsx
-// DECEPTIVE: Looks correct but has timing bug
-setItems(newItems);           // UI updates immediately
-notifyBackend(newItems);      // Async fires (no await)
-// BUG: UI shows new items but old totals until backend responds!
-
-// CORRECT: Track pending state
-setItems(newItems);
-setIsPending(true);
-await notifyBackend(newItems);
-setIsPending(false);
-```
-
-**Pattern 4: Default/fallback hides missing data**
-```tsx
-// DECEPTIVE: Fallback masks the bug
-const price = response.price ?? calculateLocally(item);  // Fallback used!
-
-// CORRECT: Fail explicitly if data missing
-const price = response.price;
-if (price === undefined) throw new Error("Backend did not return price");
-```
-
-### Verification Checklist
-
-Before saying code is correct, verify these with EVIDENCE:
-
-- [ ] **Server logs show HTTP calls** were actually made
-- [ ] **Response data is used** in the UI (not local calculations)
-- [ ] **No hardcoded/mock data** in the actual code path
-- [ ] **Loading states shown** during async operations
-- [ ] **Error handling works** when backend fails
-- [ ] **User sees correct data** through manual testing
-
-### When Static Analysis is INSUFFICIENT
-
-You MUST do runtime verification when:
-- Code involves HTTP/API calls
-- Multiple components share or sync state
-- Async operations affect UI display
-- Data flows from backend to frontend
-- User actions trigger calculations that should happen server-side
-
-For these cases, **reading code is not enough** - you must observe actual behavior through logs, network inspection, or manual testing.
-
-### Key Principle
-
-**Never claim code works based solely on:**
-- "The function exists and looks correct"
-- "TypeScript/linting passes"
-- "The logic seems right"
-
-**Always verify with evidence:**
-- Server logs showing actual calls
-- Network tab showing request/response
-- Manual testing showing correct behavior
-- Console logs confirming code path execution
+- Keep this file concise and non-duplicative.
+- Keep one canonical commands section (`Runtime Commands` + `Quality Gates`).
+- If runtime commands or architecture change, update this file in the same PR.
+- If behavior and docs conflict, resolve with the user before adding workaround guidance.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -46,14 +46,14 @@ For this project we will also build a **client agent simulator** that behaves li
 ## 1. Goals & Background Context
 
 * **Primary Goal**: Create a reference architecture that enables retailers to maintain "Merchant of Record" control while leveraging autonomous agents to optimize margins and loyalty.
-* **Protocol Fidelity**: 100% compliance with ACP specification (OpenAI/Stripe standard). UCP alignment targets checkout + discovery only (v2026-01-11).
+* **Protocol Fidelity**: 100% compliance with ACP specification. UCP alignment targets checkout + discovery only (v2026-01-11).
 * **Observability**: Real-time "Glass Box" visualization of agent reasoning and JSON traces.
 
 ## 2. Functional Requirements (FR)
 
 ### 2.1 ACP Checkout Endpoints (Per Official Specification)
 
-Implement the 5 required RESTful endpoints per the OpenAI/Stripe ACP specification (API Version: `2026-01-16`):
+Implement the 5 required RESTful endpoints per the ACP specification (API Version: `2026-01-16`):
 
 #### FR-ACP-01: Create Checkout Session
 * **Endpoint**: `POST /checkout_sessions`
@@ -268,19 +268,19 @@ Per [OpenAI Apps SDK guidelines](https://developers.openai.com/apps-sdk/deploy),
 | Mode | Environment | Purpose |
 |------|-------------|---------|
 | **Standalone** | Local (localhost:3000) | Development with simulated `window.openai` bridge |
-| **ChatGPT Integration** | ngrok tunnel | Pre-production testing in real ChatGPT |
-| **Production** | Vercel/Alpic/Cloud | Public deployment via ChatGPT Apps Directory |
+| **Client Agent Integration** | ngrok tunnel | Pre-production testing with a real client agent |
+| **Production** | Vercel/Alpic/Cloud | Public deployment via client agent's app directory |
 
 **Standalone Testing** (simulated):
 - Protocol Inspector embeds merchant iframe locally
-- Simulated `window.openai` bridge mimics ChatGPT behavior
-- Full ACP payment flow works without ChatGPT connection
+- Simulated `window.openai` bridge mimics client agent behavior
+- Full ACP payment flow works without client agent connection
 
-**ChatGPT Integration Testing** (via ngrok):
+**Client Agent Integration Testing** (via ngrok):
 ```bash
 ngrok http 2091
 # Exposes MCP server at https://<subdomain>.ngrok.app/mcp
-# Configure in ChatGPT Settings → Connectors
+# Configure tunnel URL in the client agent's connector settings
 ```
 
 **MCP Server Requirements**:

--- a/docs/agent-playbook.md
+++ b/docs/agent-playbook.md
@@ -1,0 +1,192 @@
+# Agent Playbook (Deep Context)
+
+This document supplements `AGENTS.md` with rationale, diagnostics, and failure patterns.
+
+## Purpose And Scope
+
+Use this document when:
+- Requirements are ambiguous.
+- Runtime behavior is suspicious despite passing static checks.
+- You need architecture-level troubleshooting guidance.
+- You need concrete anti-pattern examples.
+
+Do not duplicate canonical run commands or quality gates here. Keep those in `AGENTS.md`.
+
+## Authority And Precedence
+
+When guidance conflicts, use this precedence:
+1. Protocol specifications in `docs/specs/`
+2. `AGENTS.md` execution contract
+3. This playbook
+
+Code is never the source of truth by itself for protocol ownership or flow contracts.
+
+## Quick Triage Flow
+
+Use this sequence before implementing a fix:
+1. Identify the task domain (ACP, UCP, Apps SDK, NAT, UI integration).
+2. Read the relevant spec sections.
+3. Confirm caller ownership for each endpoint/hop.
+4. Reproduce with runtime evidence (logs/network/status codes).
+5. Confirm downstream usage of response data (not local recompute).
+6. Validate pending and failure states.
+7. Fix root-cause architecture mismatch before environment tuning.
+
+## Source Anchors (Validated)
+
+These are the most common places where architecture assumptions fail:
+
+- ACP checkout and delegation endpoints are defined in `docs/specs/acp-spec.md`.
+- ACP webhook ownership is specified as merchant-originated events in `docs/specs/acp-spec.md`.
+- Feature webhook flow (merchant calls client webhook endpoint) is documented in `docs/features/feature-11-webhook-integration.md`.
+- UCP required headers and A2A checkout methods are defined in `docs/specs/ucp-spec.md`.
+- UCP protocol toggle expectations are described in `docs/features/feature-17-ucp-integration.md`.
+- Apps SDK search tool behavior is defined in `docs/specs/apps-sdk-spec.md`.
+
+If implementation behavior differs from these sources, treat it as an architecture discrepancy first.
+
+## Documentation-First Mindset
+
+Common wrong assumptions:
+- "The UI currently calls this endpoint, so that is the intended contract."
+- "This is deployment/config; a workaround is faster than re-checking specs."
+- "The service exists, so it is wired into the real flow."
+
+Correct posture:
+- "I need to verify endpoint ownership in the relevant spec."
+- "I need to trace the data flow end-to-end."
+- "I need runtime evidence that this path executed as expected."
+
+## Clarifying Questions Pattern
+
+Ask early when docs and implementation diverge:
+1. "Spec says X but implementation does Y. Which source should we treat as canonical for this change?"
+2. "This service exists but has no active call path. Should integration be part of this task?"
+3. "Docs indicate Merchant -> Client webhook flow, but code shows Client -> Client. Is that intentional?"
+
+## Case Study: Webhook Ownership Error
+
+Anti-pattern:
+- UI called its own webhook path rather than receiving merchant-originated webhook events.
+
+Why it causes defects:
+- Violates trust boundary assumptions.
+- Invalidates signature verification semantics.
+- Hides architecture bugs as configuration noise.
+
+Correct diagnostic sequence:
+1. Read ACP webhook ownership requirements in spec.
+2. Confirm sender/receiver in feature docs.
+3. Verify request origin in runtime logs.
+4. Fix flow ownership first, then evaluate deployment/config concerns.
+
+## Runtime Verification Diligence
+
+Static checks are necessary but insufficient for integration correctness.
+
+### Blind Spots Static Analysis Misses
+
+- Mock/hardcoded data path masquerading as real integration.
+- Backend call executes but response is ignored in UI/state.
+- Async state transitions show stale values during pending operations.
+- Dead code path exists but is never invoked.
+- Fallback values hide broken backend contracts.
+
+### Questions Before Claiming "Works"
+
+1. Is the data source real (network-backed) or fallback/local?
+2. Is backend response consumed directly where expected?
+3. What does the user see while pending?
+4. What happens on failure, retry, timeout, and rollback?
+5. What runtime evidence proves this path executed?
+
+### Verification Methods (Most To Least Reliable)
+
+1. Server logs (actual request paths/status codes)
+2. Browser network inspection
+3. Focused instrumentation/logging
+4. Manual user-flow tests
+5. Direct `curl`/API checks
+6. Code reading alone (never sufficient)
+
+## Common Deceptive Patterns
+
+### Pattern 1: Local Calculation Disguised As Backend-Driven State
+
+```tsx
+// Deceptive
+const total = calculateTotal(items);
+
+// Better
+const total = backendResponse.totals.find((t) => t.type === "total")?.amount;
+```
+
+### Pattern 2: Backend Call Result Ignored
+
+```tsx
+// Deceptive
+await updateBackend(newItems);
+setDisplayTotal(localCalculation(newItems));
+
+// Better
+const response = await updateBackend(newItems);
+setDisplayTotal(response.total);
+```
+
+### Pattern 3: Fire-And-Forget Async State Mismatch
+
+```tsx
+// Deceptive
+setItems(newItems);
+notifyBackend(newItems);
+
+// Better
+setItems(newItems);
+setIsPending(true);
+await notifyBackend(newItems);
+setIsPending(false);
+```
+
+### Pattern 4: Fallback Masks Contract Breakage
+
+```tsx
+// Deceptive
+const price = response.price ?? calculateLocally(item);
+
+// Better
+if (response.price === undefined) {
+  throw new Error("Backend did not return price");
+}
+const price = response.price;
+```
+
+## Completion Evidence Template
+
+For behavior-changing work, report:
+- Commands run
+- Key status codes or test outcomes
+- Log evidence proving path execution
+- Failure-mode coverage
+- Assumptions and residual risk
+
+Example skeleton:
+
+```text
+Commands:
+- <command 1>
+- <command 2>
+
+Results:
+- HTTP 200 on create, HTTP 200 on update
+- Verified merchant->client webhook request observed in logs
+
+Failure coverage:
+- Invalid signature returns expected error
+- Timeout path surfaces user-visible retry state
+```
+
+## Maintenance
+
+When new recurring failure patterns appear:
+- Add diagnostic guidance here.
+- Keep `AGENTS.md` concise and procedural.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -363,7 +363,7 @@ graph TD
   - **Loyalty Integration**: Pre-authenticated user with points display
   - **Same Payment Flow**: Uses identical ACP + PSP payment infrastructure
 
-* **Apps SDK Testing Modes**: The implementation supports three testing environments per [OpenAI deployment guidelines](https://developers.openai.com/apps-sdk/deploy):
+* **Apps SDK Testing Modes**: The implementation supports three testing environments per Apps SDK deployment guidelines:
 
 ```mermaid
 graph TD
@@ -375,8 +375,8 @@ graph TD
         S2 --> S3
     end
 
-    subgraph "Mode 2: ChatGPT Integration"
-        C1[ChatGPT]
+    subgraph "Mode 2: Client Agent Integration"
+        C1[Client Agent]
         C2[ngrok Tunnel]
         C3[MCP Server localhost:2091]
         C4[Widget Bundle]
@@ -386,7 +386,7 @@ graph TD
     end
 
     subgraph "Mode 3: Production"
-        P1[ChatGPT]
+        P1[Client Agent]
         P2[MCP Server Vercel/Alpic]
         P3[Widget CDN]
         P1 -->|HTTPS| P2
@@ -394,9 +394,9 @@ graph TD
     end
 ```
 
-  - **Standalone**: Local development with simulated ChatGPT bridge
-  - **ChatGPT Integration**: Real ChatGPT testing via ngrok tunnel before production
-  - **Production**: Deployed MCP server accessible from ChatGPT Apps Directory
+  - **Standalone**: Local development with simulated client agent bridge
+  - **Client Agent Integration**: Testing with a real client agent via ngrok tunnel before production
+  - **Production**: Deployed MCP server accessible from the client agent's app directory
 
 ---
 

--- a/docs/features/feature-16-apps-sdk.md
+++ b/docs/features/feature-16-apps-sdk.md
@@ -2,7 +2,7 @@
 
 **Goal**: Implement an alternative checkout experience using the Apps SDK pattern, where the merchant controls a fully-owned iframe embedded within the Client Agent panel. This demonstrates how merchants can maintain complete UI control while leveraging the ACP payment infrastructure.
 
-**Reference**: [ChatGPT Apps SDK Developer Guide](../specs/apps-sdk-spec.md)
+**Reference**: [Apps SDK Developer Guide](../specs/apps-sdk-spec.md)
 
 ## Architecture Overview
 
@@ -371,14 +371,14 @@ Apps SDK events are logged in the Merchant Panel alongside native ACP events:
 NEXT_PUBLIC_MERCHANT_APP_URL=/merchant-app
 NEXT_PUBLIC_RECOMMENDATION_AGENT_URL=http://localhost:8004
 
-# MCP Server Configuration (for ChatGPT testing)
+# MCP Server Configuration (for client agent testing)
 MCP_SERVER_PORT=2091
 NGROK_ENABLED=false
 ```
 
 ## Deployment & Testing Architecture
 
-The Apps SDK integration is architected to support **three testing modes**, following the [OpenAI Apps SDK deployment guidelines](https://developers.openai.com/apps-sdk/deploy):
+The Apps SDK integration is architected to support **three testing modes**, following Apps SDK deployment guidelines:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -398,24 +398,24 @@ The Apps SDK integration is architected to support **three testing modes**, foll
 │                                                                             │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                             │
-│  MODE 2: CHATGPT INTEGRATION (ngrok Tunnel)                                 │
-│  ════════════════════════════════════════════                               │
+│  MODE 2: CLIENT AGENT INTEGRATION (ngrok Tunnel)                             │
+│  ════════════════════════════════════════════════                           │
 │  ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐       │
-│  │    ChatGPT      │     │   MCP Server    │     │  Merchant App   │       │
+│  │  Client Agent   │     │   MCP Server    │     │  Merchant App   │       │
 │  │    (Real)       │────▶│  (ngrok tunnel) │────▶│  + ACP Backend  │       │
 │  │                 │     │  *.ngrok.app    │     │  localhost:*    │       │
 │  └─────────────────┘     └─────────────────┘     └─────────────────┘       │
 │         │                        │                                          │
 │         ▼                        ▼                                          │
 │  Real window.openai        MCP Protocol                                     │
-│  injected by ChatGPT       over HTTPS                                       │
+│  injected by client agent  over HTTPS                                       │
 │                                                                             │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                             │
 │  MODE 3: PRODUCTION (Deployed)                                              │
 │  ═════════════════════════════                                              │
 │  ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐       │
-│  │    ChatGPT      │     │   MCP Server    │     │  Merchant App   │       │
+│  │  Client Agent   │     │   MCP Server    │     │  Merchant App   │       │
 │  │    (Real)       │────▶│  (Vercel/etc)   │────▶│  (Production)   │       │
 │  │                 │     │  HTTPS endpoint │     │                 │       │
 │  └─────────────────┘     └─────────────────┘     └─────────────────┘       │
@@ -423,9 +423,9 @@ The Apps SDK integration is architected to support **three testing modes**, foll
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Mode 1: Standalone Testing (Simulated ChatGPT)
+### Mode 1: Standalone Testing (Simulated Client Agent)
 
-For local development without ChatGPT:
+For local development without a client agent:
 
 ```bash
 # Terminal 1: Start ACP Backend + ARAG Agent
@@ -439,14 +439,14 @@ cd src/ui && pnpm run dev
 # Switch to "Apps SDK" tab to test merchant iframe
 ```
 
-The standalone mode uses a **simulated `window.openai` bridge** that mimics the real ChatGPT Apps SDK:
+The standalone mode uses a **simulated `window.openai` bridge** that mimics the real Apps SDK:
 - Parent window injects simulated bridge via `postMessage`
 - Merchant iframe uses same code as production
 - Full ACP payment flow works identically
 
-### Mode 2: ChatGPT Integration Testing (ngrok)
+### Mode 2: Client Agent Integration Testing (ngrok)
 
-For testing directly in ChatGPT before production:
+For testing with a real client agent before production:
 
 ```bash
 # Terminal 1: Start all backend services
@@ -465,8 +465,8 @@ ngrok http 2091
 cd src/ui && pnpm run dev
 ```
 
-**ChatGPT Configuration:**
-1. Go to ChatGPT Settings → Connectors
+**Client Agent Configuration:**
+1. Go to the client agent's connector settings
 2. Add Connector with ngrok URL: `https://<subdomain>.ngrok.app/mcp`
 3. Test with prompts like: "Show me t-shirt recommendations"
 
@@ -483,7 +483,7 @@ For production, deploy to a hosting platform with HTTPS:
 
 ## MCP Server Architecture
 
-The merchant app is structured as a proper MCP server that works with ChatGPT:
+The merchant app is structured as a proper MCP server that works with any compatible client agent:
 
 ```
 src/apps_sdk/
@@ -557,9 +557,9 @@ The widget will load from the MCP server (port 2091) or fall back to the Vite de
 
 ### MCP Tools Definition
 
-Per the [Apps SDK spec](../specs/apps-sdk-spec.md), the MCP server exposes tools that ChatGPT can invoke. The merchant-owned iframe handles product display and recommendations internally - these don't need MCP tools since the merchant controls the UI.
+Per the [Apps SDK spec](../specs/apps-sdk-spec.md), the MCP server exposes tools that the client agent can invoke. The merchant-owned iframe handles product display and recommendations internally - these don't need MCP tools since the merchant controls the UI.
 
-**Tools exposed to ChatGPT:**
+**Tools exposed to the client agent:**
 
 | Tool | Description | Per Spec |
 |------|-------------|----------|
@@ -634,7 +634,7 @@ async def checkout(cart_id: str) -> dict:
 - [x] Implement `CheckoutButton` component
 - [x] Create simulated `window.openai` bridge for standalone mode
 
-**Phase 3: MCP Server (ChatGPT Integration)** ✅
+**Phase 3: MCP Server (Client Agent Integration)** ✅
 - [x] Create `src/apps-sdk/server/` with FastMCP server
 - [x] Implement `get-recommendations` tool with ARAG integration
 - [x] Implement `add-to-cart` and `remove-from-cart` tools
@@ -660,9 +660,9 @@ async def checkout(cart_id: str) -> dict:
 - [x] Log Apps SDK events in Protocol Inspector
 
 **Phase 7: ngrok Testing**
-- [ ] Document ngrok setup for ChatGPT testing
+- [ ] Document ngrok setup for client agent testing
 - [ ] Add environment variable for tunnel mode
-- [ ] Test complete flow in real ChatGPT
+- [ ] Test complete flow in real client agent
 - [ ] Capture screenshots/recordings for documentation
 
 ## Acceptance Criteria
@@ -678,14 +678,14 @@ async def checkout(cart_id: str) -> dict:
 - [x] Pre-authenticated user displays with name and loyalty points
 - [x] Recommendation carousel shows 3 items (mock/ARAG)
 - [x] Shopping cart supports add/remove items and quantity changes
-- [x] Simulated `window.openai` bridge works identically to real ChatGPT
+- [x] Simulated `window.openai` bridge works identically to real client agent
 
-**MCP Server (ChatGPT Integration)** ✅:
+**MCP Server (Client Agent Integration)** ✅:
 - [x] MCP server starts and responds to tool calls
 - [x] `get-recommendations` tool returns ARAG recommendations (with fallback)
 - [x] `add-to-cart`, `remove-from-cart`, and `checkout` tools work correctly
 - [x] Widget resources are served with correct MIME types
-- [ ] Server supports ngrok tunneling for ChatGPT testing (Phase 7)
+- [ ] Server supports ngrok tunneling for client agent testing (Phase 7)
 
 **ARAG Integration** ✅:
 - [x] Recommendations are fetched from ARAG Recommendation Agent
@@ -694,7 +694,7 @@ async def checkout(cart_id: str) -> dict:
 
 **Communication Bridge** ✅:
 - [x] `window.openai.callTool()` pattern works from iframe (standalone)
-- [ ] `window.openai.callTool()` works from real ChatGPT (via ngrok)
+- [ ] `window.openai.callTool()` works from real client agent (via ngrok)
 - [x] Parent receives and processes checkout requests
 - [x] Results are returned to iframe/widget after payment
 
@@ -708,9 +708,9 @@ async def checkout(cart_id: str) -> dict:
 - [x] Event flow is traceable from iframe to order completion
 
 **Deployment & Testing**:
-- [ ] Standalone mode works without ChatGPT connection
-- [ ] ngrok tunnel successfully exposes MCP server to ChatGPT
-- [ ] Real ChatGPT can invoke tools and render widgets
+- [ ] Standalone mode works without client agent connection
+- [ ] ngrok tunnel successfully exposes MCP server to client agent
+- [ ] Real client agent can invoke tools and render widgets
 - [ ] Widget bundle builds correctly for production
 - [ ] Documentation covers all three testing modes
 

--- a/docs/features/feature-17-ucp-integration.md
+++ b/docs/features/feature-17-ucp-integration.md
@@ -2,7 +2,7 @@
 
 **Priority**: P1
 
-**Status**: 🟡 In Progress (Phase 1 Complete)
+**Status**: 🟡 In Progress (Phase 3 Complete)
 
 **Dependencies**: Features 3, 4, 5, 6, 7, 8
 
@@ -24,7 +24,7 @@ This feature adds UCP-compliant endpoints that share the same intelligent agent 
 |-------|-------------|--------|
 | **Phase 1** | Discovery Endpoint (`GET /.well-known/ucp`) | ✅ Complete |
 | **Phase 2** | Checkout Endpoints (REST) + Checkout-Only Capability Negotiation | ✅ Complete |
-| **Phase 3** | A2A Transport (JSON-RPC 2.0) | 🔲 Planned |
+| **Phase 3** | A2A Transport (JSON-RPC 2.0) | ✅ Complete |
 | **Phase 4** | Full Capability Negotiation (extension pruning) | 🔲 Planned |
 | **Phase 5** | Frontend Protocol Toggle | 🔲 Planned |
 | **Phase 6** | Fulfillment Extension (`dev.ucp.shopping.fulfillment`) | 🔲 Planned |
@@ -75,6 +75,27 @@ This is deferred until Phase 6 to keep Phase 2 scope tight and avoid advertising
 - Real capability negotiation (checkout-only)
 - In-memory profile caching (10 min TTL)
 - Spec-aligned error codes (400, 422, 424)
+- Ruff linting and Pyright type checking passed
+
+### Phase 3 Deliverables (Complete)
+
+| File | Description |
+|------|-------------|
+| `src/merchant/api/routes/ucp/a2a.py` | A2A JSON-RPC 2.0 endpoint (`POST /a2a`) |
+| `src/merchant/api/routes/ucp/agent_card.py` | Agent Card discovery (`GET /.well-known/agent-card.json`) |
+| `src/merchant/api/a2a_schemas.py` | Pydantic schemas for A2A messages and parts |
+| `src/merchant/services/a2a.py` | A2A service layer: action routing, context management, idempotency, agent card builder |
+| `src/merchant/services/ucp.py` | Updated `build_business_profile()` with A2A transport + `spec` fields |
+| `src/merchant/main.py` | Registered A2A and Agent Card routers |
+| `tests/merchant/api/test_ucp_a2a.py` | 21 unit tests covering all actions and error cases |
+
+- JSON-RPC 2.0 `message/send` method with structured DataPart actions
+- Required header validation (`UCP-Agent`, `X-A2A-Extensions`) with JSON-RPC error codes
+- 7 checkout actions: `create_checkout`, `add_to_checkout`, `remove_from_checkout`, `update_checkout`, `get_checkout`, `complete_checkout`, `cancel_checkout`
+- contextId-to-session mapping for multi-turn conversations
+- messageId-based idempotency via existing `IdempotencyStore`
+- Agent Card with map-keyed capabilities per `checkout-a2a.md`
+- UCP discovery updated with A2A transport entry (version + spec fields)
 - Ruff linting and Pyright type checking passed
 
 ---
@@ -438,14 +459,14 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. UCP oper
 1. **Create UCP Router Module** (`src/merchant/api/routes/ucp/`)
    - [x] `discovery.py` - UCP profile endpoint ✅ Phase 1
    - [x] `checkout.py` - UCP checkout endpoints (REST)
-   - [ ] `a2a.py` - A2A transport endpoints (JSON-RPC 2.0)
+   - [x] `a2a.py` - A2A transport endpoints (JSON-RPC 2.0) ✅ Phase 3
    - [ ] `negotiation.py` - Capability negotiation logic
 
-2. **Implement A2A Transport** (`src/merchant/api/routes/ucp/a2a.py`)
-   - [ ] JSON-RPC 2.0 request parsing
-   - [ ] Method routing (`a2a.ucp.checkout.create`, `.get`, `.update`, `.complete`, `.cancel`)
-   - [ ] Response formatting (JSON-RPC 2.0)
-   - [ ] Error handling with JSON-RPC error codes
+2. **Implement A2A Transport** (`src/merchant/api/routes/ucp/a2a.py`) ✅ Phase 3
+   - [x] JSON-RPC 2.0 request parsing
+   - [x] Method routing (action-based via DataPart)
+   - [x] Response formatting (JSON-RPC 2.0)
+   - [x] Error handling with JSON-RPC error codes
 
 3. **Implement UCP Discovery** ✅ Phase 1 Complete
    - [x] Static business profile configuration
@@ -513,7 +534,7 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. UCP oper
 1. **Unit Tests** (`tests/merchant/test_ucp_*.py`)
    - [x] `test_ucp_discovery.py` - Discovery endpoint tests ✅ Phase 1
    - [x] `test_ucp_checkout.py` - UCP checkout CRUD tests
-   - [ ] `test_ucp_a2a.py` - A2A transport tests (JSON-RPC 2.0)
+   - [x] `test_ucp_a2a.py` - A2A transport tests (JSON-RPC 2.0) ✅ Phase 3
    - [ ] `test_ucp_negotiation.py` - Capability negotiation tests
    - [ ] Happy path, edge cases, failure cases for each
 

--- a/docs/project-brief.md
+++ b/docs/project-brief.md
@@ -7,7 +7,7 @@
 * **Proposed Solution**: A Python **3.12+**-based (FastAPI) middleware that acts as a relational, intelligent bridge between agentic clients and existing merchant data.
 * **Key Value Proposition**: Demonstrates a "Glass Box" approach to agentic commerce, where business logic (discounts, recommendations, loyalty) is optimized by autonomous agents in real-time.
 * **Protocol Support**: Dual-protocol architecture supporting both ACP and UCP:
-  * **ACP**: OpenAI's Agentic Commerce Protocol for delegated payments
+  * **ACP**: Agentic Commerce Protocol for delegated payments
   * **UCP**: Industry-standard Universal Commerce Protocol with capability negotiation
 * **Demo Client (Client Agent Simulator)**: A static simulator with pre-populated products that can:
   * Accept search prompts (e.g., "find some t-shirts") and display product cards via RAG-powered Search Agent
@@ -114,8 +114,8 @@ The Post-Purchase Agent uses a configurable Brand Persona:
   * Payment via `window.openai.callTool()` pattern → same ACP flow
   * **Three Testing Modes** per [OpenAI Apps SDK guidelines](https://developers.openai.com/apps-sdk/deploy):
     * Standalone: Local development with simulated `window.openai` bridge
-    * ChatGPT Integration: Real ChatGPT testing via ngrok tunnel
-    * Production: Deployed MCP server accessible from ChatGPT Apps Directory
+    * Client Agent Integration: Testing with a real client agent via ngrok tunnel
+    * Production: Deployed MCP server accessible from the client agent's app directory
   * MCP server with `search-products`, `get-recommendations`, `add-to-cart`, `checkout` tools
   * Widget bundles served via `openai/outputTemplate` metadata
 

--- a/docs/specs/acp-spec.md
+++ b/docs/specs/acp-spec.md
@@ -1,12 +1,12 @@
 # Agentic Checkout Protocol - API Specification
 
-**Call Direction**: OpenAI → Merchant (REST) | Merchant → OpenAI (Webhooks)
+**Call Direction**: Client Agent → Merchant (REST) | Merchant → Client Agent (Webhooks)
 
 **API Version**: `2026-01-16`
 
 ## Overview
 
-This document defines the REST endpoints and webhook events for the Agentic Checkout Protocol. Merchants implement these endpoints to enable end-to-end checkout flows inside ChatGPT.
+This document defines the REST endpoints and webhook events for the Agentic Checkout Protocol. Merchants implement these endpoints to enable end-to-end checkout flows with client agents.
 
 ACP Checkout Sessions provide a stateful model for managing the checkout experience where:
 - **Merchants remain the system of record** for orders, payments, taxes, and compliance
@@ -80,7 +80,7 @@ ACP Checkout Sessions provide a stateful model for managing the checkout experie
 | Header          | Description                                      | Example                                         |
 |:----------------|:-------------------------------------------------|:------------------------------------------------|
 | Accept-Language | Preferred locale for messages/errors             | `en-US`                                         |
-| User-Agent      | Client identification                            | `ChatGPT/2.0`                                   |
+| User-Agent      | Client identification                            | `AgentClient/2.0`                               |
 | Idempotency-Key | Ensures request idempotency                      | `idem_abc123`                                   |
 | Request-Id      | Unique request identifier for tracing            | `req_xyz789`                                    |
 | Signature       | Request signature (base64url)                    | `ZXltZX...`                                     |
@@ -945,9 +945,9 @@ Can be strings or objects:
 
 ---
 
-## Webhooks (Merchant → OpenAI)
+## Webhooks (Merchant → Client Agent)
 
-Merchants send webhook events to OpenAI for order lifecycle updates. Events are signed with HMAC using a key provided by OpenAI.
+Merchants send webhook events to the client agent for order lifecycle updates. Events are signed with HMAC using a shared key.
 
 ### Webhook Event Schema
 

--- a/docs/specs/apps-sdk-spec.md
+++ b/docs/specs/apps-sdk-spec.md
@@ -1,4 +1,4 @@
-# Ultimate ChatGPT Apps SDK Developer Guide
+# Apps SDK Developer Guide
 
 > **For AI Coding Assistants**: This guide provides comprehensive reference material for building ChatGPT applications using OpenAI's Apps SDK with MCP servers and HTML/React widgets.
 

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -42,34 +42,34 @@ The Apps SDK mode provides an alternative merchant-controlled checkout experienc
 
 ### Apps SDK MCP Server Stack
 
-For ChatGPT integration testing and production deployment:
+For client agent integration testing and production deployment:
 
 | Component | Technology | Version | Purpose |
 | --- | --- | --- | --- |
-| **MCP Server** | FastAPI + MCP | n/a | Tool registration and handling for ChatGPT |
-| **Widget Bundle** | Vite + React | latest | Builds HTML widget files for ChatGPT rendering |
-| **Tunnel** | ngrok | latest | Exposes local MCP server to ChatGPT for testing |
+| **MCP Server** | FastAPI + MCP | n/a | Tool registration and handling for the client agent |
+| **Widget Bundle** | Vite + React | latest | Builds HTML widget files for client agent rendering |
+| **Tunnel** | ngrok | latest | Exposes local MCP server to the client agent for testing |
 | **Hosting** | Vercel / Alpic | n/a | Production deployment with HTTPS and CDN |
 
 ### Testing Modes
 
-The Apps SDK is architected for three testing environments per [OpenAI guidelines](https://developers.openai.com/apps-sdk/deploy):
+The Apps SDK is architected for three testing environments per Apps SDK deployment guidelines:
 
-| Mode | ChatGPT | MCP Server | Purpose |
+| Mode | Client Agent | MCP Server | Purpose |
 | --- | --- | --- | --- |
-| **Standalone** | Simulated | N/A (postMessage) | Local development without ChatGPT |
-| **Integration** | Real | ngrok tunnel | Pre-production testing in ChatGPT |
+| **Standalone** | Simulated | N/A (postMessage) | Local development without a client agent |
+| **Integration** | Real | ngrok tunnel | Pre-production testing with a client agent |
 | **Production** | Real | Vercel/Alpic | Public deployment |
 
 ```bash
-# Standalone (simulated ChatGPT)
+# Standalone (simulated client agent)
 cd src/ui && pnpm run dev
 # Access http://localhost:3000, switch to Apps SDK tab
 
-# Integration (real ChatGPT via ngrok)
+# Integration (real client agent via ngrok)
 uvicorn src.apps_sdk.main:app --reload --port 2091
-ngrok http 2091                  # Tunnel to ChatGPT
-# Configure ngrok URL in ChatGPT Settings → Connectors
+ngrok http 2091                  # Tunnel to client agent
+# Configure ngrok URL in the client agent's connector settings
 ```
 
 #### Apps SDK Communication Flow

--- a/src/merchant/api/a2a_schemas.py
+++ b/src/merchant/api/a2a_schemas.py
@@ -1,0 +1,74 @@
+"""Pydantic schemas for A2A (Agent-to-Agent) JSON-RPC 2.0 transport.
+
+Defines request/response models for the A2A binding of UCP checkout capability
+per checkout-a2a.md specification.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class A2APart(BaseModel):
+    """A2A message part (text or data).
+
+    The A2A spec uses both ``type`` and ``kind`` for part discrimination.
+    This model accepts either on input and always emits ``kind`` on output.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    kind: str | None = Field(default=None)
+    text: str | None = None
+    data: dict[str, Any] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_type_or_kind(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Normalize incoming ``type`` field to ``kind``."""
+        if "type" in values and "kind" not in values:
+            values["kind"] = values.pop("type")
+        return values
+
+    @model_validator(mode="after")
+    def _infer_kind(self) -> A2APart:
+        """Infer kind from payload when not explicitly set."""
+        if self.kind is None:
+            self.kind = "data" if self.data is not None else "text"
+        return self
+
+
+class A2AMessage(BaseModel):
+    """A2A message within a JSON-RPC request or response."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    role: str = Field(..., description="Message role: 'user' or 'agent'")
+    message_id: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        alias="messageId",
+        description="Unique message identifier for idempotency",
+    )
+    context_id: str | None = Field(
+        default=None,
+        alias="contextId",
+        description="A2A conversation context identifier",
+    )
+    kind: str = Field(default="message", description="Must be 'message'")
+    parts: list[A2APart] = Field(  # type: ignore[assignment]
+        default_factory=list, description="Message parts"
+    )
+
+
+class A2AJsonRpcRequest(BaseModel):
+    """Top-level JSON-RPC 2.0 request envelope for A2A."""
+
+    jsonrpc: str = Field(..., description="Must be '2.0'")
+    id: str | int = Field(..., description="Request identifier")
+    method: str = Field(..., description="JSON-RPC method name")
+    params: dict[str, Any] = Field(
+        default_factory=dict, description="Method parameters"
+    )

--- a/src/merchant/api/routes/ucp/a2a.py
+++ b/src/merchant/api/routes/ucp/a2a.py
@@ -1,0 +1,270 @@
+"""A2A (Agent-to-Agent) JSON-RPC 2.0 transport endpoint for UCP checkout.
+
+Implements the checkout-a2a.md binding specification. All UCP checkout
+operations are exposed via the ``message/send`` JSON-RPC method with
+structured DataPart actions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, cast
+
+import httpx
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from sqlmodel import Session
+
+from src.merchant.api.a2a_schemas import A2AMessage
+from src.merchant.api.dependencies import verify_api_key
+from src.merchant.db.database import get_session
+from src.merchant.services.a2a import (
+    A2A_UCP_EXTENSION_URL,
+    JSONRPC_DISCOVERY_FAILURE,
+    JSONRPC_INVALID_PARAMS,
+    JSONRPC_INVALID_REQUEST,
+    JSONRPC_INVALID_STATE,
+    JSONRPC_METHOD_NOT_FOUND,
+    JSONRPC_PARSE_ERROR,
+    JSONRPC_SESSION_NOT_FOUND,
+    UCP_AGENT_HEADER,
+    build_jsonrpc_error,
+    build_jsonrpc_result,
+    check_message_idempotency,
+    dispatch_action,
+    extract_action,
+    negotiate_a2a_capabilities,
+    store_message_idempotency,
+)
+from src.merchant.services.checkout import (
+    InvalidStateTransitionError,
+    ProductNotFoundError,
+    SessionNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/a2a",
+    tags=["ucp-a2a"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+@router.post(
+    "",
+    summary="A2A JSON-RPC 2.0 Endpoint",
+    description="Handles UCP checkout operations via A2A message/send.",
+)
+async def handle_a2a_request(
+    http_request: Request,
+    db: Session = Depends(get_session),
+) -> JSONResponse:
+    """Process an A2A JSON-RPC 2.0 request.
+
+    Steps:
+    1. Parse JSON body
+    2. Validate JSON-RPC envelope
+    3. Validate method is ``message/send``
+    4. Extract and validate required headers
+    5. Check messageId idempotency
+    6. Route action to checkout handler
+    7. Store idempotency entry
+    8. Return JSON-RPC result with checkout DataPart
+    """
+    # ---- 1. Parse raw JSON body ----
+    raw_body = await http_request.body()
+    try:
+        body = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JSONResponse(
+            build_jsonrpc_error(None, JSONRPC_PARSE_ERROR, "Parse error"),
+        )
+
+    if not isinstance(body, dict):
+        return JSONResponse(
+            build_jsonrpc_error(None, JSONRPC_PARSE_ERROR, "Parse error"),
+        )
+
+    body_dict: dict[str, Any] = cast(dict[str, Any], body)
+    request_id: Any = body_dict.get("id")
+
+    # ---- 2. Validate JSON-RPC envelope ----
+    if (
+        body_dict.get("jsonrpc") != "2.0"
+        or "method" not in body_dict
+        or "id" not in body_dict
+    ):
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_REQUEST,
+                "Invalid Request: missing jsonrpc, method, or id",
+            ),
+        )
+
+    # ---- 3. Validate method ----
+    method_name = str(body_dict["method"])
+    if method_name != "message/send":
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_METHOD_NOT_FOUND,
+                f"Method not found: {method_name}",
+            ),
+        )
+
+    # ---- 4. Extract and validate required headers ----
+    ucp_agent_value = http_request.headers.get(UCP_AGENT_HEADER)
+    if not ucp_agent_value:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                "Invalid params",
+                {"detail": f"Missing required header: {UCP_AGENT_HEADER}"},
+            ),
+        )
+
+    x_a2a_ext = http_request.headers.get("X-A2A-Extensions")
+    if not x_a2a_ext:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                "Invalid params",
+                {"detail": "Missing required header: X-A2A-Extensions"},
+            ),
+        )
+
+    if A2A_UCP_EXTENSION_URL not in x_a2a_ext:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                "Invalid params",
+                {"detail": "X-A2A-Extensions must contain UCP extension URI"},
+            ),
+        )
+
+    # ---- 5. Parse message from params ----
+    params_val: Any = body_dict.get("params", {})
+    params = cast(dict[str, Any], params_val) if isinstance(params_val, dict) else {}
+    message_raw: Any = params.get("message")
+    if not isinstance(message_raw, dict):
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                "Invalid params: missing message object",
+            ),
+        )
+
+    try:
+        message = A2AMessage.model_validate(message_raw)
+    except Exception:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                "Invalid params: malformed message",
+            ),
+        )
+
+    # ---- 6. Check idempotency ----
+    cached = check_message_idempotency(message.message_id, raw_body)
+    if cached is not None:
+        logger.info("A2A idempotency hit for messageId=%s", message.message_id)
+        return JSONResponse(cached)
+
+    # ---- 7. Resolve contextId ----
+    context_id = message.context_id or str(uuid.uuid4())
+
+    # ---- 8. Negotiate capabilities ----
+    base_url = str(http_request.base_url).rstrip("/")
+    try:
+        negotiated = await negotiate_a2a_capabilities(ucp_agent_value, base_url)
+    except ValueError as exc:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_DISCOVERY_FAILURE,
+                str(exc),
+            ),
+        )
+    except httpx.RequestError as exc:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_DISCOVERY_FAILURE,
+                f"Platform profile unreachable: {exc}",
+            ),
+        )
+
+    # ---- 9. Extract and dispatch action ----
+    try:
+        action, action_data = extract_action(message)
+    except ValueError as exc:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                f"Invalid params: {exc}",
+            ),
+        )
+
+    try:
+        data_part = await dispatch_action(
+            action=action,
+            data=action_data,
+            message=message,
+            context_id=context_id,
+            db=db,
+            negotiated=negotiated,
+        )
+    except SessionNotFoundError:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_SESSION_NOT_FOUND,
+                "Checkout session not found for this context",
+            ),
+        )
+    except ProductNotFoundError as exc:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                exc.message,
+            ),
+        )
+    except InvalidStateTransitionError as exc:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_STATE,
+                exc.message,
+            ),
+        )
+    except ValueError as exc:
+        return JSONResponse(
+            build_jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                str(exc),
+            ),
+        )
+
+    # ---- 10. Build success response ----
+    result = build_jsonrpc_result(
+        request_id=request_id,
+        context_id=context_id,
+        parts=[{"kind": "data", "data": data_part}],
+    )
+
+    # ---- 11. Store idempotency ----
+    store_message_idempotency(message.message_id, raw_body, result)
+
+    return JSONResponse(result)

--- a/src/merchant/api/routes/ucp/agent_card.py
+++ b/src/merchant/api/routes/ucp/agent_card.py
@@ -1,0 +1,31 @@
+"""A2A Agent Card discovery endpoint.
+
+Returns the Agent Card document used by platforms to discover this
+business agent's A2A capabilities and UCP extension support.
+
+This is a public endpoint (no API key required) since platforms need
+to fetch the agent card before establishing authenticated sessions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from src.merchant.config import get_settings
+from src.merchant.services.a2a import build_agent_card
+
+router = APIRouter(tags=["ucp-a2a"])
+
+
+@router.get(
+    "/.well-known/agent-card.json",
+    summary="A2A Agent Card Discovery",
+    description="Returns the A2A Agent Card for this merchant agent. Public endpoint.",
+)
+async def get_agent_card(request: Request) -> dict[str, Any]:
+    """Return dynamically-built A2A Agent Card for discovery."""
+    settings = get_settings()
+    base_url = settings.ucp_base_url or str(request.base_url).rstrip("/")
+    return build_agent_card(base_url)

--- a/src/merchant/main.py
+++ b/src/merchant/main.py
@@ -11,6 +11,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.merchant.api.routes.checkout import router as checkout_router
 from src.merchant.api.routes.health import router as health_router
 from src.merchant.api.routes.products import router as products_router
+from src.merchant.api.routes.ucp.a2a import router as ucp_a2a_router
+from src.merchant.api.routes.ucp.agent_card import router as ucp_agent_card_router
 from src.merchant.api.routes.ucp.checkout import router as ucp_checkout_router
 from src.merchant.api.routes.ucp.discovery import router as ucp_discovery_router
 from src.merchant.config import get_settings
@@ -103,3 +105,5 @@ app.include_router(checkout_router)
 app.include_router(products_router)
 app.include_router(ucp_discovery_router)
 app.include_router(ucp_checkout_router)
+app.include_router(ucp_a2a_router)
+app.include_router(ucp_agent_card_router)

--- a/src/merchant/services/a2a.py
+++ b/src/merchant/services/a2a.py
@@ -1,0 +1,570 @@
+"""A2A transport service layer for UCP checkout operations.
+
+Handles JSON-RPC 2.0 protocol logic, contextId-to-session mapping,
+action routing, messageId idempotency, and agent card construction.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, cast
+
+from sqlmodel import Session
+
+from src.merchant.api.a2a_schemas import A2AMessage, A2APart
+from src.merchant.api.schemas import (
+    CheckoutSessionResponse,
+    CreateCheckoutRequest,
+    ItemInput,
+    PaymentDataInput,
+    PaymentProviderEnum,
+    UpdateCheckoutRequest,
+)
+from src.merchant.api.ucp_schemas import UCPCapabilityVersion
+from src.merchant.config import get_settings
+from src.merchant.services.checkout import (
+    SessionNotFoundError,
+    cancel_checkout_session,
+    complete_checkout_session,
+    create_checkout_session,
+    get_checkout_session,
+    update_checkout_session,
+)
+from src.merchant.services.idempotency import get_idempotency_store
+from src.merchant.services.ucp import (
+    build_business_profile,
+    compute_capability_intersection,
+    fetch_platform_profile,
+    parse_ucp_agent_header,
+    transform_to_ucp_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# A2A UCP Constants (sourced from official spec: checkout-a2a.md)
+# ---------------------------------------------------------------------------
+
+A2A_UCP_EXTENSION_URL = "https://ucp.dev/specification/reference?v=2026-01-11"
+UCP_CHECKOUT_KEY = "a2a.ucp.checkout"
+UCP_PAYMENT_DATA_KEY = "a2a.ucp.checkout.payment"
+UCP_RISK_SIGNALS_KEY = "a2a.ucp.checkout.risk_signals"
+UCP_AGENT_HEADER = "UCP-Agent"
+
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 Error Codes
+# ---------------------------------------------------------------------------
+
+JSONRPC_PARSE_ERROR = -32700
+JSONRPC_INVALID_REQUEST = -32600
+JSONRPC_METHOD_NOT_FOUND = -32601
+JSONRPC_INVALID_PARAMS = -32602
+JSONRPC_SESSION_NOT_FOUND = -32000
+JSONRPC_INVALID_STATE = -32001
+JSONRPC_DISCOVERY_FAILURE = -32002
+
+# ---------------------------------------------------------------------------
+# Context-to-Session Mapping (in-memory)
+# ---------------------------------------------------------------------------
+
+_context_sessions: dict[str, str] = {}
+
+
+def get_checkout_id_for_context(context_id: str) -> str | None:
+    """Look up checkout session ID for an A2A contextId."""
+    return _context_sessions.get(context_id)
+
+
+def set_checkout_id_for_context(context_id: str, checkout_id: str) -> None:
+    """Store checkout session ID for an A2A contextId."""
+    _context_sessions[context_id] = checkout_id
+
+
+def clear_context_sessions() -> None:
+    """Clear all context-to-session mappings (for testing)."""
+    _context_sessions.clear()
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC Response Builders
+# ---------------------------------------------------------------------------
+
+
+def build_jsonrpc_error(
+    request_id: Any,
+    code: int,
+    message: str,
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 error response."""
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": error,
+    }
+
+
+def build_jsonrpc_result(
+    request_id: Any,
+    context_id: str,
+    parts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 success response wrapping an A2A Message."""
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": {
+            "messageId": str(uuid.uuid4()),
+            "contextId": context_id,
+            "role": "agent",
+            "kind": "message",
+            "parts": parts,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Idempotency via existing IdempotencyStore
+# ---------------------------------------------------------------------------
+
+
+def check_message_idempotency(
+    message_id: str, request_body: bytes
+) -> dict[str, Any] | None:
+    """Return cached response for a duplicate messageId, or None."""
+    store = get_idempotency_store()
+    entry, _is_conflict = store.get(
+        idempotency_key=f"a2a:{message_id}",
+        body=request_body,
+        path="/a2a",
+        method="POST",
+    )
+    if entry is not None:
+        return entry.response_body
+    return None
+
+
+def store_message_idempotency(
+    message_id: str,
+    request_body: bytes,
+    response_body: dict[str, Any],
+) -> None:
+    """Persist a response keyed by messageId for future duplicate detection."""
+    store = get_idempotency_store()
+    store.store(
+        idempotency_key=f"a2a:{message_id}",
+        body=request_body,
+        path="/a2a",
+        method="POST",
+        response_status=200,
+        response_body=response_body,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capability Negotiation (A2A-specific wrapper)
+# ---------------------------------------------------------------------------
+
+
+async def negotiate_a2a_capabilities(
+    ucp_agent_header: str,
+    request_base_url: str,
+) -> dict[str, list[UCPCapabilityVersion]]:
+    """Run UCP capability negotiation from UCP-Agent header value.
+
+    Raises ValueError / httpx.RequestError on failure (caller maps to
+    JSON-RPC error codes).
+    """
+    profile_url = parse_ucp_agent_header(ucp_agent_header)
+    platform_profile = await fetch_platform_profile(profile_url)
+
+    # Version validation
+    ucp_block = platform_profile.get("ucp", {})
+    platform_version = ucp_block.get("version")
+    if not isinstance(platform_version, str):
+        raise ValueError("Platform profile malformed")
+
+    settings = get_settings()
+    parsed_platform = datetime.strptime(platform_version, "%Y-%m-%d").date()
+    parsed_business = datetime.strptime(settings.ucp_version, "%Y-%m-%d").date()
+    if parsed_platform > parsed_business:
+        raise ValueError("Platform profile version unsupported")
+
+    business_profile = build_business_profile(request_base_url=request_base_url)
+    negotiated = compute_capability_intersection(business_profile, platform_profile)
+    if not negotiated:
+        raise ValueError("Platform does not support checkout capability")
+    return negotiated
+
+
+# ---------------------------------------------------------------------------
+# Action Extraction Helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_action(message: A2AMessage) -> tuple[str, dict[str, Any]]:
+    """Extract the action name and its data payload from the first DataPart.
+
+    Returns (action_name, data_dict_without_action_key).
+    Raises ValueError when no action is found.
+    """
+    for part in message.parts:
+        if part.data and "action" in part.data:
+            data = dict(part.data)
+            action = data.pop("action")
+            if not isinstance(action, str):
+                raise ValueError("action must be a string")
+            return action, data
+    raise ValueError("No action found in message parts")
+
+
+def extract_payment_data(
+    parts: list[A2APart],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Extract payment instruments and risk signals from DataParts."""
+    payment: dict[str, Any] | None = None
+    risk_signals: dict[str, Any] | None = None
+    for part in parts:
+        if part.data:
+            if UCP_PAYMENT_DATA_KEY in part.data:
+                payment = part.data[UCP_PAYMENT_DATA_KEY]
+            if UCP_RISK_SIGNALS_KEY in part.data:
+                risk_signals = part.data[UCP_RISK_SIGNALS_KEY]
+    return payment, risk_signals
+
+
+# ---------------------------------------------------------------------------
+# Action Handlers (delegate to Phase 2 checkout service)
+# ---------------------------------------------------------------------------
+
+
+async def handle_create(
+    data: dict[str, Any],
+    _context_id: str,
+    db: Session,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> dict[str, Any]:
+    """Handle create_checkout action."""
+    items_raw: Any = data.get("line_items") or data.get("items") or []
+    items: list[ItemInput] = []
+    if isinstance(items_raw, list):
+        typed_list = cast(list[Any], items_raw)
+        for entry in typed_list:
+            ri = cast(dict[str, Any], entry)
+            pid: str = str(ri.get("product_id") or ri.get("id", ""))
+            qty: int = int(ri.get("quantity", 1))
+            items.append(ItemInput(id=pid, quantity=qty))
+    if not items:
+        # Single-item shorthand: product_id + quantity at top level
+        product_id = data.get("product_id")
+        if product_id:
+            items = [
+                ItemInput(id=str(product_id), quantity=int(data.get("quantity", 1)))
+            ]
+
+    if not items:
+        raise ValueError("No items provided for create_checkout")
+
+    request = CreateCheckoutRequest(items=items)
+    acp_response = await create_checkout_session(db, request, protocol="ucp")
+
+    set_checkout_id_for_context(_context_id, acp_response.id)
+    return _to_checkout_data_part(acp_response, negotiated)
+
+
+async def handle_update(
+    data: dict[str, Any],
+    context_id: str,
+    db: Session,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+    action: str = "update_checkout",
+) -> dict[str, Any]:
+    """Handle add_to_checkout, remove_from_checkout, and update_checkout."""
+    session_id = get_checkout_id_for_context(context_id)
+    if not session_id:
+        raise SessionNotFoundError(session_id="unknown")
+
+    existing = get_checkout_session(db, session_id)
+
+    if action == "add_to_checkout":
+        product_id = data.get("product_id") or data.get("id")
+        quantity = data.get("quantity", 1)
+        if not product_id:
+            raise ValueError("product_id required for add_to_checkout")
+
+        existing_items = [
+            ItemInput(id=li.item.id, quantity=li.item.quantity)
+            for li in existing.line_items
+        ]
+        found = False
+        for item in existing_items:
+            if item.id == product_id:
+                item.quantity += quantity
+                found = True
+                break
+        if not found:
+            existing_items.append(ItemInput(id=product_id, quantity=quantity))
+
+        request = UpdateCheckoutRequest(items=existing_items)
+
+    elif action == "remove_from_checkout":
+        product_id = data.get("product_id") or data.get("id")
+        if not product_id:
+            raise ValueError("product_id required for remove_from_checkout")
+
+        items = [
+            ItemInput(id=li.item.id, quantity=li.item.quantity)
+            for li in existing.line_items
+            if li.item.id != product_id
+        ]
+        request = UpdateCheckoutRequest(items=items if items else None)
+
+    else:
+        raw_items: Any = data.get("line_items") or data.get("items") or []
+        items: list[ItemInput] = []
+        if isinstance(raw_items, list):
+            typed_items = cast(list[Any], raw_items)
+            for entry in typed_items:
+                ri = cast(dict[str, Any], entry)
+                pid = str(ri.get("product_id") or ri.get("id", ""))
+                qty = int(ri.get("quantity", 1))
+                items.append(ItemInput(id=pid, quantity=qty))
+        request = UpdateCheckoutRequest(items=items if items else None)
+
+    acp_response = await update_checkout_session(db, session_id, request)
+    return _to_checkout_data_part(acp_response, negotiated)
+
+
+def handle_get(
+    context_id: str,
+    db: Session,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> dict[str, Any]:
+    """Handle get_checkout action."""
+    session_id = get_checkout_id_for_context(context_id)
+    if not session_id:
+        raise SessionNotFoundError(session_id="unknown")
+
+    acp_response = get_checkout_session(db, session_id)
+    return _to_checkout_data_part(acp_response, negotiated)
+
+
+def _resolve_payment_provider(handler_id: str) -> PaymentProviderEnum:
+    """Map a UCP payment handler_id to the internal PaymentProviderEnum.
+
+    The business advertises payment handlers in the UCP profile (e.g.,
+    ``com.example.processor_tokenizer``).  The platform submits a
+    ``handler_id`` referencing one of those handlers.  This function maps
+    that handler_id to the internal provider enum used by the checkout
+    service.
+
+    Falls back to STRIPE for this reference implementation since it is
+    the only PSP currently configured.
+    """
+    handler_map: dict[str, PaymentProviderEnum] = {
+        "processor_tokenizer": PaymentProviderEnum.STRIPE,
+    }
+    return handler_map.get(handler_id, PaymentProviderEnum.STRIPE)
+
+
+def handle_complete(
+    parts: list[A2APart],
+    context_id: str,
+    db: Session,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> dict[str, Any]:
+    """Handle complete_checkout action with payment data from DataParts.
+
+    Per checkout-a2a.md, payment MUST be submitted as a DataPart with
+    key ``a2a.ucp.checkout.payment`` containing an ``instruments`` array.
+    """
+    session_id = get_checkout_id_for_context(context_id)
+    if not session_id:
+        raise SessionNotFoundError(session_id="unknown")
+
+    payment, _risk_signals = extract_payment_data(parts)
+
+    if not payment or "instruments" not in payment:
+        raise ValueError(
+            "Payment data required: submit a2a.ucp.checkout.payment "
+            "DataPart with instruments array"
+        )
+
+    instruments_list = cast(list[Any], payment.get("instruments", []))
+    if not instruments_list:
+        raise ValueError("Payment instruments array must not be empty")
+
+    instrument = cast(dict[str, Any], instruments_list[0])
+    credential = cast(dict[str, Any], instrument.get("credential", {}))
+    token_val: str = str(credential.get("token", ""))
+    if not token_val:
+        raise ValueError("Payment credential token is required")
+
+    handler_id: str = str(instrument.get("handler_id", ""))
+    provider = _resolve_payment_provider(handler_id)
+
+    payment_data = PaymentDataInput(token=token_val, provider=provider)
+
+    acp_response = complete_checkout_session(db, session_id, payment_data, buyer=None)
+    result = _to_checkout_data_part(acp_response, negotiated)
+
+    if acp_response.order:
+        result[UCP_CHECKOUT_KEY]["order"] = {
+            "id": acp_response.order.id,
+            "permalink_url": acp_response.order.permalink_url,
+        }
+
+    return result
+
+
+def handle_cancel(
+    context_id: str,
+    db: Session,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> dict[str, Any]:
+    """Handle cancel_checkout action."""
+    session_id = get_checkout_id_for_context(context_id)
+    if not session_id:
+        raise SessionNotFoundError(session_id="unknown")
+
+    acp_response = cancel_checkout_session(db, session_id)
+    return _to_checkout_data_part(acp_response, negotiated)
+
+
+# ---------------------------------------------------------------------------
+# Response Transformation
+# ---------------------------------------------------------------------------
+
+
+def _to_checkout_data_part(
+    acp_response: CheckoutSessionResponse,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> dict[str, Any]:
+    """Convert an ACP response into a dict suitable for a DataPart."""
+    ucp_response = transform_to_ucp_response(acp_response, negotiated)
+    checkout_dict = ucp_response.model_dump(mode="json", by_alias=True)
+    return {UCP_CHECKOUT_KEY: checkout_dict}
+
+
+# ---------------------------------------------------------------------------
+# Action Dispatcher
+# ---------------------------------------------------------------------------
+
+SUPPORTED_ACTIONS = {
+    "create_checkout",
+    "add_to_checkout",
+    "remove_from_checkout",
+    "update_checkout",
+    "get_checkout",
+    "complete_checkout",
+    "cancel_checkout",
+}
+
+
+async def dispatch_action(
+    action: str,
+    data: dict[str, Any],
+    message: A2AMessage,
+    context_id: str,
+    db: Session,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> dict[str, Any]:
+    """Route an action string to the appropriate handler.
+
+    Returns the DataPart dict ({UCP_CHECKOUT_KEY: ...}).
+    """
+    if action not in SUPPORTED_ACTIONS:
+        raise ValueError(f"Unknown action: {action}")
+
+    if action == "create_checkout":
+        return await handle_create(data, context_id, db, negotiated)
+
+    if action in ("add_to_checkout", "remove_from_checkout", "update_checkout"):
+        return await handle_update(data, context_id, db, negotiated, action=action)
+
+    if action == "get_checkout":
+        return handle_get(context_id, db, negotiated)
+
+    if action == "complete_checkout":
+        return handle_complete(message.parts, context_id, db, negotiated)
+
+    # cancel_checkout
+    return handle_cancel(context_id, db, negotiated)
+
+
+# ---------------------------------------------------------------------------
+# Agent Card Builder
+# ---------------------------------------------------------------------------
+
+
+def _build_agent_card_capabilities(
+    base_url: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """Derive Agent Card capabilities from the business profile.
+
+    This ensures the Agent Card and ``/.well-known/ucp`` discovery
+    advertise the same capabilities from a single source of truth
+    (``build_business_profile``).  The format is converted from the
+    Pydantic ``UCPCapabilityVersion`` models to the map-keyed dict
+    form required by the A2A Agent Card spec.
+    """
+    profile = build_business_profile(request_base_url=base_url)
+    caps: dict[str, list[dict[str, Any]]] = {}
+    for cap_name, versions in profile.ucp.capabilities.items():
+        cap_entries: list[dict[str, Any]] = []
+        for ver in versions:
+            entry: dict[str, Any] = {"version": ver.version}
+            if ver.extends:
+                entry["extends"] = ver.extends
+            cap_entries.append(entry)
+        caps[cap_name] = cap_entries
+    return caps
+
+
+def build_agent_card(base_url: str) -> dict[str, Any]:
+    """Build the A2A Agent Card dynamically from configuration.
+
+    Capabilities are derived from ``build_business_profile()`` so they
+    stay in sync with the UCP discovery endpoint.
+    """
+    return {
+        "name": "Agentic Commerce Merchant Agent",
+        "description": "UCP-compliant merchant checkout agent",
+        "protocolVersion": "0.3.0",
+        "url": f"{base_url}/a2a",
+        "preferredTransport": "JSONRPC",
+        "version": "1.0.0",
+        "provider": {
+            "organization": "Agentic Commerce",
+            "url": base_url,
+        },
+        "capabilities": {
+            "extensions": [
+                {
+                    "uri": A2A_UCP_EXTENSION_URL,
+                    "description": "Business agent supporting UCP",
+                    "params": {
+                        "capabilities": _build_agent_card_capabilities(base_url),
+                    },
+                }
+            ],
+            "streaming": False,
+        },
+        "defaultInputModes": ["text", "text/plain", "application/json"],
+        "defaultOutputModes": ["text", "text/plain", "application/json"],
+        "skills": [
+            {
+                "id": "checkout",
+                "name": "Checkout",
+                "description": (
+                    "Manage checkout sessions - add items, update, complete, or cancel"
+                ),
+                "tags": ["shopping", "checkout", "ucp"],
+            }
+        ],
+    }

--- a/src/merchant/services/ucp.py
+++ b/src/merchant/services/ucp.py
@@ -83,6 +83,8 @@ def build_business_profile(request_base_url: str | None = None) -> UCPBusinessPr
             )
         ]
 
+    agent_card_url = f"{base_url.rstrip('/')}/.well-known/agent-card.json"
+
     return UCPBusinessProfile(
         ucp=UCPMetadata(
             version=settings.ucp_version,
@@ -90,9 +92,16 @@ def build_business_profile(request_base_url: str | None = None) -> UCPBusinessPr
                 "dev.ucp.shopping": [
                     UCPService(
                         version=settings.ucp_version,
+                        spec="https://ucp.dev/specification/overview",
                         transport="rest",
                         endpoint=service_endpoint,
-                    )
+                    ),
+                    UCPService(
+                        version=settings.ucp_version,
+                        spec="https://ucp.dev/specification/overview",
+                        transport="a2a",
+                        endpoint=agent_card_url,
+                    ),
                 ]
             },
             capabilities={

--- a/tests/merchant/api/test_ucp_a2a.py
+++ b/tests/merchant/api/test_ucp_a2a.py
@@ -1,0 +1,421 @@
+"""Tests for UCP A2A (Agent-to-Agent) JSON-RPC 2.0 transport endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.merchant.config import get_settings
+from src.merchant.db.database import reset_engine
+from src.merchant.services.a2a import (
+    A2A_UCP_EXTENSION_URL,
+    clear_context_sessions,
+)
+from src.merchant.services.idempotency import reset_idempotency_store
+from src.merchant.services.ucp import clear_profile_cache
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    """Clear per-test state: profile cache, context sessions, idempotency."""
+    clear_profile_cache()
+    clear_context_sessions()
+    reset_idempotency_store()
+
+
+@pytest.fixture(autouse=True)
+def _use_temp_database(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "ucp_a2a_test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    get_settings.cache_clear()
+    reset_engine()
+    yield
+    reset_engine()
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def platform_profile() -> dict[str, Any]:
+    return {
+        "ucp": {
+            "version": get_settings().ucp_version,
+            "capabilities": {
+                "dev.ucp.shopping.checkout": [{"version": get_settings().ucp_version}]
+            },
+        }
+    }
+
+
+@pytest.fixture
+def mock_platform_profile(monkeypatch, platform_profile) -> None:
+    async def _mock_fetch(_url: str) -> dict[str, Any]:
+        return platform_profile
+
+    monkeypatch.setattr("src.merchant.services.a2a.fetch_platform_profile", _mock_fetch)
+
+
+@pytest.fixture
+def a2a_headers() -> dict[str, str]:
+    return {
+        "UCP-Agent": 'profile="https://platform.example/profile"',
+        "X-A2A-Extensions": A2A_UCP_EXTENSION_URL,
+    }
+
+
+def _make_request(
+    action: str,
+    data: dict[str, Any] | None = None,
+    context_id: str | None = None,
+    message_id: str | None = None,
+    extra_parts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal A2A JSON-RPC request for a checkout action."""
+    action_data = {"action": action}
+    if data:
+        action_data.update(data)
+    parts: list[dict[str, Any]] = [{"type": "data", "data": action_data}]
+    if extra_parts:
+        parts.extend(extra_parts)
+    message: dict[str, Any] = {
+        "role": "user",
+        "messageId": message_id or str(uuid.uuid4()),
+        "kind": "message",
+        "parts": parts,
+    }
+    if context_id:
+        message["contextId"] = context_id
+    return {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": "message/send",
+        "params": {"message": message},
+    }
+
+
+# ===========================================================================
+# 1. JSON-RPC Envelope Validation
+# ===========================================================================
+
+
+class TestJsonRpcEnvelope:
+    def test_malformed_json_returns_parse_error(self, auth_client: TestClient) -> None:
+        response = auth_client.post(
+            "/a2a", content=b"not-json", headers={"Content-Type": "application/json"}
+        )
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == -32700
+
+    def test_missing_jsonrpc_field_returns_invalid_request(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        response = auth_client.post(
+            "/a2a",
+            json={"id": "1", "method": "message/send"},
+            headers=a2a_headers,
+        )
+        assert response.json()["error"]["code"] == -32600
+
+    def test_missing_id_field_returns_invalid_request(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        response = auth_client.post(
+            "/a2a",
+            json={"jsonrpc": "2.0", "method": "message/send"},
+            headers=a2a_headers,
+        )
+        assert response.json()["error"]["code"] == -32600
+
+    def test_wrong_method_returns_method_not_found(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        response = auth_client.post(
+            "/a2a",
+            json={"jsonrpc": "2.0", "id": "1", "method": "tasks/create"},
+            headers=a2a_headers,
+        )
+        assert response.json()["error"]["code"] == -32601
+
+
+# ===========================================================================
+# 2. Required Header Validation
+# ===========================================================================
+
+
+class TestHeaderValidation:
+    def test_missing_ucp_agent_returns_invalid_params(
+        self, auth_client: TestClient
+    ) -> None:
+        request = _make_request("create_checkout", {"product_id": "prod_1"})
+        response = auth_client.post(
+            "/a2a",
+            json=request,
+            headers={"X-A2A-Extensions": A2A_UCP_EXTENSION_URL},
+        )
+        body = response.json()
+        assert body["error"]["code"] == -32602
+        assert "UCP-Agent" in body["error"]["data"]["detail"]
+
+    def test_missing_x_a2a_extensions_returns_invalid_params(
+        self, auth_client: TestClient
+    ) -> None:
+        request = _make_request("create_checkout", {"product_id": "prod_1"})
+        response = auth_client.post(
+            "/a2a",
+            json=request,
+            headers={"UCP-Agent": 'profile="https://platform.example/p"'},
+        )
+        body = response.json()
+        assert body["error"]["code"] == -32602
+        assert "X-A2A-Extensions" in body["error"]["data"]["detail"]
+
+    def test_wrong_extension_uri_returns_invalid_params(
+        self, auth_client: TestClient
+    ) -> None:
+        request = _make_request("create_checkout", {"product_id": "prod_1"})
+        response = auth_client.post(
+            "/a2a",
+            json=request,
+            headers={
+                "UCP-Agent": 'profile="https://platform.example/p"',
+                "X-A2A-Extensions": "https://other.dev/wrong",
+            },
+        )
+        body = response.json()
+        assert body["error"]["code"] == -32602
+
+    def test_unauthenticated_request_returns_401(
+        self, client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        request = _make_request("create_checkout", {"product_id": "prod_1"})
+        response = client.post("/a2a", json=request, headers=a2a_headers)
+        assert response.status_code == 401
+
+
+# ===========================================================================
+# 3. Checkout Actions (happy path)
+# ===========================================================================
+
+
+class TestCheckoutActions:
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_create_checkout(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        request = _make_request("create_checkout", {"product_id": "prod_1"})
+        response = auth_client.post("/a2a", json=request, headers=a2a_headers)
+
+        body = response.json()
+        assert "error" not in body
+        result = body["result"]
+        assert result["role"] == "agent"
+        assert result["kind"] == "message"
+        assert "contextId" in result
+
+        checkout = result["parts"][0]["data"]["a2a.ucp.checkout"]
+        assert checkout["status"] == "incomplete"
+        assert checkout["id"]
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_get_checkout(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        # Create first
+        create_req = _make_request("create_checkout", {"product_id": "prod_1"})
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        # Get
+        get_req = _make_request("get_checkout", context_id=ctx)
+        get_resp = auth_client.post("/a2a", json=get_req, headers=a2a_headers)
+
+        body = get_resp.json()
+        assert "error" not in body
+        checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
+        assert checkout["id"]
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_add_to_checkout(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        # Create
+        create_req = _make_request("create_checkout", {"product_id": "prod_1"})
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        # Add another product
+        add_req = _make_request(
+            "add_to_checkout",
+            {"product_id": "prod_2", "quantity": 2},
+            context_id=ctx,
+        )
+        add_resp = auth_client.post("/a2a", json=add_req, headers=a2a_headers)
+
+        body = add_resp.json()
+        assert "error" not in body
+        checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
+        assert len(checkout["line_items"]) == 2
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_cancel_checkout(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        create_req = _make_request("create_checkout", {"product_id": "prod_1"})
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        cancel_req = _make_request("cancel_checkout", context_id=ctx)
+        cancel_resp = auth_client.post("/a2a", json=cancel_req, headers=a2a_headers)
+
+        body = cancel_resp.json()
+        assert "error" not in body
+        checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
+        assert checkout["status"] == "canceled"
+
+
+# ===========================================================================
+# 4. Error Handling (application-level)
+# ===========================================================================
+
+
+class TestApplicationErrors:
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_get_without_context_returns_session_not_found(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        request = _make_request("get_checkout", context_id="nonexistent-ctx")
+        response = auth_client.post("/a2a", json=request, headers=a2a_headers)
+        assert response.json()["error"]["code"] == -32000
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_unknown_action_returns_invalid_params(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        request = _make_request("unknown_action")
+        response = auth_client.post("/a2a", json=request, headers=a2a_headers)
+        assert response.json()["error"]["code"] == -32602
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_no_action_in_parts_returns_invalid_params(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        request = {
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "messageId": str(uuid.uuid4()),
+                    "kind": "message",
+                    "parts": [{"type": "text", "text": "hello"}],
+                }
+            },
+        }
+        response = auth_client.post("/a2a", json=request, headers=a2a_headers)
+        assert response.json()["error"]["code"] == -32602
+
+
+# ===========================================================================
+# 5. Context / Session Persistence
+# ===========================================================================
+
+
+class TestContextPersistence:
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_first_message_generates_context_id(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        request = _make_request("create_checkout", {"product_id": "prod_1"})
+        response = auth_client.post("/a2a", json=request, headers=a2a_headers)
+        ctx = response.json()["result"]["contextId"]
+        assert ctx  # not empty
+
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_subsequent_messages_use_same_context(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        create_req = _make_request("create_checkout", {"product_id": "prod_1"})
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        get_req = _make_request("get_checkout", context_id=ctx)
+        get_resp = auth_client.post("/a2a", json=get_req, headers=a2a_headers)
+        assert get_resp.json()["result"]["contextId"] == ctx
+
+
+# ===========================================================================
+# 6. messageId Idempotency
+# ===========================================================================
+
+
+class TestIdempotency:
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_duplicate_message_id_returns_cached_response(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        msg_id = str(uuid.uuid4())
+        request = _make_request(
+            "create_checkout", {"product_id": "prod_1"}, message_id=msg_id
+        )
+
+        resp1 = auth_client.post("/a2a", json=request, headers=a2a_headers)
+        resp2 = auth_client.post("/a2a", json=request, headers=a2a_headers)
+
+        assert resp1.json() == resp2.json()
+
+
+# ===========================================================================
+# 7. Agent Card Endpoint
+# ===========================================================================
+
+
+class TestAgentCard:
+    def test_agent_card_returns_valid_structure(self, auth_client: TestClient) -> None:
+        response = auth_client.get("/.well-known/agent-card.json")
+        assert response.status_code == 200
+
+        card = response.json()
+        assert card["name"] == "Agentic Commerce Merchant Agent"
+        assert card["protocolVersion"] == "0.3.0"
+        assert "/a2a" in card["url"]
+        assert card["capabilities"]["streaming"] is False
+
+        ext = card["capabilities"]["extensions"][0]
+        assert ext["uri"] == A2A_UCP_EXTENSION_URL
+
+        caps = ext["params"]["capabilities"]
+        assert "dev.ucp.shopping.checkout" in caps
+        assert isinstance(caps["dev.ucp.shopping.checkout"], list)
+
+    def test_agent_card_is_public(self, client: TestClient) -> None:
+        """Agent card does not require authentication."""
+        response = client.get("/.well-known/agent-card.json")
+        assert response.status_code == 200
+
+
+# ===========================================================================
+# 8. UCP Discovery includes A2A transport
+# ===========================================================================
+
+
+class TestDiscoveryA2A:
+    def test_discovery_includes_a2a_service(self, client: TestClient) -> None:
+        response = client.get("/.well-known/ucp")
+        assert response.status_code == 200
+
+        services = response.json()["ucp"]["services"]["dev.ucp.shopping"]
+        transports = [s["transport"] for s in services]
+        assert "rest" in transports
+        assert "a2a" in transports
+
+        a2a_entry = next(s for s in services if s["transport"] == "a2a")
+        assert a2a_entry["version"] == get_settings().ucp_version
+        assert a2a_entry["spec"] == "https://ucp.dev/specification/overview"
+        assert "agent-card.json" in a2a_entry["endpoint"]


### PR DESCRIPTION
## Summary

- Add A2A (Agent-to-Agent) JSON-RPC 2.0 transport for UCP checkout operations per `checkout-a2a.md` spec
- New endpoints: `POST /a2a` (JSON-RPC 2.0) and `GET /.well-known/agent-card.json` (public discovery)
- Generalize documentation to use "client agent" instead of ChatGPT-specific branding

## Test plan

- [x] 21 new unit tests (233 total, 0 regressions)
- [x] Ruff check + format clean
- [x] Pyright 0 errors
- [x] Live curl validation: 12/12 endpoints pass (error handling, full checkout flow, idempotency)

Made with [Cursor](https://cursor.com)