### PR TITLE
[metrics] Replace mock dashboard data with live merchant and agent metrics

### DIFF
--- a/env.example
+++ b/env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # Application Settings
-DEBUG=false
+DEBUG=true
 
 # =============================================================================
 # NAT Agent Configuration (NVIDIA NeMo Agent Toolkit)

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -11,6 +11,7 @@ import contextlib
 import json
 import logging
 import os
+import time
 from collections import deque
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -147,6 +148,11 @@ class GetRecommendationsInput(BaseModel):
         default=[],
         alias="cartItems",
         description="Current cart items for context",
+    )
+    session_id: str | None = Field(
+        None,
+        alias="sessionId",
+        description="Optional cart/session identifier for attribution tracking",
     )
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
@@ -300,6 +306,11 @@ class GetRecommendationsOutput(BaseModel):
     pipelineTrace: PipelineTraceOutput | None = Field(
         None, alias="pipelineTrace", description="ARAG pipeline trace"
     )
+    recommendationRequestId: str | None = Field(
+        None,
+        alias="recommendationRequestId",
+        description="Identifier for click/purchase attribution across this recommendation set",
+    )
     error: str | None = Field(None, description="Error message if request failed")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -353,6 +364,109 @@ def _recommendations_meta() -> dict[str, Any]:
         "openai/toolInvocation/invoking": "Getting recommendations...",
         "openai/toolInvocation/invoked": "Recommendations ready",
     }
+
+
+def _classify_outcome_status(
+    *,
+    agent_type: str,
+    error_message: str | None,
+) -> tuple[str, str | None]:
+    """Map tool-level error messages to normalized outcome statuses."""
+    if not error_message:
+        return "success", None
+
+    message = error_message.lower()
+    if agent_type == "search" and "no products found" in message:
+        return "success", None
+    if "timeout" in message:
+        return "error_timeout", "timeout"
+    if "unavailable" in message or "connect" in message or "agent error" in message:
+        return "error_upstream", "upstream_error"
+    if "validation" in message:
+        return "error_validation", "validation_error"
+    return "error_internal", "internal_error"
+
+
+async def _record_apps_sdk_outcome(
+    *,
+    agent_type: str,
+    status: str,
+    latency_ms: int,
+    error_code: str | None = None,
+) -> None:
+    """Best-effort metrics handoff to Merchant API for dashboard aggregation."""
+    try:
+        async with httpx.AsyncClient(timeout=4.0) as client:
+            response = await client.post(
+                f"{settings.merchant_api_url}/metrics/agent-outcomes",
+                headers={
+                    "Authorization": f"Bearer {settings.merchant_api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "agent_type": agent_type,
+                    "channel": "apps_sdk",
+                    "status": status,
+                    "latency_ms": max(latency_ms, 0),
+                    "error_code": error_code,
+                },
+            )
+            if response.status_code >= 400:
+                logger.warning(
+                    "Failed to record %s outcome (status=%d): %s",
+                    agent_type,
+                    response.status_code,
+                    response.text,
+                )
+    except Exception as exc:
+        logger.warning("Unable to record %s outcome: %s", agent_type, exc)
+
+
+async def _record_recommendation_attribution_event(
+    *,
+    event_type: str,
+    product_id: str,
+    session_id: str | None = None,
+    recommendation_request_id: str | None = None,
+    position: int | None = None,
+    order_id: str | None = None,
+    quantity: int = 1,
+    revenue_cents: int = 0,
+    source: str = "apps_sdk",
+) -> None:
+    """Best-effort recording of recommendation attribution events."""
+    try:
+        async with httpx.AsyncClient(timeout=4.0) as client:
+            response = await client.post(
+                f"{settings.merchant_api_url}/metrics/recommendation-attribution",
+                headers={
+                    "Authorization": f"Bearer {settings.merchant_api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "event_type": event_type,
+                    "product_id": product_id,
+                    "session_id": session_id,
+                    "recommendation_request_id": recommendation_request_id,
+                    "position": position,
+                    "order_id": order_id,
+                    "quantity": max(quantity, 1),
+                    "revenue_cents": max(revenue_cents, 0),
+                    "source": source,
+                },
+            )
+            if response.status_code >= 400:
+                logger.warning(
+                    "Failed to record recommendation attribution event (%s): %s",
+                    event_type,
+                    response.text,
+                )
+    except Exception as exc:
+        logger.warning(
+            "Unable to record recommendation attribution event (%s): %s",
+            event_type,
+            exc,
+        )
 
 
 def _parse_agent_response(raw_result: Any) -> dict[str, Any]:
@@ -680,7 +794,21 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
 
     if tool_name == "search-products":
         payload = SearchProductsInput.model_validate(args)
+        started = time.perf_counter()
         result = await search_products(payload.query, payload.category, payload.limit)
+        error_message = (
+            str(result.get("error")) if result.get("error") is not None else None
+        )
+        status, error_code = _classify_outcome_status(
+            agent_type="search",
+            error_message=error_message,
+        )
+        await _record_apps_sdk_outcome(
+            agent_type="search",
+            status=status,
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            error_code=error_code,
+        )
         if result.get("error"):
             return types.ServerResult(
                 types.CallToolResult(
@@ -796,11 +924,47 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
 
     elif tool_name == "get-recommendations":
         payload = GetRecommendationsInput.model_validate(args)
+        recommendation_request_id = f"rec_{uuid4().hex[:12]}"
+        started = time.perf_counter()
         result = await call_recommendation_agent(
             payload.product_id,
             payload.product_name,
             payload.cart_items,
         )
+        error_message = (
+            str(result.get("error")) if result.get("error") is not None else None
+        )
+        status, error_code = _classify_outcome_status(
+            agent_type="recommendation",
+            error_message=error_message,
+        )
+        await _record_apps_sdk_outcome(
+            agent_type="recommendation",
+            status=status,
+            latency_ms=int((time.perf_counter() - started) * 1000),
+            error_code=error_code,
+        )
+        raw_recommendations = (
+            result.get("recommendations")
+            if isinstance(result.get("recommendations"), list)
+            else []
+        )
+        for index, rec in enumerate(raw_recommendations):
+            if not isinstance(rec, dict):
+                continue
+            product_id = rec.get("product_id") or rec.get("productId")
+            if not isinstance(product_id, str) or not product_id:
+                continue
+            position_value = rec.get("rank")
+            position = int(position_value) if isinstance(position_value, int) else index + 1
+            await _record_recommendation_attribution_event(
+                event_type="impression",
+                product_id=product_id,
+                session_id=payload.session_id,
+                recommendation_request_id=recommendation_request_id,
+                position=position,
+            )
+        result["recommendationRequestId"] = recommendation_request_id
         rec_count = len(result.get("recommendations", []))
         return types.ServerResult(
             types.CallToolResult(
@@ -1116,6 +1280,32 @@ async def clear_checkout_events() -> dict[str, str]:
 # REST API ENDPOINTS FOR WIDGET
 # =============================================================================
 # These endpoints allow the widget to make direct HTTP calls without MCP/JSON-RPC
+
+
+class RecommendationClickRequest(BaseModel):
+    """Request body for recommendation click tracking."""
+
+    product_id: str = Field(..., alias="productId")
+    recommendation_request_id: str = Field(..., alias="recommendationRequestId")
+    session_id: str | None = Field(None, alias="sessionId")
+    position: int | None = None
+    source: str = Field(default="apps_sdk_widget")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+@app.post("/recommendations/click", tags=["metrics"])
+async def api_recommendation_click(request: RecommendationClickRequest) -> dict[str, bool]:
+    """Track a recommendation click event for attribution analytics."""
+    await _record_recommendation_attribution_event(
+        event_type="click",
+        product_id=request.product_id,
+        session_id=request.session_id,
+        recommendation_request_id=request.recommendation_request_id,
+        position=request.position,
+        source=request.source,
+    )
+    return {"recorded": True}
 
 
 class CartAddRequest(BaseModel):
@@ -1617,4 +1807,36 @@ async def api_checkout(request: CartCheckoutRequest) -> dict[str, Any]:
 
     # Process checkout with customer name for personalized post-purchase messages
     result = await checkout(cart_id, customer_name=request.customer_name)
+
+    if result.get("success") is True:
+        order_id = str(result.get("orderId") or "")
+        for item in request.cart_items:
+            if not isinstance(item, dict):
+                continue
+            recommendation_request_id = item.get("recommendationRequestId") or item.get(
+                "recommendation_request_id"
+            )
+            product_id = item.get("id") or item.get("productId")
+            if not isinstance(recommendation_request_id, str) or not recommendation_request_id:
+                continue
+            if not isinstance(product_id, str) or not product_id:
+                continue
+            quantity_raw = item.get("quantity")
+            price_raw = item.get("basePrice") if "basePrice" in item else item.get("base_price")
+            quantity = quantity_raw if isinstance(quantity_raw, int) and quantity_raw > 0 else 1
+            unit_price = price_raw if isinstance(price_raw, int) and price_raw >= 0 else 0
+            position_raw = item.get("recommendationPosition")
+            position = position_raw if isinstance(position_raw, int) else None
+
+            await _record_recommendation_attribution_event(
+                event_type="purchase",
+                product_id=product_id,
+                session_id=request.cart_id,
+                recommendation_request_id=recommendation_request_id,
+                position=position,
+                order_id=order_id or None,
+                quantity=quantity,
+                revenue_cents=unit_price * quantity,
+                source="apps_sdk_checkout",
+            )
     return result

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -944,19 +944,24 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
             latency_ms=int((time.perf_counter() - started) * 1000),
             error_code=error_code,
         )
-        raw_recommendations = (
-            result.get("recommendations")
-            if isinstance(result.get("recommendations"), list)
+        raw_recommendations_value: Any = result.get("recommendations")
+        raw_recommendations: list[dict[str, Any]] = (
+            [
+                cast(dict[str, Any], rec)
+                for rec in cast(list[Any], raw_recommendations_value)
+                if isinstance(rec, dict)
+            ]
+            if isinstance(raw_recommendations_value, list)
             else []
         )
         for index, rec in enumerate(raw_recommendations):
-            if not isinstance(rec, dict):
-                continue
             product_id = rec.get("product_id") or rec.get("productId")
             if not isinstance(product_id, str) or not product_id:
                 continue
             position_value = rec.get("rank")
-            position = int(position_value) if isinstance(position_value, int) else index + 1
+            position = (
+                int(position_value) if isinstance(position_value, int) else index + 1
+            )
             await _record_recommendation_attribution_event(
                 event_type="impression",
                 product_id=product_id,
@@ -1295,7 +1300,9 @@ class RecommendationClickRequest(BaseModel):
 
 
 @app.post("/recommendations/click", tags=["metrics"])
-async def api_recommendation_click(request: RecommendationClickRequest) -> dict[str, bool]:
+async def api_recommendation_click(
+    request: RecommendationClickRequest,
+) -> dict[str, bool]:
     """Track a recommendation click event for attribution analytics."""
     await _record_recommendation_attribution_event(
         event_type="click",
@@ -1811,20 +1818,29 @@ async def api_checkout(request: CartCheckoutRequest) -> dict[str, Any]:
     if result.get("success") is True:
         order_id = str(result.get("orderId") or "")
         for item in request.cart_items:
-            if not isinstance(item, dict):
-                continue
             recommendation_request_id = item.get("recommendationRequestId") or item.get(
                 "recommendation_request_id"
             )
             product_id = item.get("id") or item.get("productId")
-            if not isinstance(recommendation_request_id, str) or not recommendation_request_id:
+            if (
+                not isinstance(recommendation_request_id, str)
+                or not recommendation_request_id
+            ):
                 continue
             if not isinstance(product_id, str) or not product_id:
                 continue
             quantity_raw = item.get("quantity")
-            price_raw = item.get("basePrice") if "basePrice" in item else item.get("base_price")
-            quantity = quantity_raw if isinstance(quantity_raw, int) and quantity_raw > 0 else 1
-            unit_price = price_raw if isinstance(price_raw, int) and price_raw >= 0 else 0
+            price_raw = (
+                item.get("basePrice") if "basePrice" in item else item.get("base_price")
+            )
+            quantity = (
+                quantity_raw
+                if isinstance(quantity_raw, int) and quantity_raw > 0
+                else 1
+            )
+            unit_price = (
+                price_raw if isinstance(price_raw, int) and price_raw >= 0 else 0
+            )
             position_raw = item.get("recommendationPosition")
             position = position_raw if isinstance(position_raw, int) else None
 

--- a/src/apps_sdk/web/src/App.tsx
+++ b/src/apps_sdk/web/src/App.tsx
@@ -134,6 +134,33 @@ export function App() {
     }
   }, []);
 
+  const trackRecommendationClick = useCallback(
+    async (product: Product) => {
+      if (!product.recommendationRequestId) {
+        return;
+      }
+      try {
+        const apiBaseUrl = getApiBaseUrl();
+        await fetch(`${apiBaseUrl}/recommendations/click`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            productId: product.id,
+            recommendationRequestId: product.recommendationRequestId,
+            sessionId: cartState.cartId || sessionId || undefined,
+            position: product.recommendationPosition,
+            source: product.recommendationSource ?? "apps_sdk_widget",
+          }),
+        });
+      } catch (error) {
+        console.warn("[Widget] Failed to track recommendation click:", error);
+      }
+    },
+    [getApiBaseUrl, cartState.cartId, sessionId]
+  );
+
   // Create or update ACP checkout session
   const syncCheckoutSession = useCallback(
     async (items: CartItem[], currentSessionId: string | null): Promise<{sessionId: string | null; sessionData: ACPSessionResponse | null}> => {
@@ -275,34 +302,50 @@ export function App() {
   }, [acpSession, cartItems, sessionId, isPendingCartUpdate]);
 
   // Add item to cart
-  const handleAddToCart = useCallback((product: Product) => {
-    setCartItems((prev) => {
-      const existingItem = prev.find((item) => item.id === product.id);
-      let newItems: CartItem[];
-      if (existingItem) {
-        newItems = prev.map((item) =>
-          item.id === product.id
-            ? { ...item, quantity: item.quantity + 1 }
-            : item
-        );
-      } else {
-        newItems = [
-          ...prev,
-          {
-            id: product.id,
-            name: product.name,
-            basePrice: product.basePrice,
-            quantity: 1,
-            variant: product.variant,
-            size: product.size,
-          },
-        ];
-      }
-      // Notify server after state update
-      notifyCartUpdate(newItems);
-      return newItems;
-    });
-  }, [notifyCartUpdate]);
+  const handleAddToCart = useCallback(
+    (product: Product) => {
+      void trackRecommendationClick(product);
+      setCartItems((prev) => {
+        const existingItem = prev.find((item) => item.id === product.id);
+        let newItems: CartItem[];
+        if (existingItem) {
+          newItems = prev.map((item) =>
+            item.id === product.id
+              ? {
+                  ...item,
+                  quantity: item.quantity + 1,
+                  recommendationRequestId:
+                    item.recommendationRequestId ?? product.recommendationRequestId,
+                  recommendationPosition:
+                    item.recommendationPosition ?? product.recommendationPosition,
+                  recommendationSource:
+                    item.recommendationSource ?? product.recommendationSource,
+                }
+              : item
+          );
+        } else {
+          newItems = [
+            ...prev,
+            {
+              id: product.id,
+              name: product.name,
+              basePrice: product.basePrice,
+              quantity: 1,
+              variant: product.variant,
+              size: product.size,
+              recommendationRequestId: product.recommendationRequestId,
+              recommendationPosition: product.recommendationPosition,
+              recommendationSource: product.recommendationSource,
+            },
+          ];
+        }
+        // Notify server after state update
+        notifyCartUpdate(newItems);
+        return newItems;
+      });
+    },
+    [notifyCartUpdate, trackRecommendationClick]
+  );
 
   // Update item quantity
   const handleUpdateQuantity = useCallback(
@@ -343,6 +386,7 @@ export function App() {
   // Navigate to product detail page
   const handleProductClick = useCallback(
     async (product: Product) => {
+      void trackRecommendationClick(product);
       setSelectedProduct(product);
       setCurrentPage("product_detail");
       setProductRecommendations([]);
@@ -360,6 +404,7 @@ export function App() {
             name: item.name,
             price: item.basePrice,
           })),
+          sessionId: cartState.cartId || sessionId || undefined,
         };
         window.parent.postMessage(message, "*");
       } catch (error) {
@@ -367,7 +412,7 @@ export function App() {
         setIsLoadingRecommendations(false);
       }
     },
-    [cartItems]
+    [cartItems, cartState.cartId, sessionId, trackRecommendationClick]
   );
 
   // Handle recommendations response from parent
@@ -392,7 +437,7 @@ export function App() {
         };
         
         const products: Product[] = event.data.recommendations?.length > 0
-          ? event.data.recommendations.map((rec: EnrichedRec) => ({
+          ? event.data.recommendations.map((rec: EnrichedRec, index: number) => ({
               id: rec.productId ?? rec.product_id ?? `prod_${Date.now()}`,
               sku: rec.sku ?? `SKU-${rec.productId ?? rec.product_id}`,
               name: rec.productName ?? rec.product_name ?? "Product",
@@ -401,6 +446,12 @@ export function App() {
               variant: "Default",
               size: "One Size",
               imageUrl: rec.image_url,
+              recommendationRequestId:
+                typeof event.data.recommendationRequestId === "string"
+                  ? (event.data.recommendationRequestId as string)
+                  : undefined,
+              recommendationPosition: typeof rec.rank === "number" ? rec.rank : index + 1,
+              recommendationSource: source,
             }))
           : [];
         
@@ -450,6 +501,7 @@ export function App() {
             name: item.name,
             price: item.basePrice,
           })),
+          sessionId: cartState.cartId || sessionId || undefined,
         };
         console.log("[Widget] Requesting checkout recommendations:", message);
         window.parent.postMessage(message, "*");
@@ -458,18 +510,28 @@ export function App() {
         setIsLoadingCheckoutRecommendations(false);
       }
     }
-  }, [cartItems]);
+  }, [cartItems, cartState.cartId, sessionId]);
 
   // Add to cart with quantity (for product detail page)
   const handleAddToCartWithQuantity = useCallback(
     (product: Product, quantity: number) => {
+      void trackRecommendationClick(product);
       setCartItems((prev) => {
         const existingItem = prev.find((item) => item.id === product.id);
         let newItems: CartItem[];
         if (existingItem) {
           newItems = prev.map((item) =>
             item.id === product.id
-              ? { ...item, quantity: item.quantity + quantity }
+              ? {
+                  ...item,
+                  quantity: item.quantity + quantity,
+                  recommendationRequestId:
+                    item.recommendationRequestId ?? product.recommendationRequestId,
+                  recommendationPosition:
+                    item.recommendationPosition ?? product.recommendationPosition,
+                  recommendationSource:
+                    item.recommendationSource ?? product.recommendationSource,
+                }
               : item
           );
         } else {
@@ -482,6 +544,9 @@ export function App() {
               quantity,
               variant: product.variant,
               size: product.size,
+              recommendationRequestId: product.recommendationRequestId,
+              recommendationPosition: product.recommendationPosition,
+              recommendationSource: product.recommendationSource,
             },
           ];
         }
@@ -490,7 +555,7 @@ export function App() {
         return newItems;
       });
     },
-    [notifyCartUpdate]
+    [notifyCartUpdate, trackRecommendationClick]
   );
 
   // Handle checkout - makes real API calls to the MCP server

