### PR TITLE
[frontend] Fix Phoenix metrics latency in Docker deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,7 @@ services:
       # Server-side URLs (internal Docker network) - used by proxy routes
       - MERCHANT_API_URL=http://merchant:8000
       - PSP_API_URL=http://psp:8001
+      - PHOENIX_API_URL=${PHOENIX_API_URL:-http://phoenix:6006}
       # Server-side API keys (NOT exposed to browser) - used by proxy routes
       - MERCHANT_API_KEY=${MERCHANT_API_KEY:-merchant-api-key-12345}
       - PSP_API_KEY=${PSP_API_KEY:-psp-api-key-12345}
@@ -121,6 +122,7 @@ services:
       - WEBHOOK_SECRET=${WEBHOOK_SECRET:-whsec_demo_secret}
     networks:
       - acp-network
+      - acp-infra-network
     restart: unless-stopped
 
   # =============================================================================

--- a/src/ui/env.example
+++ b/src/ui/env.example
@@ -11,6 +11,7 @@ MERCHANT_API_URL=http://localhost:8000
 MERCHANT_API_KEY=test-api-key
 PSP_API_URL=http://localhost:8001
 PSP_API_KEY=psp-api-key-12345
+PHOENIX_API_URL=http://localhost:6006
 
 # =============================================================================
 # Client-side (safe to expose)


### PR DESCRIPTION
## Summary
- add PHOENIX_API_URL for the UI service with an env-driven default for Docker
- attach the ui service to acp-infra-network so it can resolve and reach the phoenix container
- document PHOENIX_API_URL in src/ui/env.example for local configuration clarity

## Test plan
- Docker runtime verification only (per request):
  - recreated ui container via docker compose up -d ui
  - confirmed PHOENIX_API_URL=http://phoenix:6006 in UI container env
  - verified /api/proxy/phoenix/v1/projects returns HTTP 200 from UI container
  - verified non-zero Phoenix latency samples via UI proxy:
    - promotion-agent avg ~641ms
    - arag-recommendations-ultrafast avg ~2690ms
    - post-purchase-agent avg ~844ms
    - search-agent avg ~2702ms

## Related
- fixes metrics dashboard showing 0ms avg latency for all agents in Docker deployment