--- a/src/apps_sdk/web/src/types/index.ts
+++ b/src/apps_sdk/web/src/types/index.ts
@@ -15,6 +15,9 @@ export interface Product {
   variant?: string;
   size?: string;
   imageUrl?: string;
+  recommendationRequestId?: string;
+  recommendationPosition?: number;
+  recommendationSource?: string;
 }
 
 // =============================================================================
@@ -44,6 +47,9 @@ export interface CartItem {
   variant?: string;
   size?: string;
   imageUrl?: string;
+  recommendationRequestId?: string;
+  recommendationPosition?: number;
+  recommendationSource?: string;
 }
 
 /**

--- a/src/merchant/api/metrics_schemas.py
+++ b/src/merchant/api/metrics_schemas.py
@@ -1,0 +1,232 @@
+"""Pydantic schemas for metrics dashboard endpoints."""
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DashboardTimeRange(StrEnum):
+    """Supported metrics dashboard time ranges."""
+
+    ONE_HOUR = "1h"
+    TWENTY_FOUR_HOURS = "24h"
+    SEVEN_DAYS = "7d"
+    THIRTY_DAYS = "30d"
+
+
+class KPIFormat(StrEnum):
+    """Supported KPI display formats."""
+
+    CURRENCY = "currency"
+    NUMBER = "number"
+    PERCENT = "percent"
+    DURATION = "duration"
+
+
+class KPITrend(StrEnum):
+    """KPI trend direction."""
+
+    UP = "up"
+    DOWN = "down"
+    NEUTRAL = "neutral"
+
+
+class DashboardKPI(BaseModel):
+    """Single KPI for the metrics dashboard."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: str
+    value: float
+    previous_value: float = Field(default=0)
+    format: KPIFormat
+    trend: KPITrend = KPITrend.NEUTRAL
+    trend_value: float = Field(default=0)
+
+
+class DashboardRevenuePoint(BaseModel):
+    """Revenue timeseries point."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    timestamp: str
+    revenue: int
+    orders: int
+
+
+class DashboardPromotionBreakdown(BaseModel):
+    """Promotion action breakdown."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    label: str
+    count: int
+    total_savings: int
+
+
+class DashboardAgentType(StrEnum):
+    """Agent identifiers shown in the metrics dashboard."""
+
+    PROMOTION = "promotion"
+    RECOMMENDATION = "recommendation"
+    POST_PURCHASE = "post_purchase"
+    SEARCH = "search"
+
+
+class AgentOutcomeChannel(StrEnum):
+    """Supported invocation channels."""
+
+    ACP = "acp"
+    APPS_SDK = "apps_sdk"
+    UCP = "ucp"
+
+
+class AgentOutcomeStatus(StrEnum):
+    """Normalized invocation status."""
+
+    SUCCESS = "success"
+    FALLBACK_SUCCESS = "fallback_success"
+    ERROR_TIMEOUT = "error_timeout"
+    ERROR_UPSTREAM = "error_upstream"
+    ERROR_VALIDATION = "error_validation"
+    ERROR_INTERNAL = "error_internal"
+
+
+class DashboardAgentOutcome(BaseModel):
+    """Application-layer agent outcome summary."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_type: DashboardAgentType
+    total_calls: int
+    errors: int
+    success_rate: float | None = None
+    source: str = Field(
+        default="application",
+        description="application when calculated from merchant outcomes, unavailable otherwise",
+    )
+
+
+class RecordAgentOutcomeRequest(BaseModel):
+    """Request payload for recording agent invocation outcomes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_type: DashboardAgentType
+    channel: AgentOutcomeChannel = AgentOutcomeChannel.ACP
+    status: AgentOutcomeStatus
+    latency_ms: int = Field(default=0, ge=0)
+    request_id: str | None = None
+    session_id: str | None = None
+    error_code: str | None = None
+
+
+class RecordAgentOutcomeResponse(BaseModel):
+    """Response payload for outcome recording."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    recorded: bool
+
+
+class RecommendationAttributionEventType(StrEnum):
+    """Recommendation funnel event type."""
+
+    IMPRESSION = "impression"
+    CLICK = "click"
+    PURCHASE = "purchase"
+
+
+class RecordRecommendationAttributionRequest(BaseModel):
+    """Request payload for recommendation attribution events."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    event_type: RecommendationAttributionEventType
+    product_id: str
+    session_id: str | None = None
+    recommendation_request_id: str | None = None
+    position: int | None = None
+    order_id: str | None = None
+    quantity: int = Field(default=1, ge=1)
+    revenue_cents: int = Field(default=0, ge=0)
+    source: str = Field(default="apps_sdk")
+
+
+class RecordRecommendationAttributionResponse(BaseModel):
+    """Response payload for attribution event recording."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    recorded: bool
+
+
+class DashboardRecommendationTopProduct(BaseModel):
+    """Top converting recommended product row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    product_id: str
+    product_name: str
+    clicks: int
+    purchases: int
+    conversion_rate: float | None = None
+    attributed_revenue: int
+
+
+class DashboardRecommendationAttribution(BaseModel):
+    """Recommendation attribution funnel metrics."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    impressions: int
+    clicks: int
+    purchases: int
+    click_through_rate: float | None = None
+    conversion_rate: float | None = None
+    attributed_revenue: int
+    top_products: list[DashboardRecommendationTopProduct]
+
+
+class DashboardProductHealth(BaseModel):
+    """Product health row for the metrics table."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    sku: str
+    stock_level: int
+    stock_status: str
+    base_price: int
+    competitor_price: int | None = None
+    price_position: str
+    needs_attention: bool
+    attention_reason: str | None = None
+
+
+class DashboardEffectiveWindow(BaseModel):
+    """Effective time window used for metrics aggregation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    requested_time_range: DashboardTimeRange
+    start: str
+    end: str
+    fallback_applied: bool
+
+
+class DashboardMetricsResponse(BaseModel):
+    """Metrics dashboard response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    effective_window: DashboardEffectiveWindow
+    kpis: list[DashboardKPI]
+    revenue_data: list[DashboardRevenuePoint]
+    agent_outcomes: list[DashboardAgentOutcome]
+    recommendation_attribution: DashboardRecommendationAttribution
+    promotion_breakdown: list[DashboardPromotionBreakdown]
+    product_health: list[DashboardProductHealth]

--- a/src/merchant/api/routes/metrics.py
+++ b/src/merchant/api/routes/metrics.py
@@ -1,0 +1,105 @@
+"""Metrics dashboard API routes."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session
+
+from src.merchant.api.dependencies import verify_api_key
+from src.merchant.api.metrics_schemas import (
+    DashboardMetricsResponse,
+    DashboardTimeRange,
+    RecordAgentOutcomeRequest,
+    RecordAgentOutcomeResponse,
+    RecordRecommendationAttributionRequest,
+    RecordRecommendationAttributionResponse,
+)
+from src.merchant.db.database import get_session
+from src.merchant.services.agent_outcomes import record_agent_outcome
+from src.merchant.services.metrics import get_dashboard_metrics
+from src.merchant.services.recommendation_attribution import (
+    record_recommendation_attribution_event,
+)
+
+router = APIRouter(
+    prefix="/metrics",
+    tags=["metrics"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+@router.get(
+    "/dashboard",
+    response_model=DashboardMetricsResponse,
+    summary="Get Metrics Dashboard Data",
+    description="Return aggregated commerce metrics for the dashboard.",
+)
+def get_metrics_dashboard(
+    time_range: DashboardTimeRange = DashboardTimeRange.TWENTY_FOUR_HOURS,
+    db: Session = Depends(get_session),
+) -> DashboardMetricsResponse:
+    """Get dashboard metrics for the requested time range."""
+    data = get_dashboard_metrics(db, time_range)
+    return DashboardMetricsResponse.model_validate(data)
+
+
+@router.post(
+    "/agent-outcomes",
+    response_model=RecordAgentOutcomeResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record Agent Invocation Outcome",
+    description="Record application-layer success/error outcomes for agent calls.",
+)
+def post_agent_outcome(
+    payload: RecordAgentOutcomeRequest,
+    db: Session = Depends(get_session),
+) -> RecordAgentOutcomeResponse:
+    """Persist one agent invocation outcome."""
+    persisted = record_agent_outcome(
+        db=db,
+        auto_commit=True,
+        agent_type=payload.agent_type.value,
+        channel=payload.channel.value,
+        status=payload.status.value,
+        latency_ms=payload.latency_ms,
+        request_id=payload.request_id,
+        session_id=payload.session_id,
+        error_code=payload.error_code,
+    )
+    if not persisted:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to record agent outcome",
+        )
+    return RecordAgentOutcomeResponse(recorded=True)
+
+
+@router.post(
+    "/recommendation-attribution",
+    response_model=RecordRecommendationAttributionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record Recommendation Attribution Event",
+    description="Record impression/click/purchase events for recommendation conversion analytics.",
+)
+def post_recommendation_attribution(
+    payload: RecordRecommendationAttributionRequest,
+    db: Session = Depends(get_session),
+) -> RecordRecommendationAttributionResponse:
+    """Persist one recommendation attribution event."""
+    persisted = record_recommendation_attribution_event(
+        db=db,
+        auto_commit=True,
+        event_type=payload.event_type.value,
+        product_id=payload.product_id,
+        session_id=payload.session_id,
+        recommendation_request_id=payload.recommendation_request_id,
+        position=payload.position,
+        order_id=payload.order_id,
+        quantity=payload.quantity,
+        revenue_cents=payload.revenue_cents,
+        source=payload.source,
+    )
+    if not persisted:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to record recommendation attribution event",
+        )
+    return RecordRecommendationAttributionResponse(recorded=True)

--- a/src/merchant/db/models.py
+++ b/src/merchant/db/models.py
@@ -21,6 +21,33 @@ class CheckoutStatus(StrEnum):
     CANCELED = "canceled"
 
 
+class AgentInvocationStatus(StrEnum):
+    """Normalized status for recorded agent invocations."""
+
+    SUCCESS = "success"
+    FALLBACK_SUCCESS = "fallback_success"
+    ERROR_TIMEOUT = "error_timeout"
+    ERROR_UPSTREAM = "error_upstream"
+    ERROR_VALIDATION = "error_validation"
+    ERROR_INTERNAL = "error_internal"
+
+
+class AgentInvocationChannel(StrEnum):
+    """Invocation channel for agent calls."""
+
+    ACP = "acp"
+    APPS_SDK = "apps_sdk"
+    UCP = "ucp"
+
+
+class RecommendationAttributionEventType(StrEnum):
+    """Lifecycle events for recommendation attribution."""
+
+    IMPRESSION = "impression"
+    CLICK = "click"
+    PURCHASE = "purchase"
+
+
 class Customer(SQLModel, table=True):
     """Customer model representing shoppers in the system.
 
@@ -168,3 +195,41 @@ class CheckoutSession(SQLModel, table=True):
     created_at: datetime = Field(default_factory=_utc_now)
     updated_at: datetime = Field(default_factory=_utc_now)
     expires_at: datetime | None = Field(default=None)
+
+
+class AgentInvocationOutcome(SQLModel, table=True):
+    """Recorded outcome for each agent invocation."""
+
+    __tablename__: ClassVar[str] = "agent_invocation_outcome"  # type: ignore[assignment]
+
+    id: int | None = Field(default=None, primary_key=True)
+    timestamp: datetime = Field(default_factory=_utc_now, index=True)
+    agent_type: str = Field(index=True)
+    channel: AgentInvocationChannel = Field(default=AgentInvocationChannel.ACP, index=True)
+    status: AgentInvocationStatus = Field(default=AgentInvocationStatus.SUCCESS, index=True)
+    latency_ms: int = Field(default=0)
+
+    request_id: str | None = Field(default=None, index=True)
+    session_id: str | None = Field(default=None, index=True)
+    error_code: str | None = Field(default=None, index=True)
+
+
+class RecommendationAttributionEvent(SQLModel, table=True):
+    """Recommendation attribution event for conversion funnel analytics."""
+
+    __tablename__: ClassVar[str] = "recommendation_attribution_event"  # type: ignore[assignment]
+
+    id: int | None = Field(default=None, primary_key=True)
+    timestamp: datetime = Field(default_factory=_utc_now, index=True)
+    event_type: RecommendationAttributionEventType = Field(
+        default=RecommendationAttributionEventType.IMPRESSION,
+        index=True,
+    )
+    session_id: str | None = Field(default=None, index=True)
+    recommendation_request_id: str | None = Field(default=None, index=True)
+    product_id: str = Field(index=True)
+    position: int | None = Field(default=None)
+    order_id: str | None = Field(default=None, index=True)
+    quantity: int = Field(default=1)
+    revenue_cents: int = Field(default=0)
+    source: str = Field(default="apps_sdk", index=True)

--- a/src/merchant/db/models.py
+++ b/src/merchant/db/models.py
@@ -205,8 +205,12 @@ class AgentInvocationOutcome(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     timestamp: datetime = Field(default_factory=_utc_now, index=True)
     agent_type: str = Field(index=True)
-    channel: AgentInvocationChannel = Field(default=AgentInvocationChannel.ACP, index=True)
-    status: AgentInvocationStatus = Field(default=AgentInvocationStatus.SUCCESS, index=True)
+    channel: AgentInvocationChannel = Field(
+        default=AgentInvocationChannel.ACP, index=True
+    )
+    status: AgentInvocationStatus = Field(
+        default=AgentInvocationStatus.SUCCESS, index=True
+    )
     latency_ms: int = Field(default=0)
 
     request_id: str | None = Field(default=None, index=True)

--- a/src/merchant/main.py
+++ b/src/merchant/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.merchant.api.routes.checkout import router as checkout_router
 from src.merchant.api.routes.health import router as health_router
+from src.merchant.api.routes.metrics import router as metrics_router
 from src.merchant.api.routes.products import router as products_router
 from src.merchant.api.routes.ucp.a2a import router as ucp_a2a_router
 from src.merchant.api.routes.ucp.agent_card import router as ucp_agent_card_router
@@ -102,6 +103,7 @@ app.add_middleware(RequestLoggingMiddleware)
 # Include routers
 app.include_router(health_router)
 app.include_router(checkout_router)
+app.include_router(metrics_router)
 app.include_router(products_router)
 app.include_router(ucp_discovery_router)
 app.include_router(ucp_checkout_router)

--- a/src/merchant/services/agent_outcomes.py
+++ b/src/merchant/services/agent_outcomes.py
@@ -18,7 +18,12 @@ from src.merchant.middleware.logging import get_request_id
 
 logger = logging.getLogger(__name__)
 
-AGENT_TYPES: tuple[str, ...] = ("promotion", "recommendation", "post_purchase", "search")
+AGENT_TYPES: tuple[str, ...] = (
+    "promotion",
+    "recommendation",
+    "post_purchase",
+    "search",
+)
 
 
 def _to_utc(dt: datetime) -> datetime:
@@ -85,7 +90,9 @@ def record_agent_outcome(
 
     Returns True if the outcome was persisted, False when best-effort recording fails.
     """
-    effective_request_id = request_id if request_id is not None else get_request_id() or None
+    effective_request_id = (
+        request_id if request_id is not None else get_request_id() or None
+    )
 
     try:
         if db is None:
@@ -150,7 +157,9 @@ def summarize_agent_outcomes(
             continue
         aggregate = aggregates[agent_type]
         aggregate["total_calls"] += 1
-        status_value = str(row.status.value if hasattr(row.status, "value") else row.status)
+        status_value = str(
+            row.status.value if hasattr(row.status, "value") else row.status
+        )
         if status_value.startswith("error"):
             aggregate["errors"] += 1
 
@@ -160,7 +169,9 @@ def summarize_agent_outcomes(
         total_calls = int(aggregate["total_calls"])
         errors = int(aggregate["errors"])
         if total_calls > 0:
-            aggregate["success_rate"] = round(((total_calls - errors) / total_calls) * 100, 1)
+            aggregate["success_rate"] = round(
+                ((total_calls - errors) / total_calls) * 100, 1
+            )
             aggregate["source"] = "application"
         ordered.append(aggregate)
 

--- a/src/merchant/services/agent_outcomes.py
+++ b/src/merchant/services/agent_outcomes.py
@@ -1,0 +1,167 @@
+"""Service helpers for recording and aggregating agent invocation outcomes."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlmodel import Session, select
+
+from src.merchant.db.database import get_engine
+from src.merchant.db.models import (
+    AgentInvocationChannel,
+    AgentInvocationOutcome,
+    AgentInvocationStatus,
+)
+from src.merchant.middleware.logging import get_request_id
+
+logger = logging.getLogger(__name__)
+
+AGENT_TYPES: tuple[str, ...] = ("promotion", "recommendation", "post_purchase", "search")
+
+
+def _to_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _normalize_status(status: str) -> AgentInvocationStatus:
+    try:
+        return AgentInvocationStatus(status)
+    except ValueError:
+        return AgentInvocationStatus.ERROR_INTERNAL
+
+
+def _normalize_channel(channel: str) -> AgentInvocationChannel:
+    try:
+        return AgentInvocationChannel(channel)
+    except ValueError:
+        return AgentInvocationChannel.ACP
+
+
+def _insert_outcome(
+    db: Session,
+    *,
+    agent_type: str,
+    channel: str,
+    status: str,
+    latency_ms: int,
+    request_id: str | None,
+    session_id: str | None,
+    error_code: str | None,
+    auto_commit: bool,
+) -> None:
+    outcome = AgentInvocationOutcome(
+        agent_type=agent_type,
+        channel=_normalize_channel(channel),
+        status=_normalize_status(status),
+        latency_ms=max(latency_ms, 0),
+        request_id=request_id,
+        session_id=session_id,
+        error_code=error_code,
+    )
+    db.add(outcome)
+    if auto_commit:
+        db.commit()
+    else:
+        db.flush()
+
+
+def record_agent_outcome(
+    *,
+    agent_type: str,
+    channel: str,
+    status: str,
+    latency_ms: int,
+    request_id: str | None = None,
+    session_id: str | None = None,
+    error_code: str | None = None,
+    db: Session | None = None,
+    auto_commit: bool = True,
+) -> bool:
+    """Record a single agent invocation outcome.
+
+    Returns True if the outcome was persisted, False when best-effort recording fails.
+    """
+    effective_request_id = request_id if request_id is not None else get_request_id() or None
+
+    try:
+        if db is None:
+            with Session(get_engine()) as local_db:
+                _insert_outcome(
+                    local_db,
+                    agent_type=agent_type,
+                    channel=channel,
+                    status=status,
+                    latency_ms=latency_ms,
+                    request_id=effective_request_id,
+                    session_id=session_id,
+                    error_code=error_code,
+                    auto_commit=True,
+                )
+        else:
+            _insert_outcome(
+                db,
+                agent_type=agent_type,
+                channel=channel,
+                status=status,
+                latency_ms=latency_ms,
+                request_id=effective_request_id,
+                session_id=session_id,
+                error_code=error_code,
+                auto_commit=auto_commit,
+            )
+    except Exception as exc:
+        if db is not None:
+            db.rollback()
+        logger.warning("Failed to persist agent outcome (%s): %s", agent_type, exc)
+        return False
+
+    return True
+
+
+def summarize_agent_outcomes(
+    db: Session, *, start: datetime, end: datetime
+) -> list[dict[str, Any]]:
+    """Summarize invocation outcomes for dashboard consumption."""
+    rows = db.exec(
+        select(AgentInvocationOutcome).where(
+            AgentInvocationOutcome.timestamp >= _to_utc(start),
+            AgentInvocationOutcome.timestamp < _to_utc(end),
+        )
+    ).all()
+
+    aggregates: dict[str, dict[str, Any]] = {
+        agent_type: {
+            "agent_type": agent_type,
+            "total_calls": 0,
+            "errors": 0,
+            "success_rate": None,
+            "source": "unavailable",
+        }
+        for agent_type in AGENT_TYPES
+    }
+
+    for row in rows:
+        agent_type = str(row.agent_type)
+        if agent_type not in aggregates:
+            continue
+        aggregate = aggregates[agent_type]
+        aggregate["total_calls"] += 1
+        status_value = str(row.status.value if hasattr(row.status, "value") else row.status)
+        if status_value.startswith("error"):
+            aggregate["errors"] += 1
+
+    ordered: list[dict[str, Any]] = []
+    for agent_type in AGENT_TYPES:
+        aggregate = aggregates[agent_type]
+        total_calls = int(aggregate["total_calls"])
+        errors = int(aggregate["errors"])
+        if total_calls > 0:
+            aggregate["success_rate"] = round(((total_calls - errors) / total_calls) * 100, 1)
+            aggregate["source"] = "application"
+        ordered.append(aggregate)
+
+    return ordered

--- a/src/merchant/services/metrics.py
+++ b/src/merchant/services/metrics.py
@@ -1,0 +1,500 @@
+"""Service layer for dashboard metrics aggregation."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlmodel import Session, select
+
+from src.merchant.api.metrics_schemas import DashboardTimeRange
+from src.merchant.db.models import CheckoutSession, CompetitorPrice, Product
+from src.merchant.services.agent_outcomes import summarize_agent_outcomes
+from src.merchant.services.recommendation_attribution import (
+    summarize_recommendation_attribution,
+)
+
+_TIME_RANGE_TO_DURATION: dict[DashboardTimeRange, timedelta] = {
+    DashboardTimeRange.ONE_HOUR: timedelta(hours=1),
+    DashboardTimeRange.TWENTY_FOUR_HOURS: timedelta(hours=24),
+    DashboardTimeRange.SEVEN_DAYS: timedelta(days=7),
+    DashboardTimeRange.THIRTY_DAYS: timedelta(days=30),
+}
+
+_TIME_RANGE_TO_INTERVAL: dict[DashboardTimeRange, timedelta] = {
+    DashboardTimeRange.ONE_HOUR: timedelta(minutes=5),
+    DashboardTimeRange.TWENTY_FOUR_HOURS: timedelta(hours=1),
+    DashboardTimeRange.SEVEN_DAYS: timedelta(days=1),
+    DashboardTimeRange.THIRTY_DAYS: timedelta(days=1),
+}
+
+_PROMO_LABELS: dict[str, str] = {
+    "DISCOUNT_5_PCT": "5% Discount",
+    "DISCOUNT_10_PCT": "10% Discount",
+    "DISCOUNT_15_PCT": "15% Discount",
+    "DISCOUNT_20_PCT": "20% Discount",
+    "NO_PROMO": "No Promotion",
+}
+
+_PROMOTION_FAILURE_MARKERS = (
+    "agent unavailable",
+    "failed to connect",
+    "timed out",
+    "timeout",
+    "unexpected error",
+    "error:",
+)
+
+
+def get_dashboard_metrics(db: Session, time_range: DashboardTimeRange) -> dict[str, Any]:
+    """Build metrics dashboard aggregates for the requested time range."""
+    now = datetime.now(UTC)
+    duration = _TIME_RANGE_TO_DURATION[time_range]
+    interval = _TIME_RANGE_TO_INTERVAL[time_range]
+    requested_start = now - duration
+    requested_end = now
+
+    sessions = db.exec(select(CheckoutSession)).all()
+    products = db.exec(select(Product)).all()
+    competitor_prices = db.exec(select(CompetitorPrice)).all()
+
+    window_start, window_end, fallback_applied = _resolve_effective_window(
+        sessions=sessions,
+        now=now,
+        duration=duration,
+    )
+
+    previous_start = window_start - duration
+    previous_end = window_start
+
+    current_sessions = _sessions_in_window(sessions, window_start, window_end)
+    previous_sessions = _sessions_in_window(sessions, previous_start, previous_end)
+
+    current_completed = [s for s in current_sessions if _is_completed_status(s.status)]
+    previous_completed = [s for s in previous_sessions if _is_completed_status(s.status)]
+
+    revenue = _sum_revenue(current_completed)
+    previous_revenue = _sum_revenue(previous_completed)
+    orders = len(current_completed)
+    previous_orders = len(previous_completed)
+    conversion = _calculate_conversion_rate(current_sessions, current_completed)
+    previous_conversion = _calculate_conversion_rate(previous_sessions, previous_completed)
+    aov = (revenue / orders) if orders > 0 else 0.0
+    previous_aov = (previous_revenue / previous_orders) if previous_orders > 0 else 0.0
+
+    # Agent outcomes should reflect the user-selected window even when KPI
+    # revenue falls back to the latest completed-checkout window.
+    outcome_window_start = requested_start
+    outcome_window_end = requested_end
+    outcome_sessions = _sessions_in_window(
+        sessions, outcome_window_start, outcome_window_end
+    )
+
+    aggregated_outcomes = summarize_agent_outcomes(
+        db,
+        start=outcome_window_start,
+        end=outcome_window_end,
+    )
+    aggregated_outcomes = _merge_with_legacy_promotion_outcomes(
+        aggregated_outcomes=aggregated_outcomes,
+        sessions=outcome_sessions,
+    )
+    recommendation_attribution = summarize_recommendation_attribution(
+        db,
+        start=requested_start,
+        end=requested_end,
+    )
+
+    return {
+        "effective_window": {
+            "requested_time_range": time_range.value,
+            "start": window_start.isoformat(),
+            "end": window_end.isoformat(),
+            "fallback_applied": fallback_applied,
+        },
+        "kpis": [
+            _build_kpi(
+                kpi_id="revenue",
+                label="Revenue",
+                value=float(revenue),
+                previous_value=float(previous_revenue),
+                value_format="currency",
+            ),
+            _build_kpi(
+                kpi_id="orders",
+                label="Orders",
+                value=float(orders),
+                previous_value=float(previous_orders),
+                value_format="number",
+            ),
+            _build_kpi(
+                kpi_id="conversion",
+                label="Conv. Rate",
+                value=float(conversion),
+                previous_value=float(previous_conversion),
+                value_format="percent",
+            ),
+            _build_kpi(
+                kpi_id="aov",
+                label="Avg Order",
+                value=float(round(aov)),
+                previous_value=float(round(previous_aov)),
+                value_format="currency",
+            ),
+        ],
+        "revenue_data": _build_revenue_series(
+            sessions=current_completed,
+            start=window_start,
+            end=window_end,
+            interval=interval,
+        ),
+        "agent_outcomes": aggregated_outcomes,
+        "recommendation_attribution": recommendation_attribution,
+        "promotion_breakdown": _build_promotion_breakdown(current_completed),
+        "product_health": _build_product_health(products, competitor_prices),
+    }
+
+
+def _to_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _is_completed_status(status: Any) -> bool:
+    status_value = str(status.value) if hasattr(status, "value") else str(status)
+    return status_value.lower() == "completed"
+
+
+def _sessions_in_window(
+    sessions: list[CheckoutSession], start: datetime, end: datetime
+) -> list[CheckoutSession]:
+    result: list[CheckoutSession] = []
+    for session in sessions:
+        updated_at = _to_utc(session.updated_at)
+        if start <= updated_at < end:
+            result.append(session)
+    return result
+
+
+def _resolve_effective_window(
+    sessions: list[CheckoutSession], now: datetime, duration: timedelta
+) -> tuple[datetime, datetime, bool]:
+    requested_end = now
+    requested_start = requested_end - duration
+    requested_sessions = _sessions_in_window(sessions, requested_start, requested_end)
+
+    if any(_is_completed_status(s.status) for s in requested_sessions):
+        return requested_start, requested_end, False
+
+    max_lookback = timedelta(days=90)
+    max_steps = max(1, int(max_lookback / duration))
+
+    for step in range(1, max_steps + 1):
+        candidate_end = requested_start - (duration * (step - 1))
+        candidate_start = candidate_end - duration
+        candidate_sessions = _sessions_in_window(sessions, candidate_start, candidate_end)
+        if any(_is_completed_status(s.status) for s in candidate_sessions):
+            return candidate_start, candidate_end, True
+
+    return requested_start, requested_end, False
+
+
+def _extract_total_amount(totals_json: str) -> int:
+    try:
+        parsed = json.loads(totals_json)
+    except json.JSONDecodeError:
+        return 0
+
+    if isinstance(parsed, list):
+        for total_line in parsed:
+            if (
+                isinstance(total_line, dict)
+                and str(total_line.get("type", "")).lower() == "total"
+                and isinstance(total_line.get("amount"), (int, float))
+            ):
+                return int(total_line["amount"])
+        return 0
+
+    if isinstance(parsed, dict):
+        amount = parsed.get("total")
+        if isinstance(amount, (int, float)):
+            return int(amount)
+
+    return 0
+
+
+def _sum_revenue(sessions: list[CheckoutSession]) -> int:
+    return sum(_extract_total_amount(session.totals_json) for session in sessions)
+
+
+def _calculate_conversion_rate(
+    all_sessions: list[CheckoutSession], completed_sessions: list[CheckoutSession]
+) -> float:
+    if not all_sessions:
+        return 0.0
+    return round((len(completed_sessions) / len(all_sessions)) * 100, 2)
+
+
+def _trend(current: float, previous: float) -> tuple[str, float]:
+    if previous <= 0:
+        return "neutral", 0.0
+    delta_percent = ((current - previous) / previous) * 100
+    rounded = round(delta_percent, 1)
+    if abs(rounded) < 0.1:
+        return "neutral", 0.0
+    return ("up" if rounded > 0 else "down"), rounded
+
+
+def _build_kpi(
+    kpi_id: str,
+    label: str,
+    value: float,
+    previous_value: float,
+    value_format: str,
+) -> dict[str, Any]:
+    trend_direction, trend_value = _trend(value, previous_value)
+    return {
+        "id": kpi_id,
+        "label": label,
+        "value": value,
+        "previous_value": previous_value,
+        "format": value_format,
+        "trend": trend_direction,
+        "trend_value": trend_value,
+    }
+
+
+def _build_revenue_series(
+    sessions: list[CheckoutSession],
+    start: datetime,
+    end: datetime,
+    interval: timedelta,
+) -> list[dict[str, Any]]:
+    bucket_count = int((end - start) / interval)
+    if bucket_count <= 0:
+        return []
+
+    buckets: list[dict[str, Any]] = []
+    for i in range(bucket_count):
+        bucket_start = start + (interval * i)
+        buckets.append(
+            {
+                "timestamp": bucket_start.isoformat(),
+                "revenue": 0,
+                "orders": 0,
+            }
+        )
+
+    for session in sessions:
+        session_time = _to_utc(session.updated_at)
+        if session_time < start or session_time >= end:
+            continue
+
+        bucket_index = int((session_time - start) / interval)
+        if 0 <= bucket_index < bucket_count:
+            buckets[bucket_index]["orders"] += 1
+            buckets[bucket_index]["revenue"] += _extract_total_amount(
+                session.totals_json
+            )
+
+    return buckets
+
+
+def _extract_line_items(line_items_json: str) -> list[dict[str, Any]]:
+    try:
+        parsed = json.loads(line_items_json)
+    except json.JSONDecodeError:
+        return []
+    if isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)]
+    return []
+
+
+def _build_promotion_breakdown(sessions: list[CheckoutSession]) -> list[dict[str, Any]]:
+    counts: defaultdict[str, int] = defaultdict(int)
+    savings: defaultdict[str, int] = defaultdict(int)
+
+    for session in sessions:
+        for item in _extract_line_items(session.line_items_json):
+            promotion = item.get("promotion")
+            action = "NO_PROMO"
+            if isinstance(promotion, dict):
+                action = str(promotion.get("action", "NO_PROMO"))
+            counts[action] += 1
+            if isinstance(item.get("discount"), (int, float)):
+                savings[action] += int(item["discount"])
+
+    if not counts:
+        counts["NO_PROMO"] = 0
+        savings["NO_PROMO"] = 0
+
+    ordered_actions = sorted(
+        counts.keys(), key=lambda action: (action == "NO_PROMO", action)
+    )
+    return [
+        {
+            "type": action,
+            "label": _PROMO_LABELS.get(action, action.replace("_", " ").title()),
+            "count": counts[action],
+            "total_savings": savings[action],
+        }
+        for action in ordered_actions
+    ]
+
+
+def _success_rate(total_calls: int, errors: int) -> float | None:
+    if total_calls <= 0:
+        return None
+    successes = total_calls - errors
+    return round((successes / total_calls) * 100, 1)
+
+
+def _is_promotion_failure(promotion: dict[str, Any]) -> bool:
+    reasoning = str(promotion.get("reasoning", "")).lower()
+    if any(marker in reasoning for marker in _PROMOTION_FAILURE_MARKERS):
+        return True
+
+    reason_codes = promotion.get("reason_codes")
+    if isinstance(reason_codes, list):
+        for code in reason_codes:
+            text = str(code).upper()
+            if "ERROR" in text or "TIMEOUT" in text:
+                return True
+
+    return False
+
+
+def _build_agent_outcomes(sessions: list[CheckoutSession]) -> list[dict[str, Any]]:
+    promotion_calls = 0
+    promotion_errors = 0
+
+    for session in sessions:
+        for item in _extract_line_items(session.line_items_json):
+            promotion = item.get("promotion")
+            if not isinstance(promotion, dict):
+                continue
+            promotion_calls += 1
+            if _is_promotion_failure(promotion):
+                promotion_errors += 1
+
+    outcomes: list[dict[str, Any]] = [
+        {
+            "agent_type": "promotion",
+            "total_calls": promotion_calls,
+            "errors": promotion_errors,
+            "success_rate": _success_rate(promotion_calls, promotion_errors),
+            "source": "application",
+        },
+        {
+            "agent_type": "recommendation",
+            "total_calls": 0,
+            "errors": 0,
+            "success_rate": None,
+            "source": "unavailable",
+        },
+        {
+            "agent_type": "post_purchase",
+            "total_calls": 0,
+            "errors": 0,
+            "success_rate": None,
+            "source": "unavailable",
+        },
+        {
+            "agent_type": "search",
+            "total_calls": 0,
+            "errors": 0,
+            "success_rate": None,
+            "source": "unavailable",
+        },
+    ]
+
+    return outcomes
+
+
+def _merge_with_legacy_promotion_outcomes(
+    aggregated_outcomes: list[dict[str, Any]],
+    sessions: list[CheckoutSession],
+) -> list[dict[str, Any]]:
+    """Backfill promotion outcome from checkout line-item metadata when needed."""
+    promotion_index = next(
+        (idx for idx, item in enumerate(aggregated_outcomes) if item.get("agent_type") == "promotion"),
+        None,
+    )
+    if promotion_index is None:
+        return aggregated_outcomes
+
+    promotion_outcome = aggregated_outcomes[promotion_index]
+    if int(promotion_outcome.get("total_calls", 0)) > 0:
+        return aggregated_outcomes
+
+    legacy = _build_agent_outcomes(sessions)[0]
+    if int(legacy.get("total_calls", 0)) <= 0:
+        return aggregated_outcomes
+
+    merged = list(aggregated_outcomes)
+    merged[promotion_index] = legacy
+    return merged
+
+
+def _stock_status(stock_count: int) -> str:
+    if stock_count <= 10:
+        return "critical"
+    if stock_count <= 30:
+        return "low"
+    return "healthy"
+
+
+def _price_position(base_price: int, competitor_price: int | None) -> str:
+    if competitor_price is None:
+        return "unknown"
+    if base_price > competitor_price:
+        return "above"
+    if base_price < competitor_price:
+        return "below"
+    return "at"
+
+
+def _attention_reason(stock_status: str, price_position: str) -> str | None:
+    if stock_status == "critical":
+        return "Critical stock"
+    if stock_status == "low":
+        return "Low stock"
+    if price_position == "above":
+        return "Above market price"
+    return None
+
+
+def _build_product_health(
+    products: list[Product], competitor_prices: list[CompetitorPrice]
+) -> list[dict[str, Any]]:
+    lowest_competitor: dict[str, int] = {}
+    for competitor in competitor_prices:
+        existing = lowest_competitor.get(competitor.product_id)
+        if existing is None or competitor.price < existing:
+            lowest_competitor[competitor.product_id] = competitor.price
+
+    data: list[dict[str, Any]] = []
+    for product in sorted(products, key=lambda p: p.id):
+        competitor_price = lowest_competitor.get(product.id)
+        stock_status = _stock_status(product.stock_count)
+        price_position = _price_position(product.base_price, competitor_price)
+        reason = _attention_reason(stock_status, price_position)
+        data.append(
+            {
+                "id": product.id,
+                "name": product.name,
+                "sku": product.sku,
+                "stock_level": product.stock_count,
+                "stock_status": stock_status,
+                "base_price": product.base_price,
+                "competitor_price": competitor_price,
+                "price_position": price_position,
+                "needs_attention": reason is not None,
+                "attention_reason": reason,
+            }
+        )
+
+    return data

--- a/src/merchant/services/metrics.py
+++ b/src/merchant/services/metrics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 from sqlmodel import Session, select
 
@@ -48,7 +48,9 @@ _PROMOTION_FAILURE_MARKERS = (
 )
 
 
-def get_dashboard_metrics(db: Session, time_range: DashboardTimeRange) -> dict[str, Any]:
+def get_dashboard_metrics(
+    db: Session, time_range: DashboardTimeRange
+) -> dict[str, Any]:
     """Build metrics dashboard aggregates for the requested time range."""
     now = datetime.now(UTC)
     duration = _TIME_RANGE_TO_DURATION[time_range]
@@ -56,9 +58,9 @@ def get_dashboard_metrics(db: Session, time_range: DashboardTimeRange) -> dict[s
     requested_start = now - duration
     requested_end = now
 
-    sessions = db.exec(select(CheckoutSession)).all()
-    products = db.exec(select(Product)).all()
-    competitor_prices = db.exec(select(CompetitorPrice)).all()
+    sessions = list(db.exec(select(CheckoutSession)).all())
+    products = list(db.exec(select(Product)).all())
+    competitor_prices = list(db.exec(select(CompetitorPrice)).all())
 
     window_start, window_end, fallback_applied = _resolve_effective_window(
         sessions=sessions,
@@ -73,14 +75,18 @@ def get_dashboard_metrics(db: Session, time_range: DashboardTimeRange) -> dict[s
     previous_sessions = _sessions_in_window(sessions, previous_start, previous_end)
 
     current_completed = [s for s in current_sessions if _is_completed_status(s.status)]
-    previous_completed = [s for s in previous_sessions if _is_completed_status(s.status)]
+    previous_completed = [
+        s for s in previous_sessions if _is_completed_status(s.status)
+    ]
 
     revenue = _sum_revenue(current_completed)
     previous_revenue = _sum_revenue(previous_completed)
     orders = len(current_completed)
     previous_orders = len(previous_completed)
     conversion = _calculate_conversion_rate(current_sessions, current_completed)
-    previous_conversion = _calculate_conversion_rate(previous_sessions, previous_completed)
+    previous_conversion = _calculate_conversion_rate(
+        previous_sessions, previous_completed
+    )
     aov = (revenue / orders) if orders > 0 else 0.0
     previous_aov = (previous_revenue / previous_orders) if previous_orders > 0 else 0.0
 
@@ -195,7 +201,9 @@ def _resolve_effective_window(
     for step in range(1, max_steps + 1):
         candidate_end = requested_start - (duration * (step - 1))
         candidate_start = candidate_end - duration
-        candidate_sessions = _sessions_in_window(sessions, candidate_start, candidate_end)
+        candidate_sessions = _sessions_in_window(
+            sessions, candidate_start, candidate_end
+        )
         if any(_is_completed_status(s.status) for s in candidate_sessions):
             return candidate_start, candidate_end, True
 
@@ -209,17 +217,20 @@ def _extract_total_amount(totals_json: str) -> int:
         return 0
 
     if isinstance(parsed, list):
-        for total_line in parsed:
-            if (
-                isinstance(total_line, dict)
-                and str(total_line.get("type", "")).lower() == "total"
-                and isinstance(total_line.get("amount"), (int, float))
-            ):
-                return int(total_line["amount"])
+        parsed_list = cast(list[Any], parsed)
+        for raw_total_line in parsed_list:
+            if not isinstance(raw_total_line, dict):
+                continue
+            total_line = cast(dict[str, Any], raw_total_line)
+            total_type = total_line.get("type")
+            amount = total_line.get("amount")
+            if str(total_type).lower() == "total" and isinstance(amount, (int, float)):
+                return int(amount)
         return 0
 
     if isinstance(parsed, dict):
-        amount = parsed.get("total")
+        parsed_dict = cast(dict[str, Any], parsed)
+        amount = parsed_dict.get("total")
         if isinstance(amount, (int, float)):
             return int(amount)
 
@@ -309,7 +320,12 @@ def _extract_line_items(line_items_json: str) -> list[dict[str, Any]]:
     except json.JSONDecodeError:
         return []
     if isinstance(parsed, list):
-        return [item for item in parsed if isinstance(item, dict)]
+        items: list[dict[str, Any]] = []
+        parsed_list = cast(list[Any], parsed)
+        for raw_item in parsed_list:
+            if isinstance(raw_item, dict):
+                items.append(cast(dict[str, Any], raw_item))
+        return items
     return []
 
 
@@ -322,7 +338,8 @@ def _build_promotion_breakdown(sessions: list[CheckoutSession]) -> list[dict[str
             promotion = item.get("promotion")
             action = "NO_PROMO"
             if isinstance(promotion, dict):
-                action = str(promotion.get("action", "NO_PROMO"))
+                promotion_dict = cast(dict[str, Any], promotion)
+                action = str(promotion_dict.get("action", "NO_PROMO"))
             counts[action] += 1
             if isinstance(item.get("discount"), (int, float)):
                 savings[action] += int(item["discount"])
@@ -359,7 +376,8 @@ def _is_promotion_failure(promotion: dict[str, Any]) -> bool:
 
     reason_codes = promotion.get("reason_codes")
     if isinstance(reason_codes, list):
-        for code in reason_codes:
+        reason_codes_list = cast(list[Any], reason_codes)
+        for code in reason_codes_list:
             text = str(code).upper()
             if "ERROR" in text or "TIMEOUT" in text:
                 return True
@@ -376,8 +394,9 @@ def _build_agent_outcomes(sessions: list[CheckoutSession]) -> list[dict[str, Any
             promotion = item.get("promotion")
             if not isinstance(promotion, dict):
                 continue
+            promotion_dict = cast(dict[str, Any], promotion)
             promotion_calls += 1
-            if _is_promotion_failure(promotion):
+            if _is_promotion_failure(promotion_dict):
                 promotion_errors += 1
 
     outcomes: list[dict[str, Any]] = [
@@ -420,7 +439,11 @@ def _merge_with_legacy_promotion_outcomes(
 ) -> list[dict[str, Any]]:
     """Backfill promotion outcome from checkout line-item metadata when needed."""
     promotion_index = next(
-        (idx for idx, item in enumerate(aggregated_outcomes) if item.get("agent_type") == "promotion"),
+        (
+            idx
+            for idx, item in enumerate(aggregated_outcomes)
+            if item.get("agent_type") == "promotion"
+        ),
         None,
     )
     if promotion_index is None:

--- a/src/merchant/services/post_purchase.py
+++ b/src/merchant/services/post_purchase.py
@@ -20,12 +20,14 @@ Designed for integration with Feature 11 (Webhook Integration).
 import asyncio
 import json
 import logging
+import time
 from enum import StrEnum
 from typing import TypedDict
 
 import httpx
 
 from src.merchant.config import get_settings
+from src.merchant.services.agent_outcomes import record_agent_outcome
 
 logger = logging.getLogger(__name__)
 
@@ -419,31 +421,53 @@ async def generate_shipping_message(
     Returns:
         ShippingMessageResponse with generated or fallback message.
     """
-    if client is None:
-        settings = get_settings()
-        # Use post_purchase_agent_url if configured, otherwise fallback
-        agent_url = getattr(settings, "post_purchase_agent_url", None)
-        if agent_url:
-            client = get_post_purchase_client(
-                agent_url,
-                getattr(settings, "post_purchase_agent_timeout", 15.0),
-            )
-        else:
+    started = time.perf_counter()
+    status = "success"
+    error_code: str | None = None
+
+    try:
+        if client is None:
+            settings = get_settings()
+            # Use post_purchase_agent_url if configured, otherwise fallback
+            agent_url = getattr(settings, "post_purchase_agent_url", None)
+            if agent_url:
+                client = get_post_purchase_client(
+                    agent_url,
+                    getattr(settings, "post_purchase_agent_timeout", 15.0),
+                )
+            else:
+                logger.info(
+                    "Post-purchase agent URL not configured, using fallback template"
+                )
+                status = "fallback_success"
+                error_code = "agent_not_configured"
+                return get_fallback_message(request)
+
+        response = await client.generate_message(request)
+
+        if response is None:
             logger.info(
-                "Post-purchase agent URL not configured, using fallback template"
+                "Post-purchase agent unavailable for order %s, using fallback template",
+                request["order"]["order_id"],
             )
+            status = "fallback_success"
+            error_code = "agent_unavailable"
             return get_fallback_message(request)
 
-    response = await client.generate_message(request)
-
-    if response is None:
-        logger.info(
-            "Post-purchase agent unavailable for order %s, using fallback template",
-            request["order"]["order_id"],
+        return response
+    except Exception:
+        status = "error_internal"
+        error_code = "internal_exception"
+        raise
+    finally:
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        record_agent_outcome(
+            agent_type="post_purchase",
+            channel="acp",
+            status=status,
+            latency_ms=latency_ms,
+            error_code=error_code,
         )
-        return get_fallback_message(request)
-
-    return response
 
 
 async def generate_shipping_messages_batch(

--- a/src/merchant/services/promotion.py
+++ b/src/merchant/services/promotion.py
@@ -21,6 +21,7 @@ All prices are in CENTS (e.g., 2500 = $25.00).
 import asyncio
 import json
 import logging
+import time
 from enum import StrEnum
 from typing import Any, TypedDict
 
@@ -29,6 +30,7 @@ from sqlmodel import Session, select
 
 from src.merchant.config import get_settings
 from src.merchant.db.models import CompetitorPrice, Product
+from src.merchant.services.agent_outcomes import record_agent_outcome
 
 logger = logging.getLogger(__name__)
 
@@ -501,45 +503,68 @@ async def get_promotion_for_product(
     Returns:
         Dictionary with 'discount' (cents), 'action', 'reason_codes', 'reasoning'.
     """
-    # Layer 1: Compute context
-    context = compute_promotion_context(db, product)
+    started = time.perf_counter()
+    status = "success"
+    error_code: str | None = None
 
-    # Layer 2: Call agent
-    decision = await call_promotion_agent(context, client)
+    try:
+        # Layer 1: Compute context
+        context = compute_promotion_context(db, product)
 
-    # Default to NO_PROMO if agent unavailable
-    if decision is None:
-        action = PromotionAction.NO_PROMO.value
-        reason_codes: list[str] = []
-        reasoning = "Agent unavailable, no discount applied"
-    else:
-        action = decision["action"]
-        reason_codes = decision["reason_codes"]
-        reasoning = decision["reasoning"]
+        # Layer 2: Call agent
+        decision = await call_promotion_agent(context, client)
 
-    # Layer 3: Apply action
-    discount = apply_promotion_action(product.base_price, action)
+        # Default to NO_PROMO if agent unavailable
+        if decision is None:
+            status = "fallback_success"
+            error_code = "agent_unavailable"
+            action = PromotionAction.NO_PROMO.value
+            reason_codes: list[str] = []
+            reasoning = "Agent unavailable, no discount applied"
+        else:
+            action = decision["action"]
+            reason_codes = decision["reason_codes"]
+            reasoning = decision["reasoning"]
 
-    # Final validation (fail closed if discount violates margin)
-    if not validate_discount_against_margin(
-        product.base_price, discount, product.min_margin
-    ):
-        logger.warning(
-            "Discount %d violates margin for product %s, reverting to NO_PROMO",
-            discount,
-            product.id,
+        # Layer 3: Apply action
+        discount = apply_promotion_action(product.base_price, action)
+
+        # Final validation (fail closed if discount violates margin)
+        if not validate_discount_against_margin(
+            product.base_price, discount, product.min_margin
+        ):
+            logger.warning(
+                "Discount %d violates margin for product %s, reverting to NO_PROMO",
+                discount,
+                product.id,
+            )
+            status = "fallback_success"
+            error_code = "margin_protected"
+            discount = 0
+            action = PromotionAction.NO_PROMO.value
+            reason_codes = ["MARGIN_PROTECTED"]
+            reasoning = "Discount reverted to protect margin constraint"
+
+        return {
+            "discount": discount,
+            "action": action,
+            "reason_codes": reason_codes,
+            "reasoning": reasoning,
+        }
+    except Exception:
+        status = "error_internal"
+        error_code = "internal_exception"
+        raise
+    finally:
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        record_agent_outcome(
+            agent_type="promotion",
+            channel="acp",
+            status=status,
+            latency_ms=latency_ms,
+            session_id=None,
+            error_code=error_code,
         )
-        discount = 0
-        action = PromotionAction.NO_PROMO.value
-        reason_codes = ["MARGIN_PROTECTED"]
-        reasoning = "Discount reverted to protect margin constraint"
-
-    return {
-        "discount": discount,
-        "action": action,
-        "reason_codes": reason_codes,
-        "reasoning": reasoning,
-    }
 
 
 async def get_promotions_for_products(

--- a/src/merchant/services/recommendation_attribution.py
+++ b/src/merchant/services/recommendation_attribution.py
@@ -1,0 +1,241 @@
+"""Service helpers for recommendation attribution events and aggregates."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlmodel import Session, select
+
+from src.merchant.db.database import get_engine
+from src.merchant.db.models import (
+    Product,
+    RecommendationAttributionEvent,
+    RecommendationAttributionEventType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _to_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _normalize_event_type(event_type: str) -> RecommendationAttributionEventType:
+    try:
+        return RecommendationAttributionEventType(event_type)
+    except ValueError:
+        return RecommendationAttributionEventType.IMPRESSION
+
+
+def _insert_event(
+    db: Session,
+    *,
+    event_type: str,
+    session_id: str | None,
+    recommendation_request_id: str | None,
+    product_id: str,
+    position: int | None,
+    order_id: str | None,
+    quantity: int,
+    revenue_cents: int,
+    source: str,
+    auto_commit: bool,
+) -> None:
+    event = RecommendationAttributionEvent(
+        event_type=_normalize_event_type(event_type),
+        session_id=session_id,
+        recommendation_request_id=recommendation_request_id,
+        product_id=product_id,
+        position=position,
+        order_id=order_id,
+        quantity=max(quantity, 1),
+        revenue_cents=max(revenue_cents, 0),
+        source=source,
+    )
+    db.add(event)
+    if auto_commit:
+        db.commit()
+    else:
+        db.flush()
+
+
+def record_recommendation_attribution_event(
+    *,
+    event_type: str,
+    product_id: str,
+    session_id: str | None = None,
+    recommendation_request_id: str | None = None,
+    position: int | None = None,
+    order_id: str | None = None,
+    quantity: int = 1,
+    revenue_cents: int = 0,
+    source: str = "apps_sdk",
+    db: Session | None = None,
+    auto_commit: bool = True,
+) -> bool:
+    """Persist one recommendation attribution event.
+
+    Returns True if persisted successfully, False otherwise.
+    """
+    try:
+        if db is None:
+            with Session(get_engine()) as local_db:
+                _insert_event(
+                    local_db,
+                    event_type=event_type,
+                    session_id=session_id,
+                    recommendation_request_id=recommendation_request_id,
+                    product_id=product_id,
+                    position=position,
+                    order_id=order_id,
+                    quantity=quantity,
+                    revenue_cents=revenue_cents,
+                    source=source,
+                    auto_commit=True,
+                )
+        else:
+            _insert_event(
+                db,
+                event_type=event_type,
+                session_id=session_id,
+                recommendation_request_id=recommendation_request_id,
+                product_id=product_id,
+                position=position,
+                order_id=order_id,
+                quantity=quantity,
+                revenue_cents=revenue_cents,
+                source=source,
+                auto_commit=auto_commit,
+            )
+    except Exception as exc:
+        if db is not None:
+            db.rollback()
+        logger.warning("Failed to persist recommendation attribution event: %s", exc)
+        return False
+
+    return True
+
+
+def summarize_recommendation_attribution(
+    db: Session,
+    *,
+    start: datetime,
+    end: datetime,
+    top_limit: int = 5,
+) -> dict[str, Any]:
+    """Build recommendation attribution funnel + top converting products."""
+    rows = db.exec(
+        select(RecommendationAttributionEvent).where(
+            RecommendationAttributionEvent.timestamp >= _to_utc(start),
+            RecommendationAttributionEvent.timestamp < _to_utc(end),
+        ).order_by(
+            RecommendationAttributionEvent.timestamp,
+            RecommendationAttributionEvent.id,
+        )
+    ).all()
+
+    impressions = 0
+    clicks = 0
+    attributed_purchases = 0
+    attributed_revenue = 0
+
+    click_keys_by_session_and_request: set[tuple[str | None, str, str | None]] = set()
+    click_keys_by_request: set[tuple[str, str]] = set()
+    click_keys_by_session: set[tuple[str | None, str]] = set()
+    product_clicks: dict[str, int] = {}
+    product_purchases: dict[str, int] = {}
+    product_revenue: dict[str, int] = {}
+
+    for row in rows:
+        event_type = row.event_type
+        product_id = row.product_id
+        key_session_request = (row.session_id, product_id, row.recommendation_request_id)
+        key_request = (
+            (row.recommendation_request_id, product_id)
+            if row.recommendation_request_id
+            else None
+        )
+        key_session = (row.session_id, product_id)
+
+        if event_type == RecommendationAttributionEventType.IMPRESSION:
+            impressions += 1
+            continue
+
+        if event_type == RecommendationAttributionEventType.CLICK:
+            clicks += 1
+            click_keys_by_session_and_request.add(key_session_request)
+            click_keys_by_session.add(key_session)
+            if key_request is not None:
+                click_keys_by_request.add(key_request)
+            product_clicks[product_id] = product_clicks.get(product_id, 0) + 1
+            continue
+
+        if event_type != RecommendationAttributionEventType.PURCHASE:
+            continue
+
+        # Purchase attribution requires a prior click signal for the same
+        # recommendation request + product pair (primary), then falls back to
+        # session + product matching when request id is unavailable.
+        has_click = key_session_request in click_keys_by_session_and_request
+        if not has_click and key_request is not None:
+            has_click = key_request in click_keys_by_request
+        if not has_click:
+            has_click = key_session in click_keys_by_session
+        if not has_click:
+            continue
+
+        attributed_purchases += 1
+        attributed_revenue += max(row.revenue_cents, 0)
+        product_purchases[product_id] = product_purchases.get(product_id, 0) + 1
+        product_revenue[product_id] = product_revenue.get(product_id, 0) + max(
+            row.revenue_cents, 0
+        )
+
+    ctr = round((clicks / impressions) * 100, 1) if impressions > 0 else None
+    conversion_rate = (
+        round((attributed_purchases / clicks) * 100, 1) if clicks > 0 else None
+    )
+
+    products = db.exec(select(Product)).all()
+    names_by_id = {product.id: product.name for product in products}
+
+    top_products: list[dict[str, Any]] = []
+    for product_id, click_count in product_clicks.items():
+        purchase_count = product_purchases.get(product_id, 0)
+        revenue_cents = product_revenue.get(product_id, 0)
+        product_conversion = (
+            round((purchase_count / click_count) * 100, 1) if click_count > 0 else None
+        )
+        top_products.append(
+            {
+                "product_id": product_id,
+                "product_name": names_by_id.get(product_id, product_id),
+                "clicks": click_count,
+                "purchases": purchase_count,
+                "conversion_rate": product_conversion,
+                "attributed_revenue": revenue_cents,
+            }
+        )
+
+    top_products.sort(
+        key=lambda item: (
+            int(item["purchases"]),
+            int(item["attributed_revenue"]),
+            int(item["clicks"]),
+        ),
+        reverse=True,
+    )
+
+    return {
+        "impressions": impressions,
+        "clicks": clicks,
+        "purchases": attributed_purchases,
+        "click_through_rate": ctr,
+        "conversion_rate": conversion_rate,
+        "attributed_revenue": attributed_revenue,
+        "top_products": top_products[:top_limit],
+    }

--- a/src/merchant/services/recommendation_attribution.py
+++ b/src/merchant/services/recommendation_attribution.py
@@ -132,11 +132,9 @@ def summarize_recommendation_attribution(
         select(RecommendationAttributionEvent).where(
             RecommendationAttributionEvent.timestamp >= _to_utc(start),
             RecommendationAttributionEvent.timestamp < _to_utc(end),
-        ).order_by(
-            RecommendationAttributionEvent.timestamp,
-            RecommendationAttributionEvent.id,
         )
     ).all()
+    rows = sorted(rows, key=lambda row: (row.timestamp, row.id or 0))
 
     impressions = 0
     clicks = 0
@@ -153,7 +151,11 @@ def summarize_recommendation_attribution(
     for row in rows:
         event_type = row.event_type
         product_id = row.product_id
-        key_session_request = (row.session_id, product_id, row.recommendation_request_id)
+        key_session_request = (
+            row.session_id,
+            product_id,
+            row.recommendation_request_id,
+        )
         key_request = (
             (row.recommendation_request_id, product_id)
             if row.recommendation_request_id

--- a/src/ui/components/agent/MerchantIframeContainer.tsx
+++ b/src/ui/components/agent/MerchantIframeContainer.tsx
@@ -273,6 +273,7 @@ export function MerchantIframeContainer({
       productName: string;
       cartItems: Array<{ productId: string; name: string; price: number }>;
       source?: string;
+      sessionId?: string;
     }) => {
       const source = data.source || "product_detail";
       // Record start time for minimum delay calculation
@@ -315,6 +316,7 @@ export function MerchantIframeContainer({
           productId: data.productId,
           productName: data.productName,
           cartItems: data.cartItems,
+          sessionId: data.sessionId,
         });
 
         // Parse the result - ensure recommendations is an array
@@ -377,6 +379,10 @@ export function MerchantIframeContainer({
         const messageToSend = {
           type: "RECOMMENDATIONS_RESULT",
           source,
+          recommendationRequestId:
+            typeof result?.recommendationRequestId === "string"
+              ? result.recommendationRequestId
+              : undefined,
           recommendations: rawRecommendations,
           userIntent,
           pipelineTrace: rawPipelineTrace,
@@ -429,6 +435,7 @@ export function MerchantIframeContainer({
           productName: string;
           cartItems: Array<{ productId: string; name: string; price: number }>;
           source?: string;
+          sessionId?: string;
         } = {
           productId: message.productId as string,
           productName: message.productName as string,
@@ -437,6 +444,9 @@ export function MerchantIframeContainer({
         };
         if (message.source) {
           requestData.source = message.source as string;
+        }
+        if (message.sessionId) {
+          requestData.sessionId = message.sessionId as string;
         }
         handleRecommendationRequest(requestData);
         return;

--- a/src/ui/components/agent/SearchPromptBar.tsx
+++ b/src/ui/components/agent/SearchPromptBar.tsx
@@ -40,7 +40,7 @@ export function SearchPromptBar({ value, onChange, onSubmit }: SearchPromptBarPr
           value={value}
           onChange={handleChange}
           placeholder="show me some shoes"
-          className="nv-text-input-element px-4"
+          className="nv-text-input-element px-4 placeholder:text-white/45"
           aria-label="Search query"
         />
       </div>

--- a/src/ui/components/layout/Navbar.tsx
+++ b/src/ui/components/layout/Navbar.tsx
@@ -16,7 +16,7 @@ export function Navbar() {
     <div className="transparent-header">
       <AppBar
         slotLeft={
-          <Flex align="center" gap="3">
+          <Link href="/" className="inline-flex items-center gap-3">
             <Image
               src="/logo.png"
               alt="NVIDIA Logo"
@@ -28,7 +28,7 @@ export function Navbar() {
             <Text kind="label/semibold/md" className="text-gray-100 hidden sm:block">
               Agentic Commerce
             </Text>
-          </Flex>
+          </Link>
         }
         slotRight={
           <Flex align="center" gap="2">

--- a/src/ui/components/metrics/MetricsDashboard.tsx
+++ b/src/ui/components/metrics/MetricsDashboard.tsx
@@ -5,6 +5,7 @@ import { MetricsHeader } from "./MetricsHeader";
 import { KPIPanel } from "./panels/KPIPanel";
 import { RevenuePanel } from "./panels/RevenuePanel";
 import { AgentPerformancePanel } from "./panels/AgentPerformancePanel";
+import { RecommendationAttributionPanel } from "./panels/RecommendationAttributionPanel";
 import { PromotionPanel } from "./panels/PromotionPanel";
 import { ProductHealthPanel } from "./panels/ProductHealthPanel";
 
@@ -20,6 +21,7 @@ export function MetricsDashboard() {
     kpis,
     revenueData,
     agentPerformance,
+    recommendationAttribution,
     promotionBreakdown,
     productHealth,
   } = state;
@@ -46,6 +48,8 @@ export function MetricsDashboard() {
         <AgentPerformancePanel data={agentPerformance} isLoading={isLoading} />
         <PromotionPanel data={promotionBreakdown} isLoading={isLoading} />
       </div>
+
+      <RecommendationAttributionPanel data={recommendationAttribution} isLoading={isLoading} />
 
       {/* Product Health Table */}
       <ProductHealthPanel data={productHealth} isLoading={isLoading} />

--- a/src/ui/components/metrics/index.ts
+++ b/src/ui/components/metrics/index.ts
@@ -15,5 +15,6 @@ export { GlassPieChart } from "./charts/GlassPieChart";
 export { KPIPanel } from "./panels/KPIPanel";
 export { RevenuePanel } from "./panels/RevenuePanel";
 export { AgentPerformancePanel } from "./panels/AgentPerformancePanel";
+export { RecommendationAttributionPanel } from "./panels/RecommendationAttributionPanel";
 export { PromotionPanel } from "./panels/PromotionPanel";
 export { ProductHealthPanel } from "./panels/ProductHealthPanel";

--- a/src/ui/components/metrics/panels/AgentPerformancePanel.tsx
+++ b/src/ui/components/metrics/panels/AgentPerformancePanel.tsx
@@ -46,56 +46,65 @@ export function AgentPerformancePanel({ data, isLoading }: AgentPerformancePanel
               letterSpacing: "0.5px",
             }}
           >
-            Success Rate
+            App Success Rate
           </p>
           <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-            {data.map((agent) => (
-              <div
-                key={agent.agentType}
-                style={{ display: "flex", alignItems: "center", gap: "12px" }}
-              >
-                <span
-                  style={{
-                    fontSize: "11px",
-                    color: "rgba(255, 255, 255, 0.6)",
-                    width: "90px",
-                    flexShrink: 0,
-                  }}
-                >
-                  {agent.label.replace(" Agent", "")}
-                </span>
+            {data.map((agent) => {
+              const hasSuccessRate = agent.successRate !== null;
+              const successRate = agent.successRate ?? 0;
+              const barWidth = hasSuccessRate
+                ? `${Math.max(0, Math.min(successRate, 100))}%`
+                : "100%";
+              return (
                 <div
-                  style={{
-                    flex: 1,
-                    height: "12px",
-                    background: "rgba(255, 255, 255, 0.06)",
-                    borderRadius: "6px",
-                    overflow: "hidden",
-                  }}
+                  key={agent.agentType}
+                  style={{ display: "flex", alignItems: "center", gap: "12px" }}
                 >
+                  <span
+                    style={{
+                      fontSize: "11px",
+                      color: "rgba(255, 255, 255, 0.6)",
+                      width: "90px",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {agent.label.replace(" Agent", "")}
+                  </span>
                   <div
                     style={{
-                      width: `${agent.successRate}%`,
-                      height: "100%",
-                      background: `linear-gradient(90deg, #76b900, #5a9200)`,
+                      flex: 1,
+                      height: "12px",
+                      background: "rgba(255, 255, 255, 0.06)",
                       borderRadius: "6px",
-                      transition: "width 800ms ease",
+                      overflow: "hidden",
                     }}
-                  />
+                  >
+                    <div
+                      style={{
+                        width: barWidth,
+                        height: "100%",
+                        background: hasSuccessRate
+                          ? "linear-gradient(90deg, #76b900, #5a9200)"
+                          : "linear-gradient(90deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.08))",
+                        borderRadius: "6px",
+                        transition: "width 800ms ease",
+                      }}
+                    />
+                  </div>
+                  <span
+                    style={{
+                      fontSize: "12px",
+                      fontWeight: 700,
+                      color: "rgba(255, 255, 255, 0.9)",
+                      width: "48px",
+                      textAlign: "right",
+                    }}
+                  >
+                    {hasSuccessRate ? `${successRate.toFixed(1)}%` : "N/A"}
+                  </span>
                 </div>
-                <span
-                  style={{
-                    fontSize: "12px",
-                    fontWeight: 700,
-                    color: "rgba(255, 255, 255, 0.9)",
-                    width: "48px",
-                    textAlign: "right",
-                  }}
-                >
-                  {agent.successRate.toFixed(1)}%
-                </span>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
 
@@ -115,7 +124,7 @@ export function AgentPerformancePanel({ data, isLoading }: AgentPerformancePanel
           <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
             {data.map((agent) => {
               const maxLatency = Math.max(...data.map((d) => d.avgLatency));
-              const widthPercent = (agent.avgLatency / maxLatency) * 100;
+              const widthPercent = maxLatency > 0 ? (agent.avgLatency / maxLatency) * 100 : 0;
               return (
                 <div
                   key={agent.agentType}

--- a/src/ui/components/metrics/panels/PromotionPanel.tsx
+++ b/src/ui/components/metrics/panels/PromotionPanel.tsx
@@ -52,25 +52,26 @@ export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
     );
   }
 
-  // Transform data for pie chart
   const pieData = data.map((item) => ({
     label: item.label,
     value: item.count,
     color: item.color,
   }));
 
-  // Calculate total savings
-  const totalSavings = data.reduce((sum, item) => sum + item.totalSavings, 0);
-  const totalPromotions = data
+  const promotionSpend = data.reduce((sum, item) => sum + item.totalSavings, 0);
+  const discountedLineItems = data
     .filter((d) => d.type !== "NO_PROMO")
     .reduce((sum, d) => sum + d.count, 0);
+  const totalLineItems = data.reduce((sum, item) => sum + item.count, 0);
+  const discountCoverage =
+    totalLineItems > 0 ? Math.round((discountedLineItems / totalLineItems) * 100) : 0;
 
   return (
     <div className="chart-container">
-      <h3 className="chart-title">Promotion Breakdown</h3>
+      <h3 className="chart-title">Promotion Impact</h3>
       <GlassPieChart
         data={pieData}
-        formatValue={(v) => `${v} promotions`}
+        formatValue={(v) => `${v} line items`}
         innerRadius={50}
         outerRadius={85}
       />
@@ -80,7 +81,8 @@ export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
           paddingTop: "16px",
           borderTop: "1px solid rgba(255, 255, 255, 0.08)",
           display: "flex",
-          justifyContent: "space-around",
+          justifyContent: "space-between",
+          gap: "12px",
         }}
       >
         <div style={{ textAlign: "center" }}>
@@ -91,10 +93,10 @@ export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
               textTransform: "uppercase",
             }}
           >
-            Total Promotions
+            Discounted Items
           </p>
           <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
-            {totalPromotions.toLocaleString()}
+            {discountedLineItems.toLocaleString()}
           </p>
         </div>
         <div style={{ textAlign: "center" }}>
@@ -105,13 +107,35 @@ export function PromotionPanel({ data, isLoading }: PromotionPanelProps) {
               textTransform: "uppercase",
             }}
           >
-            Total Savings
+            Discount Coverage
+          </p>
+          <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>{discountCoverage}%</p>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <p
+            style={{
+              fontSize: "10px",
+              color: "rgba(255, 255, 255, 0.5)",
+              textTransform: "uppercase",
+            }}
+          >
+            Promotion Spend
           </p>
           <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
-            {formatCurrency(totalSavings)}
+            {formatCurrency(promotionSpend)}
           </p>
         </div>
       </div>
+      <p
+        style={{
+          marginTop: "12px",
+          fontSize: "11px",
+          color: "rgba(255, 255, 255, 0.55)",
+          textAlign: "center",
+        }}
+      >
+        Promotion spend is the discount amount granted to buyers.
+      </p>
     </div>
   );
 }

--- a/src/ui/components/metrics/panels/RecommendationAttributionPanel.tsx
+++ b/src/ui/components/metrics/panels/RecommendationAttributionPanel.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import type { RecommendationAttributionData } from "@/types";
+
+interface RecommendationAttributionPanelProps {
+  data: RecommendationAttributionData;
+  isLoading?: boolean;
+}
+
+function formatCurrency(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+export function RecommendationAttributionPanel({
+  data,
+  isLoading,
+}: RecommendationAttributionPanelProps) {
+  if (isLoading) {
+    return (
+      <div className="chart-container">
+        <div className="chart-title">
+          <div className="glass-line w50" style={{ height: "14px", marginTop: 0 }} />
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          {[1, 2, 3, 4].map((index) => (
+            <div key={index} className="glass-line w85" style={{ height: "18px", marginTop: 0 }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const stages = [
+    { label: "Impressions", value: data.impressions },
+    { label: "Clicks", value: data.clicks },
+    { label: "Purchases", value: data.purchases },
+  ];
+  const maxStageValue = Math.max(...stages.map((stage) => stage.value), 1);
+
+  return (
+    <div className="chart-container">
+      <h3 className="chart-title">Recommendation Attribution</h3>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "12px" }}>
+        <div style={{ textAlign: "center" }}>
+          <p
+            style={{ fontSize: "10px", color: "rgba(255,255,255,0.5)", textTransform: "uppercase" }}
+          >
+            Rec CTR
+          </p>
+          <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
+            {data.clickThroughRate !== null ? `${data.clickThroughRate.toFixed(1)}%` : "N/A"}
+          </p>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <p
+            style={{ fontSize: "10px", color: "rgba(255,255,255,0.5)", textTransform: "uppercase" }}
+          >
+            Rec Conversion
+          </p>
+          <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
+            {data.conversionRate !== null ? `${data.conversionRate.toFixed(1)}%` : "N/A"}
+          </p>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <p
+            style={{ fontSize: "10px", color: "rgba(255,255,255,0.5)", textTransform: "uppercase" }}
+          >
+            Attributed Revenue
+          </p>
+          <p style={{ fontSize: "20px", fontWeight: 700, color: "#76b900" }}>
+            {formatCurrency(data.attributedRevenue)}
+          </p>
+        </div>
+      </div>
+
+      <div style={{ marginTop: "18px", display: "flex", flexDirection: "column", gap: "10px" }}>
+        {stages.map((stage) => (
+          <div key={stage.label} style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+            <span style={{ width: "88px", fontSize: "11px", color: "rgba(255,255,255,0.7)" }}>
+              {stage.label}
+            </span>
+            <div
+              style={{
+                flex: 1,
+                height: "12px",
+                background: "rgba(255,255,255,0.06)",
+                borderRadius: "6px",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${(stage.value / maxStageValue) * 100}%`,
+                  height: "100%",
+                  background: "linear-gradient(90deg, #76b900, #5a9200)",
+                  borderRadius: "6px",
+                }}
+              />
+            </div>
+            <span
+              style={{
+                width: "52px",
+                textAlign: "right",
+                fontSize: "12px",
+                fontWeight: 700,
+                color: "rgba(255,255,255,0.9)",
+              }}
+            >
+              {stage.value}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div
+        style={{
+          marginTop: "18px",
+          paddingTop: "14px",
+          borderTop: "1px solid rgba(255,255,255,0.08)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "8px",
+        }}
+      >
+        <p style={{ fontSize: "10px", color: "rgba(255,255,255,0.5)", textTransform: "uppercase" }}>
+          Top Converting Recommended Products
+        </p>
+        {data.topProducts.length === 0 ? (
+          <p style={{ fontSize: "12px", color: "rgba(255,255,255,0.6)" }}>
+            No attributed purchases in this window.
+          </p>
+        ) : (
+          data.topProducts.slice(0, 3).map((product) => (
+            <div
+              key={product.productId}
+              style={{ display: "flex", justifyContent: "space-between", gap: "12px" }}
+            >
+              <span style={{ fontSize: "12px", color: "rgba(255,255,255,0.85)" }}>
+                {product.productName}
+              </span>
+              <span style={{ fontSize: "12px", color: "rgba(255,255,255,0.7)" }}>
+                {product.purchases}/{product.clicks} ({product.conversionRate ?? 0}%)
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/hooks/useMetrics.test.tsx
+++ b/src/ui/hooks/useMetrics.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MetricsProvider, useMetrics } from "./useMetrics";
+import { getMetricsDashboard } from "@/lib/api-client";
+import { fetchPhoenixAgentPerformance } from "./usePhoenixTelemetry";
+import type { MetricsDashboardAPIResponse, AgentPerformanceData } from "@/types";
+
+vi.mock("@/lib/api-client", () => ({
+  getMetricsDashboard: vi.fn(),
+}));
+
+vi.mock("./usePhoenixTelemetry", () => ({
+  fetchPhoenixAgentPerformance: vi.fn(),
+}));
+
+const mockDashboardResponse: MetricsDashboardAPIResponse = {
+  effective_window: {
+    requested_time_range: "24h",
+    start: "2026-02-05T00:00:00.000Z",
+    end: "2026-02-06T00:00:00.000Z",
+    fallback_applied: false,
+  },
+  kpis: [
+    {
+      id: "revenue",
+      label: "Revenue",
+      value: 100000,
+      previous_value: 90000,
+      format: "currency",
+      trend: "up",
+      trend_value: 11.1,
+    },
+    {
+      id: "orders",
+      label: "Orders",
+      value: 20,
+      previous_value: 10,
+      format: "number",
+      trend: "up",
+      trend_value: 100,
+    },
+    {
+      id: "conversion",
+      label: "Conv. Rate",
+      value: 50,
+      previous_value: 40,
+      format: "percent",
+      trend: "up",
+      trend_value: 25,
+    },
+    {
+      id: "aov",
+      label: "Avg Order",
+      value: 5000,
+      previous_value: 4500,
+      format: "currency",
+      trend: "up",
+      trend_value: 11.1,
+    },
+  ],
+  revenue_data: [{ timestamp: "2026-02-05T12:00:00.000Z", revenue: 100000, orders: 20 }],
+  agent_outcomes: [
+    {
+      agent_type: "promotion",
+      total_calls: 8,
+      errors: 2,
+      success_rate: 75,
+      source: "application",
+    },
+    {
+      agent_type: "recommendation",
+      total_calls: 0,
+      errors: 0,
+      success_rate: null,
+      source: "unavailable",
+    },
+    {
+      agent_type: "post_purchase",
+      total_calls: 0,
+      errors: 0,
+      success_rate: null,
+      source: "unavailable",
+    },
+    {
+      agent_type: "search",
+      total_calls: 0,
+      errors: 0,
+      success_rate: null,
+      source: "unavailable",
+    },
+  ],
+  recommendation_attribution: {
+    impressions: 40,
+    clicks: 10,
+    purchases: 3,
+    click_through_rate: 25,
+    conversion_rate: 30,
+    attributed_revenue: 7500,
+    top_products: [
+      {
+        product_id: "prod_2",
+        product_name: "V-Neck Tee",
+        clicks: 5,
+        purchases: 2,
+        conversion_rate: 40,
+        attributed_revenue: 5600,
+      },
+    ],
+  },
+  promotion_breakdown: [
+    { type: "DISCOUNT_10_PCT", label: "10% Discount", count: 12, total_savings: 1300 },
+  ],
+  product_health: [
+    {
+      id: "prod_1",
+      name: "Classic Tee",
+      sku: "TS-001",
+      stock_level: 5,
+      stock_status: "critical",
+      base_price: 2500,
+      competitor_price: 2300,
+      price_position: "above",
+      needs_attention: true,
+      attention_reason: "Critical stock",
+    },
+  ],
+};
+
+const mockAgentPerformance: AgentPerformanceData[] = [
+  {
+    agentType: "promotion",
+    label: "Promotion Agent",
+    successRate: null,
+    avgLatency: 200,
+    totalCalls: 10,
+    errors: 0,
+  },
+  {
+    agentType: "recommendation",
+    label: "Recommendation Agent",
+    successRate: null,
+    avgLatency: 100,
+    totalCalls: 5,
+    errors: 0,
+  },
+  {
+    agentType: "post_purchase",
+    label: "Post-Purchase Agent",
+    successRate: null,
+    avgLatency: 50,
+    totalCalls: 0,
+    errors: 0,
+  },
+  {
+    agentType: "search",
+    label: "Search Agent",
+    successRate: null,
+    avgLatency: 80,
+    totalCalls: 0,
+    errors: 0,
+  },
+];
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MetricsProvider>{children}</MetricsProvider>
+);
+
+describe("useMetrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getMetricsDashboard).mockResolvedValue(mockDashboardResponse);
+    vi.mocked(fetchPhoenixAgentPerformance).mockResolvedValue(mockAgentPerformance);
+  });
+
+  it("throws when used outside MetricsProvider", () => {
+    const originalError = console.error;
+    console.error = () => {};
+
+    expect(() => renderHook(() => useMetrics())).toThrow(
+      "useMetrics must be used within MetricsProvider"
+    );
+
+    console.error = originalError;
+  });
+
+  it("loads and maps real dashboard data on mount", async () => {
+    const { result } = renderHook(() => useMetrics(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.state.kpis).toHaveLength(5);
+    });
+
+    expect(getMetricsDashboard).toHaveBeenCalledWith("24h");
+    expect(fetchPhoenixAgentPerformance).toHaveBeenCalledWith("24h");
+    expect(result.current.state.revenueData).toEqual(mockDashboardResponse.revenue_data);
+    expect(result.current.state.agentPerformance).toEqual([
+      {
+        agentType: "promotion",
+        label: "Promotion Agent",
+        successRate: 75,
+        avgLatency: 200,
+        totalCalls: 8,
+        errors: 2,
+      },
+      {
+        agentType: "recommendation",
+        label: "Recommendation Agent",
+        successRate: null,
+        avgLatency: 100,
+        totalCalls: 0,
+        errors: 0,
+      },
+      {
+        agentType: "post_purchase",
+        label: "Post-Purchase Agent",
+        successRate: null,
+        avgLatency: 50,
+        totalCalls: 0,
+        errors: 0,
+      },
+      {
+        agentType: "search",
+        label: "Search Agent",
+        successRate: null,
+        avgLatency: 80,
+        totalCalls: 0,
+        errors: 0,
+      },
+    ]);
+    expect(result.current.state.productHealth[0]?.stockStatus).toBe("critical");
+    expect(result.current.state.promotionBreakdown[0]?.totalSavings).toBe(1300);
+    expect(result.current.state.recommendationAttribution.purchases).toBe(3);
+    expect(result.current.state.recommendationAttribution.topProducts[0]?.productId).toBe("prod_2");
+
+    const latencyKpi = result.current.state.kpis.find((kpi) => kpi.id === "latency");
+    expect(latencyKpi?.value).toBe(167);
+  });
+
+  it("refetches when time range changes", async () => {
+    const { result } = renderHook(() => useMetrics(), { wrapper });
+
+    await waitFor(() => {
+      expect(getMetricsDashboard).toHaveBeenCalledWith("24h");
+    });
+
+    act(() => {
+      result.current.setTimeRange("7d");
+    });
+
+    await waitFor(() => {
+      expect(getMetricsDashboard).toHaveBeenLastCalledWith("7d");
+    });
+  });
+
+  it("refresh triggers another fetch cycle", async () => {
+    const { result } = renderHook(() => useMetrics(), { wrapper });
+
+    await waitFor(() => {
+      expect(getMetricsDashboard).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(getMetricsDashboard).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/ui/hooks/useMetrics.tsx
+++ b/src/ui/hooks/useMetrics.tsx
@@ -7,10 +7,24 @@ import {
   useCallback,
   useMemo,
   useEffect,
+  useState,
   type ReactNode,
 } from "react";
-import type { TimeRange, MetricsState, MetricsAction } from "@/types";
-import { useMockMetrics } from "./useMockMetrics";
+import type {
+  AgentType,
+  TimeRange,
+  MetricsState,
+  MetricsAction,
+  KPIData,
+  AgentPerformanceData,
+  MetricsDashboardAPIResponse,
+  MetricsAPIAgentOutcome,
+  MetricsAPIPromotionBreakdown,
+  MetricsAPIProductHealth,
+  MetricsAPIRecommendationAttribution,
+} from "@/types";
+import { getMetricsDashboard } from "@/lib/api-client";
+import { fetchPhoenixAgentPerformance } from "./usePhoenixTelemetry";
 
 const initialState: MetricsState = {
   timeRange: "24h",
@@ -19,9 +33,35 @@ const initialState: MetricsState = {
   kpis: [],
   revenueData: [],
   agentPerformance: [],
+  recommendationAttribution: {
+    impressions: 0,
+    clicks: 0,
+    purchases: 0,
+    clickThroughRate: null,
+    conversionRate: null,
+    attributedRevenue: 0,
+    topProducts: [],
+  },
   promotionBreakdown: [],
   productHealth: [],
 };
+
+const PROMOTION_COLORS: Record<string, string> = {
+  DISCOUNT_5_PCT: "#9ed253",
+  DISCOUNT_10_PCT: "#76b900",
+  DISCOUNT_15_PCT: "#5a9200",
+  DISCOUNT_20_PCT: "#3d6200",
+  NO_PROMO: "rgba(255, 255, 255, 0.2)",
+};
+
+const AGENT_LABELS: Record<AgentType, string> = {
+  promotion: "Promotion Agent",
+  recommendation: "Recommendation Agent",
+  post_purchase: "Post-Purchase Agent",
+  search: "Search Agent",
+};
+
+const AGENT_TYPES: AgentType[] = ["promotion", "recommendation", "post_purchase", "search"];
 
 function metricsReducer(state: MetricsState, action: MetricsAction): MetricsState {
   switch (action.type) {
@@ -59,56 +99,184 @@ interface MetricsContextType {
 
 const MetricsContext = createContext<MetricsContextType | null>(null);
 
+function mapDashboardKpis(
+  dashboard: MetricsDashboardAPIResponse,
+  phoenixPerformance: AgentPerformanceData[]
+): KPIData[] {
+  const merchantKpis: KPIData[] = dashboard.kpis.map((kpi) => ({
+    id: kpi.id,
+    label: kpi.label,
+    value: kpi.value,
+    previousValue: kpi.previous_value,
+    format: kpi.format,
+    trend: kpi.trend,
+    trendValue: kpi.trend_value,
+  }));
+
+  const totalCalls = phoenixPerformance.reduce((sum, agent) => sum + agent.totalCalls, 0);
+  const weightedLatency =
+    totalCalls > 0
+      ? Math.round(
+          phoenixPerformance.reduce((sum, agent) => sum + agent.avgLatency * agent.totalCalls, 0) /
+            totalCalls
+        )
+      : 0;
+
+  const latencyKpi: KPIData = {
+    id: "latency",
+    label: "Agent Latency",
+    value: weightedLatency,
+    format: "duration",
+  };
+
+  return [...merchantKpis, latencyKpi];
+}
+
+function mapPromotions(promotions: MetricsAPIPromotionBreakdown[]) {
+  return promotions.map((item) => ({
+    type: item.type,
+    label: item.label,
+    count: item.count,
+    totalSavings: item.total_savings,
+    color: PROMOTION_COLORS[item.type] ?? "rgba(255, 255, 255, 0.2)",
+  }));
+}
+
+function mapProductHealth(products: MetricsAPIProductHealth[]) {
+  return products.map((product) => {
+    const mapped = {
+      id: product.id,
+      name: product.name,
+      sku: product.sku,
+      stockLevel: product.stock_level,
+      stockStatus: product.stock_status,
+      basePrice: product.base_price,
+      pricePosition: product.price_position,
+      needsAttention: product.needs_attention,
+    };
+    return {
+      ...mapped,
+      ...(product.competitor_price !== undefined
+        ? { competitorPrice: product.competitor_price }
+        : {}),
+      ...(product.attention_reason !== undefined
+        ? { attentionReason: product.attention_reason }
+        : {}),
+    };
+  });
+}
+
+function mapRecommendationAttribution(attribution: MetricsAPIRecommendationAttribution) {
+  return {
+    impressions: attribution.impressions,
+    clicks: attribution.clicks,
+    purchases: attribution.purchases,
+    clickThroughRate: attribution.click_through_rate,
+    conversionRate: attribution.conversion_rate,
+    attributedRevenue: attribution.attributed_revenue,
+    topProducts: attribution.top_products.map((product) => ({
+      productId: product.product_id,
+      productName: product.product_name,
+      clicks: product.clicks,
+      purchases: product.purchases,
+      conversionRate: product.conversion_rate,
+      attributedRevenue: product.attributed_revenue,
+    })),
+  };
+}
+
+function mapAgentPerformance(
+  phoenixPerformance: AgentPerformanceData[],
+  agentOutcomes: MetricsAPIAgentOutcome[]
+): AgentPerformanceData[] {
+  const byPhoenix = new Map(phoenixPerformance.map((entry) => [entry.agentType, entry]));
+  const byOutcome = new Map(agentOutcomes.map((entry) => [entry.agent_type, entry]));
+
+  return AGENT_TYPES.map((agentType) => {
+    const phoenix = byPhoenix.get(agentType);
+    const outcome = byOutcome.get(agentType);
+
+    return {
+      agentType,
+      label: AGENT_LABELS[agentType],
+      successRate: outcome?.success_rate ?? null,
+      avgLatency: phoenix?.avgLatency ?? 0,
+      totalCalls: outcome?.total_calls ?? phoenix?.totalCalls ?? 0,
+      errors: outcome?.errors ?? 0,
+    };
+  });
+}
+
 /**
  * Provider component for metrics state management
  */
 export function MetricsProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(metricsReducer, initialState);
+  const [refreshCounter, setRefreshCounter] = useState(0);
 
-  // Get mock data based on current time range
-  const mockData = useMockMetrics(state.timeRange);
-
-  // Update metrics when time range changes or on mount
+  // Update metrics when time range changes or refresh is requested.
   useEffect(() => {
-    dispatch({ type: "SET_LOADING", isLoading: true });
+    let isCancelled = false;
 
-    // Simulate API delay for realistic feel
-    const timer = setTimeout(() => {
-      dispatch({
-        type: "UPDATE_METRICS",
-        metrics: {
-          kpis: mockData.kpis,
-          revenueData: mockData.revenueData,
-          agentPerformance: mockData.agentPerformance,
-          promotionBreakdown: mockData.promotionBreakdown,
-          productHealth: mockData.productHealth,
-          isLoading: false,
-        },
-      });
-    }, 300);
+    const loadMetrics = async () => {
+      dispatch({ type: "SET_LOADING", isLoading: true });
+      try {
+        const [dashboardResult, performanceResult] = await Promise.allSettled([
+          getMetricsDashboard(state.timeRange),
+          fetchPhoenixAgentPerformance(state.timeRange),
+        ]);
 
-    return () => clearTimeout(timer);
-  }, [
-    state.timeRange,
-    mockData.kpis,
-    mockData.revenueData,
-    mockData.agentPerformance,
-    mockData.promotionBreakdown,
-    mockData.productHealth,
-  ]);
+        if (dashboardResult.status !== "fulfilled") {
+          throw dashboardResult.reason;
+        }
+
+        const dashboard = dashboardResult.value;
+        const phoenixPerformance =
+          performanceResult.status === "fulfilled" ? performanceResult.value : [];
+        const agentPerformance = mapAgentPerformance(
+          phoenixPerformance,
+          dashboard.agent_outcomes ?? []
+        );
+
+        if (isCancelled) {
+          return;
+        }
+
+        dispatch({
+          type: "UPDATE_METRICS",
+          metrics: {
+            kpis: mapDashboardKpis(dashboard, phoenixPerformance),
+            revenueData: dashboard.revenue_data,
+            agentPerformance,
+            recommendationAttribution: mapRecommendationAttribution(
+              dashboard.recommendation_attribution
+            ),
+            promotionBreakdown: mapPromotions(dashboard.promotion_breakdown),
+            productHealth: mapProductHealth(dashboard.product_health),
+            isLoading: false,
+          },
+        });
+      } catch {
+        if (!isCancelled) {
+          dispatch({ type: "SET_LOADING", isLoading: false });
+        }
+      }
+    };
+
+    void loadMetrics();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [state.timeRange, refreshCounter]);
 
   const setTimeRange = useCallback((timeRange: TimeRange) => {
     dispatch({ type: "SET_TIME_RANGE", timeRange });
   }, []);
 
   const refresh = useCallback(() => {
-    dispatch({ type: "SET_LOADING", isLoading: true });
-
-    // Simulate refresh delay
-    setTimeout(() => {
-      dispatch({ type: "REFRESH" });
-      dispatch({ type: "SET_LOADING", isLoading: false });
-    }, 500);
+    dispatch({ type: "REFRESH" });
+    setRefreshCounter((current) => current + 1);
   }, []);
 
   const contextValue = useMemo(

--- a/src/ui/hooks/usePhoenixTelemetry.test.tsx
+++ b/src/ui/hooks/usePhoenixTelemetry.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchPhoenixAgentPerformance } from "./usePhoenixTelemetry";
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchPhoenixAgentPerformance", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches spans per project and aggregates top-level spans only", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes("/v1/projects") && !url.includes("/spans")) {
+        return jsonResponse({
+          data: [
+            { id: "proj_promo", name: "promotion-agent" },
+            { id: "proj_reco", name: "arag-recommendations-ultrafast" },
+            { id: "proj_post", name: "post-purchase-agent" },
+            { id: "proj_search", name: "search-agent" },
+          ],
+        });
+      }
+
+      if (url.includes("/projects/proj_promo/spans")) {
+        return jsonResponse({
+          data: [
+            {
+              context: { trace_id: "t1", span_id: "s1" },
+              name: "<workflow>",
+              parent_id: null,
+              start_time: "2026-02-05T10:00:00.000Z",
+              end_time: "2026-02-05T10:00:00.100Z",
+              status_code: "OK",
+            },
+            {
+              context: { trace_id: "t1", span_id: "s2" },
+              name: "<child>",
+              parent_id: "s1",
+              start_time: "2026-02-05T10:00:00.010Z",
+              end_time: "2026-02-05T10:00:00.020Z",
+              status_code: "ERROR",
+            },
+          ],
+          next_cursor: null,
+        });
+      }
+
+      if (url.includes("/projects/proj_reco/spans")) {
+        return jsonResponse({ data: [], next_cursor: null });
+      }
+
+      if (url.includes("/projects/proj_post/spans")) {
+        return jsonResponse({
+          data: [
+            {
+              context: { trace_id: "t2", span_id: "s3" },
+              name: "<workflow>",
+              parent_id: null,
+              start_time: "2026-02-05T10:00:00.000Z",
+              end_time: "2026-02-05T10:00:00.050Z",
+              status_code: "ERROR",
+            },
+          ],
+          next_cursor: null,
+        });
+      }
+
+      if (url.includes("/projects/proj_search/spans")) {
+        return jsonResponse({
+          data: [
+            {
+              context: { trace_id: "t3", span_id: "s4" },
+              name: "<workflow>",
+              parent_id: null,
+              start_time: "2026-02-05T10:00:00.000Z",
+              end_time: "2026-02-05T10:00:00.030Z",
+              status_code: "OK",
+            },
+            {
+              context: { trace_id: "t4", span_id: "s5" },
+              name: "<workflow>",
+              parent_id: null,
+              start_time: "2026-02-05T10:01:00.000Z",
+              end_time: "2026-02-05T10:01:00.030Z",
+              status_code: "OK",
+            },
+          ],
+          next_cursor: null,
+        });
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const data = await fetchPhoenixAgentPerformance("24h");
+
+    expect(data).toHaveLength(4);
+    expect(data.find((item) => item.agentType === "promotion")?.totalCalls).toBe(1);
+    expect(data.find((item) => item.agentType === "promotion")?.avgLatency).toBe(100);
+    expect(data.find((item) => item.agentType === "recommendation")?.totalCalls).toBe(0);
+    expect(data.find((item) => item.agentType === "post_purchase")?.errors).toBe(0);
+    expect(data.find((item) => item.agentType === "post_purchase")?.successRate).toBeNull();
+    expect(data.find((item) => item.agentType === "search")?.avgLatency).toBe(30);
+
+    const calledUrls = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(calledUrls.some((url) => url.includes("/spans?"))).toBe(true);
+    expect(calledUrls.some((url) => url.includes("start_time="))).toBe(true);
+    expect(calledUrls.some((url) => url.includes("end_time="))).toBe(true);
+  });
+
+  it("throws when project listing fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "boom" }, 500))
+    );
+
+    await expect(fetchPhoenixAgentPerformance("24h")).rejects.toThrow(
+      "Failed to fetch Phoenix projects"
+    );
+  });
+});

--- a/src/ui/hooks/usePhoenixTelemetry.tsx
+++ b/src/ui/hooks/usePhoenixTelemetry.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import type { PhoenixTraceData, AgentPerformanceData, AgentType } from "@/types";
+import type { PhoenixTraceData, AgentPerformanceData, AgentType, TimeRange } from "@/types";
 
 interface PhoenixProject {
   id: string;
@@ -10,11 +10,13 @@ interface PhoenixProject {
 }
 
 interface PhoenixSpan {
+  id?: string;
   context: {
     trace_id: string;
     span_id: string;
   };
   name: string;
+  parent_id?: string | null;
   start_time: string;
   end_time: string;
   status_code: string;
@@ -28,8 +30,132 @@ interface UsePhoenixTelemetryResult {
   traces: PhoenixTraceData[];
   agentPerformance: AgentPerformanceData[];
   fetchProjects: () => Promise<void>;
-  fetchTraces: (projectId: string, limit?: number) => Promise<void>;
+  fetchTraces: (
+    projectId: string,
+    limit?: number,
+    startTime?: string,
+    endTime?: string
+  ) => Promise<void>;
   refresh: () => Promise<void>;
+}
+
+const AGENT_PROJECTS: Record<AgentType, string> = {
+  promotion: "promotion-agent",
+  recommendation: "arag-recommendations-ultrafast",
+  post_purchase: "post-purchase-agent",
+  search: "search-agent",
+};
+
+const AGENT_LABELS: Record<AgentType, string> = {
+  promotion: "Promotion Agent",
+  recommendation: "Recommendation Agent",
+  post_purchase: "Post-Purchase Agent",
+  search: "Search Agent",
+};
+
+function getWindowStart(timeRange: TimeRange): string {
+  const now = new Date();
+  let ms = 24 * 60 * 60 * 1000;
+  if (timeRange === "1h") {
+    ms = 60 * 60 * 1000;
+  } else if (timeRange === "7d") {
+    ms = 7 * 24 * 60 * 60 * 1000;
+  } else if (timeRange === "30d") {
+    ms = 30 * 24 * 60 * 60 * 1000;
+  }
+  return new Date(now.getTime() - ms).toISOString();
+}
+
+async function fetchProjectSpans(
+  projectId: string,
+  startTime: string,
+  endTime: string,
+  limit = 1000
+): Promise<PhoenixSpan[]> {
+  let cursor: string | null = null;
+  const spans: PhoenixSpan[] = [];
+
+  do {
+    const params = new URLSearchParams({
+      limit: String(limit),
+      start_time: startTime,
+      end_time: endTime,
+    });
+    if (cursor) {
+      params.set("cursor", cursor);
+    }
+    const response = await fetch(`/api/proxy/phoenix/v1/projects/${projectId}/spans?${params}`);
+    if (!response.ok) {
+      throw new Error("Failed to fetch Phoenix spans");
+    }
+    const payload = await response.json();
+    spans.push(...((payload.data as PhoenixSpan[]) ?? []));
+    cursor = (payload.next_cursor as string | null) ?? null;
+  } while (cursor);
+
+  return spans;
+}
+
+function topLevelSpans(spans: PhoenixSpan[]): PhoenixSpan[] {
+  return spans.filter((span) => span.parent_id == null);
+}
+
+function summarizeSpans(agentType: AgentType, spans: PhoenixSpan[]): AgentPerformanceData {
+  const totalCalls = spans.length;
+  const avgLatency =
+    totalCalls > 0
+      ? Math.round(
+          spans.reduce((sum, span) => {
+            const duration =
+              new Date(span.end_time).getTime() - new Date(span.start_time).getTime();
+            return sum + Math.max(duration, 0);
+          }, 0) / totalCalls
+        )
+      : 0;
+
+  return {
+    agentType,
+    label: AGENT_LABELS[agentType],
+    successRate: null,
+    avgLatency,
+    totalCalls,
+    errors: 0,
+  };
+}
+
+/**
+ * Fetch per-agent performance metrics from Phoenix for a given time range.
+ */
+export async function fetchPhoenixAgentPerformance(
+  timeRange: TimeRange
+): Promise<AgentPerformanceData[]> {
+  const startTime = getWindowStart(timeRange);
+  const endTime = new Date().toISOString();
+  const projectsResponse = await fetch("/api/proxy/phoenix/v1/projects");
+
+  if (!projectsResponse.ok) {
+    throw new Error("Failed to fetch Phoenix projects");
+  }
+
+  const projectsPayload = await projectsResponse.json();
+  const projects: PhoenixProject[] = projectsPayload.data ?? [];
+  const projectByName = new Map(projects.map((project) => [project.name, project.id]));
+
+  const agentTypes: AgentType[] = ["promotion", "recommendation", "post_purchase", "search"];
+  const results = await Promise.all(
+    agentTypes.map(async (agentType) => {
+      const projectName = AGENT_PROJECTS[agentType];
+      const projectId = projectByName.get(projectName);
+      if (!projectId) {
+        return summarizeSpans(agentType, []);
+      }
+
+      const spans = await fetchProjectSpans(projectId, startTime, endTime);
+      return summarizeSpans(agentType, topLevelSpans(spans));
+    })
+  );
+
+  return results;
 }
 
 /**
@@ -61,63 +187,74 @@ export function usePhoenixTelemetry(): UsePhoenixTelemetryResult {
     }
   }, []);
 
-  const fetchTraces = useCallback(async (projectId: string, limit = 100) => {
+  const fetchTraces = useCallback(
+    async (projectId: string, limit = 100, startTime?: string, endTime?: string) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const params = new URLSearchParams({ limit: String(limit) });
+        if (startTime) {
+          params.set("start_time", startTime);
+        }
+        if (endTime) {
+          params.set("end_time", endTime);
+        }
+        const response = await fetch(`/api/proxy/phoenix/v1/projects/${projectId}/spans?${params}`);
+        if (!response.ok) {
+          throw new Error("Failed to fetch Phoenix spans");
+        }
+        const data = await response.json();
+        const spans: PhoenixSpan[] = data.data ?? [];
+
+        const transformedTraces: PhoenixTraceData[] = spans.map((span) => {
+          const trace: PhoenixTraceData = {
+            traceId: span.context.trace_id,
+            spanId: span.context.span_id,
+            name: span.name,
+            startTime: span.start_time,
+            endTime: span.end_time,
+            duration: new Date(span.end_time).getTime() - new Date(span.start_time).getTime(),
+            status: span.status_code === "OK" ? "ok" : "error",
+          };
+          if (span.attributes) {
+            trace.attributes = span.attributes;
+          }
+          return trace;
+        });
+
+        setTraces(transformedTraces);
+        const performance = calculateAgentPerformance(transformedTraces);
+        setAgentPerformance(performance);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+        setTraces([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    []
+  );
+
+  const refresh = useCallback(async () => {
     setIsLoading(true);
     setError(null);
-
     try {
-      const response = await fetch(
-        `/api/proxy/phoenix/v1/projects/${projectId}/traces?limit=${limit}`
-      );
-      if (!response.ok) {
-        throw new Error("Failed to fetch Phoenix traces");
-      }
-      const data = await response.json();
-      const spans: PhoenixSpan[] = data.data ?? [];
-
-      // Transform spans to traces
-      const transformedTraces: PhoenixTraceData[] = spans.map((span) => {
-        const trace: PhoenixTraceData = {
-          traceId: span.context.trace_id,
-          spanId: span.context.span_id,
-          name: span.name,
-          startTime: span.start_time,
-          endTime: span.end_time,
-          duration: new Date(span.end_time).getTime() - new Date(span.start_time).getTime(),
-          status: span.status_code === "OK" ? "ok" : "error",
-        };
-        if (span.attributes) {
-          trace.attributes = span.attributes;
-        }
-        return trace;
-      });
-
-      setTraces(transformedTraces);
-
-      // Calculate agent performance from traces
-      const performance = calculateAgentPerformance(transformedTraces);
+      const performance = await fetchPhoenixAgentPerformance("24h");
       setAgentPerformance(performance);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
-      setTraces([]);
+      setAgentPerformance([]);
     } finally {
       setIsLoading(false);
     }
   }, []);
 
-  const refresh = useCallback(async () => {
-    const firstProject = projects[0];
-    if (projects.length > 0 && firstProject) {
-      await fetchTraces(firstProject.id);
-    } else {
-      await fetchProjects();
-    }
-  }, [projects, fetchProjects, fetchTraces]);
-
   // Auto-fetch on mount
   useEffect(() => {
     void fetchProjects();
-  }, [fetchProjects]);
+    void refresh();
+  }, [fetchProjects, refresh]);
 
   return {
     isLoading,
@@ -132,38 +269,31 @@ export function usePhoenixTelemetry(): UsePhoenixTelemetryResult {
 }
 
 /**
- * Calculate agent performance metrics from traces
+ * Calculate agent performance metrics from traces.
+ *
+ * Note: This fallback parser infers agent type from span names and is mainly
+ * for manual debugging. Dashboard aggregation uses project-based mapping.
  */
 function calculateAgentPerformance(traces: PhoenixTraceData[]): AgentPerformanceData[] {
   const agentTypes: AgentType[] = ["promotion", "recommendation", "post_purchase", "search"];
 
   return agentTypes.map((agentType) => {
-    // Filter traces for this agent type
     const agentTraces = traces.filter((trace) => {
       const name = trace.name.toLowerCase();
       return name.includes(agentType) || name.includes(agentType.replace("_", "-"));
     });
 
     const totalCalls = agentTraces.length;
-    const errors = agentTraces.filter((t) => t.status === "error").length;
-    const successRate = totalCalls > 0 ? ((totalCalls - errors) / totalCalls) * 100 : 100;
     const avgLatency =
-      totalCalls > 0 ? agentTraces.reduce((sum, t) => sum + t.duration, 0) / totalCalls : 0;
-
-    const labelMap: Record<AgentType, string> = {
-      promotion: "Promotion Agent",
-      recommendation: "Recommendation Agent",
-      post_purchase: "Post-Purchase Agent",
-      search: "Search Agent",
-    };
+      totalCalls > 0 ? agentTraces.reduce((sum, trace) => sum + trace.duration, 0) / totalCalls : 0;
 
     return {
       agentType,
-      label: labelMap[agentType],
-      successRate: Math.round(successRate * 10) / 10,
+      label: AGENT_LABELS[agentType],
+      successRate: null,
       avgLatency: Math.round(avgLatency),
       totalCalls,
-      errors,
+      errors: 0,
     };
   });
 }

--- a/src/ui/lib/api-client.ts
+++ b/src/ui/lib/api-client.ts
@@ -13,6 +13,8 @@ import type {
   DelegatePaymentRequest,
   DelegatePaymentResponse,
   APIError,
+  TimeRange,
+  MetricsDashboardAPIResponse,
 } from "@/types";
 
 // =============================================================================
@@ -201,6 +203,20 @@ export async function cancelCheckout(sessionId: string): Promise<CheckoutSession
   });
 
   return handleResponse<CheckoutSessionResponse>(response);
+}
+
+/**
+ * Get aggregated metrics dashboard data.
+ */
+export async function getMetricsDashboard(
+  timeRange: TimeRange
+): Promise<MetricsDashboardAPIResponse> {
+  const response = await fetch(`${API_URL}/metrics/dashboard?time_range=${timeRange}`, {
+    method: "GET",
+    headers: getMerchantHeaders(),
+  });
+
+  return handleResponse<MetricsDashboardAPIResponse>(response);
 }
 
 // =============================================================================

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -969,7 +969,7 @@ export interface RevenueDataPoint {
 export interface AgentPerformanceData {
   agentType: AgentType;
   label: string;
-  successRate: number;
+  successRate: number | null;
   avgLatency: number;
   totalCalls: number;
   errors: number;
@@ -1003,6 +1003,129 @@ export interface ProductHealthData {
 }
 
 /**
+ * Recommendation attribution top product row.
+ */
+export interface RecommendationAttributionTopProductData {
+  productId: string;
+  productName: string;
+  clicks: number;
+  purchases: number;
+  conversionRate: number | null;
+  attributedRevenue: number;
+}
+
+/**
+ * Recommendation attribution funnel metrics.
+ */
+export interface RecommendationAttributionData {
+  impressions: number;
+  clicks: number;
+  purchases: number;
+  clickThroughRate: number | null;
+  conversionRate: number | null;
+  attributedRevenue: number;
+  topProducts: RecommendationAttributionTopProductData[];
+}
+
+/**
+ * Merchant metrics API KPI payload.
+ */
+export interface MetricsAPIKPI {
+  id: string;
+  label: string;
+  value: number;
+  previous_value: number;
+  format: "currency" | "number" | "percent" | "duration";
+  trend: "up" | "down" | "neutral";
+  trend_value: number;
+}
+
+/**
+ * Merchant metrics API promotion payload.
+ */
+export interface MetricsAPIPromotionBreakdown {
+  type: string;
+  label: string;
+  count: number;
+  total_savings: number;
+}
+
+/**
+ * Merchant metrics API product health payload.
+ */
+export interface MetricsAPIProductHealth {
+  id: string;
+  name: string;
+  sku: string;
+  stock_level: number;
+  stock_status: "healthy" | "low" | "critical";
+  base_price: number;
+  competitor_price?: number;
+  price_position: "above" | "at" | "below" | "unknown";
+  needs_attention: boolean;
+  attention_reason?: string;
+}
+
+/**
+ * Merchant metrics API effective window payload.
+ */
+export interface MetricsAPIEffectiveWindow {
+  requested_time_range: TimeRange;
+  start: string;
+  end: string;
+  fallback_applied: boolean;
+}
+
+/**
+ * Merchant metrics API application-level agent outcome payload.
+ */
+export interface MetricsAPIAgentOutcome {
+  agent_type: AgentType;
+  total_calls: number;
+  errors: number;
+  success_rate: number | null;
+  source: "application" | "unavailable";
+}
+
+/**
+ * Merchant metrics API recommendation attribution top product payload.
+ */
+export interface MetricsAPIRecommendationTopProduct {
+  product_id: string;
+  product_name: string;
+  clicks: number;
+  purchases: number;
+  conversion_rate: number | null;
+  attributed_revenue: number;
+}
+
+/**
+ * Merchant metrics API recommendation attribution payload.
+ */
+export interface MetricsAPIRecommendationAttribution {
+  impressions: number;
+  clicks: number;
+  purchases: number;
+  click_through_rate: number | null;
+  conversion_rate: number | null;
+  attributed_revenue: number;
+  top_products: MetricsAPIRecommendationTopProduct[];
+}
+
+/**
+ * Merchant metrics API dashboard response payload.
+ */
+export interface MetricsDashboardAPIResponse {
+  effective_window: MetricsAPIEffectiveWindow;
+  kpis: MetricsAPIKPI[];
+  revenue_data: RevenueDataPoint[];
+  agent_outcomes: MetricsAPIAgentOutcome[];
+  recommendation_attribution: MetricsAPIRecommendationAttribution;
+  promotion_breakdown: MetricsAPIPromotionBreakdown[];
+  product_health: MetricsAPIProductHealth[];
+}
+
+/**
  * Phoenix trace data from telemetry
  */
 export interface PhoenixTraceData {
@@ -1026,6 +1149,7 @@ export interface MetricsState {
   kpis: KPIData[];
   revenueData: RevenueDataPoint[];
   agentPerformance: AgentPerformanceData[];
+  recommendationAttribution: RecommendationAttributionData;
   promotionBreakdown: PromotionBreakdownData[];
   productHealth: ProductHealthData[];
 }

--- a/tests/apps_sdk/test_metrics_outcomes.py
+++ b/tests/apps_sdk/test_metrics_outcomes.py
@@ -1,0 +1,99 @@
+"""Tests for Apps SDK outcome classification and recording helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.apps_sdk.main import (
+    _classify_outcome_status,
+    _record_apps_sdk_outcome,
+    _record_recommendation_attribution_event,
+)
+
+
+def test_classify_outcome_status_handles_search_no_results() -> None:
+    """No-result search responses should not count as agent failures."""
+    status, error_code = _classify_outcome_status(
+        agent_type="search",
+        error_message="No products found for 'skirts'.",
+    )
+    assert status == "success"
+    assert error_code is None
+
+
+def test_classify_outcome_status_maps_timeout_and_upstream() -> None:
+    """Timeout and upstream issues map to normalized statuses."""
+    timeout_status, timeout_code = _classify_outcome_status(
+        agent_type="recommendation",
+        error_message="Recommendation agent timeout",
+    )
+    assert timeout_status == "error_timeout"
+    assert timeout_code == "timeout"
+
+    upstream_status, upstream_code = _classify_outcome_status(
+        agent_type="recommendation",
+        error_message="Recommendation agent unavailable",
+    )
+    assert upstream_status == "error_upstream"
+    assert upstream_code == "upstream_error"
+
+
+@pytest.mark.asyncio
+async def test_record_apps_sdk_outcome_posts_to_merchant_metrics() -> None:
+    """Outcome recorder sends payload to merchant metrics endpoint."""
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.text = ""
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = AsyncMock()
+        mock_instance.post.return_value = mock_response
+        mock_instance.__aenter__.return_value = mock_instance
+        mock_instance.__aexit__.return_value = None
+        mock_client.return_value = mock_instance
+
+        await _record_apps_sdk_outcome(
+            agent_type="recommendation",
+            status="success",
+            latency_ms=123,
+            error_code=None,
+        )
+
+        assert mock_instance.post.await_count == 1
+        args, kwargs = mock_instance.post.await_args
+        assert args[0].endswith("/metrics/agent-outcomes")
+        assert kwargs["json"]["agent_type"] == "recommendation"
+        assert kwargs["json"]["channel"] == "apps_sdk"
+        assert kwargs["json"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_record_recommendation_attribution_posts_to_merchant_metrics() -> None:
+    """Attribution recorder sends payload to merchant metrics endpoint."""
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.text = ""
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = AsyncMock()
+        mock_instance.post.return_value = mock_response
+        mock_instance.__aenter__.return_value = mock_instance
+        mock_instance.__aexit__.return_value = None
+        mock_client.return_value = mock_instance
+
+        await _record_recommendation_attribution_event(
+            event_type="click",
+            product_id="prod_2",
+            session_id="cart_1",
+            recommendation_request_id="rec_1",
+            position=1,
+        )
+
+        assert mock_instance.post.await_count == 1
+        args, kwargs = mock_instance.post.await_args
+        assert args[0].endswith("/metrics/recommendation-attribution")
+        assert kwargs["json"]["event_type"] == "click"
+        assert kwargs["json"]["product_id"] == "prod_2"
+        assert kwargs["json"]["recommendation_request_id"] == "rec_1"

--- a/tests/merchant/api/test_metrics.py
+++ b/tests/merchant/api/test_metrics.py
@@ -1,0 +1,82 @@
+"""Tests for metrics dashboard API endpoint."""
+
+from fastapi.testclient import TestClient
+
+
+class TestMetricsDashboardEndpoint:
+    """Test suite for GET /metrics/dashboard."""
+
+    def test_metrics_dashboard_requires_auth(self, client: TestClient) -> None:
+        """Request without API key returns 401."""
+        response = client.get("/metrics/dashboard")
+
+        assert response.status_code == 401
+
+    def test_metrics_dashboard_returns_200_with_auth(
+        self, auth_client: TestClient
+    ) -> None:
+        """Authenticated request returns metrics payload."""
+        response = auth_client.get("/metrics/dashboard?time_range=24h")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "effective_window" in data
+        assert "kpis" in data
+        assert "revenue_data" in data
+        assert "agent_outcomes" in data
+        assert "recommendation_attribution" in data
+        assert "promotion_breakdown" in data
+        assert "product_health" in data
+
+    def test_metrics_dashboard_rejects_invalid_time_range(
+        self, auth_client: TestClient
+    ) -> None:
+        """Invalid time_range query value returns validation error."""
+        response = auth_client.get("/metrics/dashboard?time_range=365d")
+
+        assert response.status_code == 422
+
+    def test_metrics_agent_outcomes_records_and_surfaces_in_dashboard(
+        self, auth_client: TestClient
+    ) -> None:
+        """Recorded outcome is returned in the dashboard aggregate."""
+        record_response = auth_client.post(
+            "/metrics/agent-outcomes",
+            json={
+                "agent_type": "recommendation",
+                "channel": "apps_sdk",
+                "status": "error_upstream",
+                "latency_ms": 153,
+                "error_code": "upstream_error",
+            },
+        )
+
+        assert record_response.status_code == 201
+        assert record_response.json() == {"recorded": True}
+
+        dashboard_response = auth_client.get("/metrics/dashboard?time_range=24h")
+        assert dashboard_response.status_code == 200
+        outcomes = dashboard_response.json()["agent_outcomes"]
+        recommendation = next(
+            entry for entry in outcomes if entry["agent_type"] == "recommendation"
+        )
+        assert recommendation["source"] == "application"
+        assert recommendation["total_calls"] >= 1
+        assert recommendation["errors"] >= 1
+
+    def test_metrics_recommendation_attribution_records_event(
+        self, auth_client: TestClient
+    ) -> None:
+        """Recommendation attribution event can be recorded via metrics endpoint."""
+        response = auth_client.post(
+            "/metrics/recommendation-attribution",
+            json={
+                "event_type": "click",
+                "product_id": "prod_2",
+                "session_id": "cart_demo_1",
+                "recommendation_request_id": "rec_demo_1",
+                "position": 1,
+            },
+        )
+        assert response.status_code == 201
+        assert response.json() == {"recorded": True}

--- a/tests/merchant/services/test_metrics.py
+++ b/tests/merchant/services/test_metrics.py
@@ -163,7 +163,9 @@ def test_get_dashboard_metrics_returns_expected_kpis() -> None:
     assert data["recommendation_attribution"]["clicks"] == 0
     assert data["recommendation_attribution"]["purchases"] == 0
     promotion_outcome = next(
-        outcome for outcome in data["agent_outcomes"] if outcome["agent_type"] == "promotion"
+        outcome
+        for outcome in data["agent_outcomes"]
+        if outcome["agent_type"] == "promotion"
     )
     assert promotion_outcome["total_calls"] == 2
     assert promotion_outcome["errors"] == 0
@@ -271,7 +273,9 @@ def test_get_dashboard_metrics_reports_promotion_application_failures() -> None:
     data = get_dashboard_metrics(session, DashboardTimeRange.SEVEN_DAYS)
 
     promotion_outcome = next(
-        outcome for outcome in data["agent_outcomes"] if outcome["agent_type"] == "promotion"
+        outcome
+        for outcome in data["agent_outcomes"]
+        if outcome["agent_type"] == "promotion"
     )
     assert promotion_outcome["total_calls"] == 2
     assert promotion_outcome["errors"] == 1
@@ -341,7 +345,9 @@ def test_get_dashboard_metrics_uses_recorded_agent_outcomes() -> None:
     assert recommendation_outcome["success_rate"] == 50.0
 
     search_outcome = next(
-        outcome for outcome in data["agent_outcomes"] if outcome["agent_type"] == "search"
+        outcome
+        for outcome in data["agent_outcomes"]
+        if outcome["agent_type"] == "search"
     )
     assert search_outcome["source"] == "application"
     assert search_outcome["total_calls"] == 1
@@ -420,7 +426,9 @@ def test_get_dashboard_metrics_reports_recommendation_attribution_funnel() -> No
     engine.dispose()
 
 
-def test_recommendation_attribution_matches_purchase_by_request_id_without_click_session() -> None:
+def test_recommendation_attribution_matches_purchase_by_request_id_without_click_session() -> (
+    None
+):
     """Attributes purchase when click and purchase share request_id/product but not session_id."""
     session, engine = _create_engine()
     now = datetime.now(UTC)

--- a/tests/merchant/services/test_metrics.py
+++ b/tests/merchant/services/test_metrics.py
@@ -1,0 +1,555 @@
+"""Tests for metrics aggregation service."""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, create_engine
+
+from src.merchant.api.metrics_schemas import DashboardTimeRange
+from src.merchant.db.models import (
+    AgentInvocationChannel,
+    AgentInvocationOutcome,
+    AgentInvocationStatus,
+    CheckoutSession,
+    CheckoutStatus,
+    CompetitorPrice,
+    Product,
+    RecommendationAttributionEvent,
+    RecommendationAttributionEventType,
+)
+from src.merchant.services.metrics import get_dashboard_metrics
+
+
+def _create_engine() -> tuple[Session, Engine]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    session = Session(engine)
+    return session, engine
+
+
+def _totals_json(total: int) -> str:
+    return (
+        '[{"type":"items_base_amount","amount":1000},{"type":"subtotal","amount":1000},'
+        f'{{"type":"total","amount":{total}}}]'
+    )
+
+
+def _line_items_json(action: str, discount: int, reasoning: str = "") -> str:
+    return json.dumps(
+        [
+            {
+                "id": "li_1",
+                "item": {"id": "prod_1", "quantity": 1},
+                "discount": discount,
+                "promotion": {
+                    "action": action,
+                    "reasoning": reasoning,
+                },
+            }
+        ]
+    )
+
+
+def _add_checkout(
+    session: Session,
+    *,
+    status: CheckoutStatus,
+    updated_at: datetime,
+    total: int,
+    action: str = "NO_PROMO",
+    discount: int = 0,
+    reasoning: str = "",
+) -> None:
+    checkout = CheckoutSession(
+        id=f"checkout_{updated_at.timestamp()}_{status.value}",
+        status=status,
+        protocol="acp",
+        currency="USD",
+        totals_json=_totals_json(total),
+        line_items_json=_line_items_json(action, discount, reasoning),
+        updated_at=updated_at,
+    )
+    session.add(checkout)
+
+
+def _seed_products(session: Session) -> None:
+    session.add(
+        Product(
+            id="prod_1",
+            sku="SKU-1",
+            name="Product 1",
+            base_price=3000,
+            stock_count=5,
+            min_margin=0.2,
+            image_url="/prod_1.jpg",
+        )
+    )
+    session.add(
+        Product(
+            id="prod_2",
+            sku="SKU-2",
+            name="Product 2",
+            base_price=2000,
+            stock_count=60,
+            min_margin=0.2,
+            image_url="/prod_2.jpg",
+        )
+    )
+    session.add(
+        Product(
+            id="prod_3",
+            sku="SKU-3",
+            name="Product 3",
+            base_price=1500,
+            stock_count=25,
+            min_margin=0.2,
+            image_url="/prod_3.jpg",
+        )
+    )
+    session.add_all(
+        [
+            CompetitorPrice(
+                product_id="prod_1",
+                retailer_name="Comp A",
+                price=2500,
+            ),
+            CompetitorPrice(
+                product_id="prod_2",
+                retailer_name="Comp B",
+                price=2200,
+            ),
+            CompetitorPrice(
+                product_id="prod_3",
+                retailer_name="Comp C",
+                price=1500,
+            ),
+        ]
+    )
+
+
+def test_get_dashboard_metrics_returns_expected_kpis() -> None:
+    """Returns KPI and chart data for a window with completed sessions."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(hours=2),
+        total=3200,
+        action="DISCOUNT_10_PCT",
+        discount=300,
+    )
+    _add_checkout(
+        session,
+        status=CheckoutStatus.NOT_READY_FOR_PAYMENT,
+        updated_at=now - timedelta(hours=1),
+        total=0,
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.SEVEN_DAYS)
+
+    assert data["effective_window"]["fallback_applied"] is False
+    assert len(data["kpis"]) == 4
+    assert {k["id"] for k in data["kpis"]} == {"revenue", "orders", "conversion", "aov"}
+    assert len(data["revenue_data"]) == 7
+    assert len(data["agent_outcomes"]) == 4
+    assert data["recommendation_attribution"]["impressions"] == 0
+    assert data["recommendation_attribution"]["clicks"] == 0
+    assert data["recommendation_attribution"]["purchases"] == 0
+    promotion_outcome = next(
+        outcome for outcome in data["agent_outcomes"] if outcome["agent_type"] == "promotion"
+    )
+    assert promotion_outcome["total_calls"] == 2
+    assert promotion_outcome["errors"] == 0
+    assert promotion_outcome["success_rate"] == 100.0
+    assert len(data["promotion_breakdown"]) >= 1
+    assert len(data["product_health"]) == 3
+
+    session.close()
+    engine.dispose()
+
+
+def test_get_dashboard_metrics_falls_back_when_window_is_empty() -> None:
+    """Falls back to the latest prior non-empty window for requested range."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(days=2, hours=1),
+        total=4500,
+        action="DISCOUNT_5_PCT",
+        discount=100,
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.TWENTY_FOUR_HOURS)
+
+    assert data["effective_window"]["fallback_applied"] is True
+    revenue_kpi = next(k for k in data["kpis"] if k["id"] == "revenue")
+    assert revenue_kpi["value"] == 4500
+
+    session.close()
+    engine.dispose()
+
+
+def test_get_dashboard_metrics_builds_promotion_breakdown_and_product_health() -> None:
+    """Aggregates promotion actions and computes product health flags."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(hours=3),
+        total=5000,
+        action="DISCOUNT_10_PCT",
+        discount=500,
+    )
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(hours=2),
+        total=5100,
+        action="NO_PROMO",
+        discount=0,
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.SEVEN_DAYS)
+
+    breakdown_by_type = {entry["type"]: entry for entry in data["promotion_breakdown"]}
+    assert breakdown_by_type["DISCOUNT_10_PCT"]["count"] == 1
+    assert breakdown_by_type["DISCOUNT_10_PCT"]["total_savings"] == 500
+    assert breakdown_by_type["NO_PROMO"]["count"] == 1
+
+    health_by_id = {entry["id"]: entry for entry in data["product_health"]}
+    assert health_by_id["prod_1"]["stock_status"] == "critical"
+    assert health_by_id["prod_1"]["price_position"] == "above"
+    assert health_by_id["prod_1"]["needs_attention"] is True
+    assert health_by_id["prod_2"]["stock_status"] == "healthy"
+    assert health_by_id["prod_2"]["price_position"] == "below"
+    assert health_by_id["prod_3"]["stock_status"] == "low"
+    assert health_by_id["prod_3"]["price_position"] == "at"
+
+    session.close()
+    engine.dispose()
+
+
+def test_get_dashboard_metrics_reports_promotion_application_failures() -> None:
+    """Counts promotion fallback/error outcomes from merchant-side metadata."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.NOT_READY_FOR_PAYMENT,
+        updated_at=now - timedelta(hours=2),
+        total=0,
+        action="NO_PROMO",
+        discount=0,
+        reasoning="Agent unavailable, no discount applied",
+    )
+    _add_checkout(
+        session,
+        status=CheckoutStatus.NOT_READY_FOR_PAYMENT,
+        updated_at=now - timedelta(hours=1),
+        total=0,
+        action="DISCOUNT_10_PCT",
+        discount=300,
+        reasoning="High inventory and above market",
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.SEVEN_DAYS)
+
+    promotion_outcome = next(
+        outcome for outcome in data["agent_outcomes"] if outcome["agent_type"] == "promotion"
+    )
+    assert promotion_outcome["total_calls"] == 2
+    assert promotion_outcome["errors"] == 1
+    assert promotion_outcome["success_rate"] == 50.0
+
+    recommendation_outcome = next(
+        outcome
+        for outcome in data["agent_outcomes"]
+        if outcome["agent_type"] == "recommendation"
+    )
+    assert recommendation_outcome["source"] == "unavailable"
+    assert recommendation_outcome["success_rate"] is None
+
+    session.close()
+    engine.dispose()
+
+
+def test_get_dashboard_metrics_uses_recorded_agent_outcomes() -> None:
+    """Uses persisted invocation outcomes for non-promotion agent metrics."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(hours=1),
+        total=3400,
+    )
+    session.add_all(
+        [
+            AgentInvocationOutcome(
+                timestamp=now - timedelta(minutes=30),
+                agent_type="recommendation",
+                channel=AgentInvocationChannel.APPS_SDK,
+                status=AgentInvocationStatus.SUCCESS,
+                latency_ms=120,
+            ),
+            AgentInvocationOutcome(
+                timestamp=now - timedelta(minutes=20),
+                agent_type="recommendation",
+                channel=AgentInvocationChannel.APPS_SDK,
+                status=AgentInvocationStatus.ERROR_UPSTREAM,
+                latency_ms=210,
+                error_code="upstream_error",
+            ),
+            AgentInvocationOutcome(
+                timestamp=now - timedelta(minutes=10),
+                agent_type="search",
+                channel=AgentInvocationChannel.APPS_SDK,
+                status=AgentInvocationStatus.SUCCESS,
+                latency_ms=98,
+            ),
+        ]
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.TWENTY_FOUR_HOURS)
+
+    recommendation_outcome = next(
+        outcome
+        for outcome in data["agent_outcomes"]
+        if outcome["agent_type"] == "recommendation"
+    )
+    assert recommendation_outcome["source"] == "application"
+    assert recommendation_outcome["total_calls"] == 2
+    assert recommendation_outcome["errors"] == 1
+    assert recommendation_outcome["success_rate"] == 50.0
+
+    search_outcome = next(
+        outcome for outcome in data["agent_outcomes"] if outcome["agent_type"] == "search"
+    )
+    assert search_outcome["source"] == "application"
+    assert search_outcome["total_calls"] == 1
+    assert search_outcome["errors"] == 0
+    assert search_outcome["success_rate"] == 100.0
+
+    session.close()
+    engine.dispose()
+
+
+def test_get_dashboard_metrics_reports_recommendation_attribution_funnel() -> None:
+    """Builds recommendation impressions/clicks/purchases attribution summary."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(hours=3),
+        total=6100,
+    )
+    session.add_all(
+        [
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=2),
+                event_type=RecommendationAttributionEventType.IMPRESSION,
+                session_id="cart_1",
+                recommendation_request_id="rec_1",
+                product_id="prod_2",
+                position=1,
+            ),
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=2),
+                event_type=RecommendationAttributionEventType.IMPRESSION,
+                session_id="cart_1",
+                recommendation_request_id="rec_1",
+                product_id="prod_3",
+                position=2,
+            ),
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=1, minutes=55),
+                event_type=RecommendationAttributionEventType.CLICK,
+                session_id="cart_1",
+                recommendation_request_id="rec_1",
+                product_id="prod_2",
+                position=1,
+            ),
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=1, minutes=30),
+                event_type=RecommendationAttributionEventType.PURCHASE,
+                session_id="cart_1",
+                recommendation_request_id="rec_1",
+                product_id="prod_2",
+                position=1,
+                order_id="order_abc123",
+                quantity=1,
+                revenue_cents=2800,
+            ),
+        ]
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.TWENTY_FOUR_HOURS)
+    attribution = data["recommendation_attribution"]
+
+    assert attribution["impressions"] == 2
+    assert attribution["clicks"] == 1
+    assert attribution["purchases"] == 1
+    assert attribution["click_through_rate"] == 50.0
+    assert attribution["conversion_rate"] == 100.0
+    assert attribution["attributed_revenue"] == 2800
+    assert attribution["top_products"][0]["product_id"] == "prod_2"
+    assert attribution["top_products"][0]["product_name"] == "Product 2"
+
+    session.close()
+    engine.dispose()
+
+
+def test_recommendation_attribution_matches_purchase_by_request_id_without_click_session() -> None:
+    """Attributes purchase when click and purchase share request_id/product but not session_id."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(hours=2),
+        total=5300,
+    )
+    session.add_all(
+        [
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=1, minutes=50),
+                event_type=RecommendationAttributionEventType.CLICK,
+                session_id=None,
+                recommendation_request_id="rec_flow_1",
+                product_id="prod_2",
+                position=1,
+            ),
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=1, minutes=40),
+                event_type=RecommendationAttributionEventType.PURCHASE,
+                session_id="checkout_abc123",
+                recommendation_request_id="rec_flow_1",
+                product_id="prod_2",
+                position=1,
+                order_id="order_xyz",
+                quantity=1,
+                revenue_cents=2800,
+            ),
+        ]
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.TWENTY_FOUR_HOURS)
+    attribution = data["recommendation_attribution"]
+
+    assert attribution["clicks"] == 1
+    assert attribution["purchases"] == 1
+    assert attribution["conversion_rate"] == 100.0
+    assert attribution["attributed_revenue"] == 2800
+
+    session.close()
+    engine.dispose()
+
+
+def test_recommendation_attribution_uses_event_time_ordering() -> None:
+    """Attribution should follow event timestamps, not insertion order."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(hours=2),
+        total=5300,
+    )
+    # Insert purchase first (out of logical order) to ensure query ordering
+    # still evaluates click -> purchase correctly by timestamp.
+    session.add_all(
+        [
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=1, minutes=40),
+                event_type=RecommendationAttributionEventType.PURCHASE,
+                session_id="checkout_123",
+                recommendation_request_id="rec_time_order_1",
+                product_id="prod_2",
+                order_id="order_time_1",
+                quantity=1,
+                revenue_cents=2800,
+            ),
+            RecommendationAttributionEvent(
+                timestamp=now - timedelta(hours=1, minutes=50),
+                event_type=RecommendationAttributionEventType.CLICK,
+                session_id=None,
+                recommendation_request_id="rec_time_order_1",
+                product_id="prod_2",
+                position=1,
+            ),
+        ]
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.TWENTY_FOUR_HOURS)
+    attribution = data["recommendation_attribution"]
+
+    assert attribution["clicks"] == 1
+    assert attribution["purchases"] == 1
+    assert attribution["attributed_revenue"] == 2800
+
+    session.close()
+    engine.dispose()
+
+
+def test_get_dashboard_metrics_uses_requested_window_for_agent_outcomes() -> None:
+    """Agent outcomes stay aligned to requested range when KPI fallback is used."""
+    session, engine = _create_engine()
+    now = datetime.now(UTC)
+    _seed_products(session)
+    _add_checkout(
+        session,
+        status=CheckoutStatus.COMPLETED,
+        updated_at=now - timedelta(days=2),
+        total=4200,
+    )
+    session.add(
+        AgentInvocationOutcome(
+            timestamp=now - timedelta(hours=1),
+            agent_type="recommendation",
+            channel=AgentInvocationChannel.APPS_SDK,
+            status=AgentInvocationStatus.SUCCESS,
+            latency_ms=140,
+        )
+    )
+    session.commit()
+
+    data = get_dashboard_metrics(session, DashboardTimeRange.TWENTY_FOUR_HOURS)
+
+    assert data["effective_window"]["fallback_applied"] is True
+    recommendation_outcome = next(
+        outcome
+        for outcome in data["agent_outcomes"]
+        if outcome["agent_type"] == "recommendation"
+    )
+    assert recommendation_outcome["source"] == "application"
+    assert recommendation_outcome["total_calls"] == 1
+    assert recommendation_outcome["errors"] == 0
+    assert recommendation_outcome["success_rate"] == 100.0
+
+    session.close()
+    engine.dispose()


### PR DESCRIPTION
## Summary
- replace mock metrics dashboard data with live merchant-backed aggregations and Phoenix-derived latency
- add application-layer agent outcomes + recommendation attribution tracking and dashboard panels
- refine retailer wording in promotion panel and search input placeholder styling

## Test plan
- uv run ruff check src/merchant/api/routes/metrics.py src/merchant/services/agent_outcomes.py src/merchant/services/recommendation_attribution.py tests/merchant/api/test_metrics.py tests/merchant/services/test_metrics.py tests/apps_sdk/test_metrics_outcomes.py
- PYTHONDONTWRITEBYTECODE=1 uv run --extra dev pytest tests/merchant/api/test_metrics.py tests/merchant/services/test_metrics.py tests/apps_sdk/test_metrics_outcomes.py -q
- pnpm test:run hooks/useMetrics.test.tsx hooks/usePhoenixTelemetry.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm format:check

## Related issue/feature
- N/A