### PR TITLE
[checkout] Add ACP discount extension coupon flow and docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The project uses three Docker Compose files:
 1. **Configure environment:**
 
    ```bash
+   git clone https://github.com/NVIDIA/Retail-Agentic-Commerce.git
+   cd Retail-Agentic-Commerce
    cp env.example .env
    ```
 
@@ -255,11 +257,9 @@ docker compose -f docker-compose.infra.yml down
 - [uv](https://docs.astral.sh/uv/) package manager
 - Docker (optional, for Recommendation Agent)
 
-### 1. Clone and Configure
+### 1. Configure
 
 ```bash
-git clone https://github.com/NVIDIA/Retail-Agentic-Commerce.git
-cd Retail-Agentic-Commerce
 cp env.example .env
 ```
 
@@ -353,6 +353,7 @@ pnpm dev
 # Terminal 9: Apps SDK Widget (port 3001) - for development
 cd src/apps_sdk/web
 pnpm install
+pnpm build
 pnpm dev
 ```
 

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -1525,6 +1525,7 @@ class ACPCreateSessionRequest(BaseModel):
     items: list[dict[str, Any]] = Field(...)
     buyer: dict[str, str] | None = Field(None)
     fulfillment_address: dict[str, str] | None = Field(None, alias="fulfillmentAddress")
+    discounts: dict[str, list[str]] | None = Field(None)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -1536,6 +1537,7 @@ class ACPUpdateSessionRequest(BaseModel):
     items: list[dict[str, Any]] | None = Field(None)
     fulfillment_option_id: str | None = Field(None, alias="fulfillmentOptionId")
     fulfillment_address: dict[str, str] | None = Field(None, alias="fulfillmentAddress")
+    discounts: dict[str, list[str]] | None = Field(None)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -1572,6 +1574,8 @@ async def acp_create_session(request: ACPCreateSessionRequest) -> dict[str, Any]
                 body["buyer"] = request.buyer
             if request.fulfillment_address:
                 body["fulfillment_address"] = request.fulfillment_address
+            if request.discounts is not None:
+                body["discounts"] = request.discounts
 
             response = await client.post(
                 f"{merchant_api_url}/checkout_sessions",
@@ -1671,6 +1675,8 @@ async def acp_update_session(
         update_parts.append("shipping")
     if request.fulfillment_address:
         update_parts.append("address")
+    if request.discounts is not None:
+        update_parts.append("discounts")
     update_summary = ", ".join(update_parts) or "session"
 
     try:
@@ -1683,6 +1689,8 @@ async def acp_update_session(
                 body["fulfillment_option_id"] = request.fulfillment_option_id
             if request.fulfillment_address is not None:
                 body["fulfillment_address"] = request.fulfillment_address
+            if request.discounts is not None:
+                body["discounts"] = request.discounts
 
             response = await client.post(
                 f"{merchant_api_url}/checkout_sessions/{session_id}",

--- a/src/apps_sdk/web/src/App.tsx
+++ b/src/apps_sdk/web/src/App.tsx
@@ -291,6 +291,42 @@ export function App() {
     [sessionId, getApiBaseUrl]
   );
 
+  // Apply coupon code via ACP session update
+  const handleApplyCoupon = useCallback(
+    async (couponCode: string) => {
+      if (!sessionId) {
+        console.warn("[Widget] No session ID for coupon update");
+        return;
+      }
+
+      const apiBaseUrl = getApiBaseUrl();
+      const normalized = couponCode.trim().toUpperCase();
+      try {
+        const response = await fetch(`${apiBaseUrl}/acp/sessions/${sessionId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionId,
+            discounts: {
+              codes: normalized ? [normalized] : [],
+            },
+          }),
+        });
+
+        if (response.ok) {
+          const data = (await response.json()) as ACPSessionResponse;
+          setAcpSession(data);
+        } else {
+          console.error("[Widget] Coupon update failed:", response.status);
+        }
+      } catch (error) {
+        console.error("[Widget] Failed to update coupon:", error);
+        throw error;
+      }
+    },
+    [sessionId, getApiBaseUrl]
+  );
+
   // Update cart state when ACP session changes - totals come from backend
   useEffect(() => {
     const newCartState = cartStateFromSession(acpSession, cartItems, sessionId || "");
@@ -652,6 +688,7 @@ export function App() {
         <CheckoutPage
           cartItems={cartItems}
           cartState={cartState}
+          sessionData={acpSession}
           recommendations={displayRecommendations}
           isLoadingRecommendations={isLoadingCheckoutRecommendations}
           isProcessing={isCheckingOut}
@@ -664,6 +701,7 @@ export function App() {
           onQuickAdd={handleAddToCart}
           onClearResult={handleClearCart}
           onShippingUpdate={handleShippingUpdate}
+          onApplyCoupon={handleApplyCoupon}
         />
       </div>
     );

--- a/src/apps_sdk/web/src/components/CheckoutPage.tsx
+++ b/src/apps_sdk/web/src/components/CheckoutPage.tsx
@@ -12,7 +12,13 @@ import {
   AlertCircle,
   ChevronDown,
 } from "lucide-react";
-import type { CartItem, CartState, Product, CheckoutResult } from "@/types";
+import type {
+  ACPSessionResponse,
+  CartItem,
+  CartState,
+  Product,
+  CheckoutResult,
+} from "@/types";
 import { formatPrice, getProductImage } from "@/types";
 import { RecommendationSkeleton } from "@/components/RecommendationSkeleton";
 import { PaymentSheet, type PaymentFormData } from "@/components/PaymentSheet";
@@ -54,6 +60,7 @@ interface CheckoutPageProps {
   cartItems: CartItem[];
   /** Cart state with totals from backend - isCalculating indicates pending update */
   cartState: CartState;
+  sessionData: ACPSessionResponse | null;
   recommendations: Product[];
   isLoadingRecommendations: boolean;
   isProcessing: boolean;
@@ -67,6 +74,8 @@ interface CheckoutPageProps {
   onClearResult: () => void;
   /** Called when shipping option changes - parent handles backend call */
   onShippingUpdate: (fulfillmentOptionId: string) => Promise<void>;
+  /** Called when coupon code is applied */
+  onApplyCoupon: (couponCode: string) => Promise<void>;
 }
 
 /**
@@ -226,6 +235,7 @@ function RecommendationCard({
 export function CheckoutPage({
   cartItems,
   cartState,
+  sessionData,
   recommendations,
   isLoadingRecommendations,
   isProcessing,
@@ -238,12 +248,15 @@ export function CheckoutPage({
   onQuickAdd,
   onClearResult,
   onShippingUpdate,
+  onApplyCoupon,
 }: CheckoutPageProps) {
   const isEmpty = cartItems.length === 0;
   const [selectedDelivery, setSelectedDelivery] = useState<string>("standard");
   const [isDeliveryOpen, setIsDeliveryOpen] = useState(false);
   const [isPaymentSheetOpen, setIsPaymentSheetOpen] = useState(false);
   const [isUpdatingShipping, setIsUpdatingShipping] = useState(false);
+  const [couponCode, setCouponCode] = useState("");
+  const [isApplyingCoupon, setIsApplyingCoupon] = useState(false);
 
   const currentDelivery = DELIVERY_OPTIONS.find((d) => d.id === selectedDelivery) || DELIVERY_OPTIONS[0];
 
@@ -257,6 +270,29 @@ export function CheckoutPage({
   const tax = cartState.tax;
   const totalDiscount = cartState.discount;
   const total = cartState.total;
+  const isCalculatingDiscounts = isCalculating || isApplyingCoupon;
+  const appliedDiscounts = sessionData?.discounts?.applied ?? [];
+  const rejectedDiscounts = sessionData?.discounts?.rejected ?? [];
+  const warningMessages = (sessionData?.messages ?? []).filter(
+    (message) => message.type === "warning"
+  );
+  const rejectedMessages = rejectedDiscounts.map(
+    (discount) => discount.message ?? `Code ${discount.code} could not be applied.`
+  );
+  const dedupedWarningMessages = warningMessages.filter((message) => {
+    const content = message.content.trim();
+    const matchesRejectedMessage = rejectedMessages.some(
+      (rejectedMessage) => rejectedMessage === content
+    );
+    const mentionsRejectedCode = rejectedDiscounts.some((discount) =>
+      content.includes(`'${discount.code}'`)
+    );
+    return !matchesRejectedMessage && !mentionsRejectedCode;
+  });
+
+  useEffect(() => {
+    setCouponCode(sessionData?.discounts?.codes?.[0] ?? "");
+  }, [sessionData?.discounts]);
 
   // Handle delivery selection - calls parent to update backend
   const handleSelectDelivery = useCallback(
@@ -300,6 +336,15 @@ export function CheckoutPage({
   const handlePay = useCallback((formData: PaymentFormData) => {
     onCheckout(formData);
   }, [onCheckout]);
+
+  const handleApplyCoupon = useCallback(async () => {
+    setIsApplyingCoupon(true);
+    try {
+      await onApplyCoupon(couponCode.trim());
+    } finally {
+      setIsApplyingCoupon(false);
+    }
+  }, [couponCode, onApplyCoupon]);
 
   // Close payment sheet when checkout result comes back
   useEffect(() => {
@@ -511,6 +556,61 @@ export function CheckoutPage({
                   </div>
                 </section>
 
+                {/* Coupon section */}
+                <section className="space-y-2 border-t border-default/50 pt-3">
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-text-tertiary">
+                    Coupon
+                  </h3>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      placeholder="Enter code (e.g. SAVE10)"
+                      value={couponCode}
+                      onChange={(event) => setCouponCode(event.target.value.toUpperCase())}
+                      className="w-full rounded-xl border border-default bg-surface-elevated px-4 py-3 text-sm text-text placeholder:text-text-tertiary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+                      disabled={isCalculatingDiscounts}
+                    />
+                    <button
+                      type="button"
+                      onClick={handleApplyCoupon}
+                      className="rounded-xl border border-default bg-surface px-4 py-3 text-sm font-medium text-text transition-colors hover:bg-surface-secondary disabled:cursor-not-allowed disabled:opacity-50"
+                      disabled={isCalculatingDiscounts || couponCode.trim().length === 0}
+                    >
+                      Apply
+                    </button>
+                  </div>
+                  {appliedDiscounts.length > 0 && (
+                    <div className="space-y-1">
+                      {appliedDiscounts.map((discount) => (
+                        <p key={discount.id} className="text-xs text-text-secondary">
+                          {discount.automatic ? "Auto offer" : `Code ${discount.code}`}: -
+                          {formatPrice(discount.amount)}
+                        </p>
+                      ))}
+                    </div>
+                  )}
+                  {(rejectedDiscounts.length > 0 || dedupedWarningMessages.length > 0) && (
+                    <div className="space-y-1">
+                      {rejectedDiscounts.map((discount) => (
+                        <p
+                          key={`${discount.code}-${discount.reason}`}
+                          className="text-xs text-amber-600 dark:text-amber-400"
+                        >
+                          {discount.message ?? `Code ${discount.code} could not be applied.`}
+                        </p>
+                      ))}
+                      {dedupedWarningMessages.map((message, index) => (
+                        <p
+                          key={`${message.code ?? "warning"}-${index}`}
+                          className="text-xs text-amber-600 dark:text-amber-400"
+                        >
+                          {message.content}
+                        </p>
+                      ))}
+                    </div>
+                  )}
+                </section>
+
                 {/* Order summary - all values from backend */}
                 <section className="space-y-2 border-t border-default/50 pt-3">
                   {isCalculating && (
@@ -562,12 +662,12 @@ export function CheckoutPage({
               <button
                 className="flex w-full items-center justify-center gap-2.5 rounded-full bg-primary px-6 py-4 text-base font-semibold text-white shadow-lg transition-all hover:bg-primary-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 dark:shadow-primary/20"
                 onClick={handleOpenPayment}
-                disabled={isCalculating}
+                disabled={isCalculatingDiscounts}
               >
                 <Lock className="h-4 w-4" strokeWidth={2} />
                 <span className="flex-1 text-center">Complete Purchase</span>
                 <span className="rounded-full bg-white/20 px-3 py-1 text-sm font-medium">
-                  {isCalculating ? "..." : formatPrice(total)}
+                  {isCalculatingDiscounts ? "..." : formatPrice(total)}
                 </span>
               </button>
             </div>

--- a/src/apps_sdk/web/src/types/index.ts
+++ b/src/apps_sdk/web/src/types/index.ts
@@ -145,6 +145,38 @@ export interface ACPLineItem {
   promotion?: PromotionMetadata;
 }
 
+export interface ACPDiscountAllocation {
+  path: string;
+  amount: number;
+}
+
+export interface ACPAppliedDiscount {
+  id: string;
+  code?: string;
+  amount: number;
+  automatic?: boolean;
+  coupon: {
+    id: string;
+    name: string;
+    percent_off?: number;
+    amount_off?: number;
+    currency?: string;
+  };
+  allocations?: ACPDiscountAllocation[];
+}
+
+export interface ACPRejectedDiscount {
+  code: string;
+  reason: string;
+  message?: string;
+}
+
+export interface ACPDiscounts {
+  codes: string[];
+  applied: ACPAppliedDiscount[];
+  rejected?: ACPRejectedDiscount[];
+}
+
 /**
  * ACP Total entry
  */
@@ -163,6 +195,19 @@ export interface ACPSessionResponse {
   currency: string;
   line_items: ACPLineItem[];
   totals: ACPTotal[];
+  discounts?: ACPDiscounts;
+  messages?: Array<{
+    type: "info" | "warning" | "error";
+    content: string;
+    code?: string;
+  }>;
+  capabilities?: {
+    extensions?: Array<{
+      name: string;
+      extends?: string[];
+      schema?: string;
+    }>;
+  };
   // Other fields we don't need for promotion display
 }
 
@@ -273,10 +318,10 @@ export function cartStateFromSession(
   const total = findTotal("total");
 
   // Calculate discount from line items (sum of individual discounts)
-  const discount = session.line_items?.reduce(
-    (sum, li) => sum + (li.discount || 0),
-    0
-  ) ?? 0;
+  const totalsDiscount = findTotal("items_discount") + findTotal("discount");
+  const discountFromLines =
+    session.line_items?.reduce((sum, li) => sum + (li.discount || 0), 0) ?? 0;
+  const discount = totalsDiscount > 0 ? totalsDiscount : discountFromLines;
 
   return {
     cartId: session.id || cartId,

--- a/src/merchant/api/schemas.py
+++ b/src/merchant/api/schemas.py
@@ -375,6 +375,14 @@ class RejectedDiscount(BaseModel):
     )
 
 
+def _default_applied_discounts() -> list[AppliedDiscount]:
+    return []
+
+
+def _default_rejected_discounts() -> list[RejectedDiscount]:
+    return []
+
+
 class DiscountsResponse(BaseModel):
     """Discount extension response payload."""
 
@@ -382,10 +390,12 @@ class DiscountsResponse(BaseModel):
         default_factory=list, description="Submitted discount codes (echo)"
     )
     applied: list[AppliedDiscount] = Field(
-        default_factory=list, description="Successfully applied discounts"
+        default_factory=_default_applied_discounts,
+        description="Successfully applied discounts",
     )
     rejected: list[RejectedDiscount] = Field(
-        default_factory=list, description="Rejected discount codes"
+        default_factory=_default_rejected_discounts,
+        description="Rejected discount codes",
     )
 
 
@@ -406,11 +416,16 @@ class ExtensionDeclaration(BaseModel):
     )
 
 
+def _default_extensions() -> list[ExtensionDeclaration]:
+    return []
+
+
 class Capabilities(BaseModel):
     """Minimal seller capabilities for extension negotiation."""
 
     extensions: list[ExtensionDeclaration] = Field(
-        default_factory=list, description="Active protocol extensions"
+        default_factory=_default_extensions,
+        description="Active protocol extensions",
     )
 
 

--- a/src/merchant/api/schemas.py
+++ b/src/merchant/api/schemas.py
@@ -67,6 +67,7 @@ class MessageTypeEnum(StrEnum):
     """Message types."""
 
     INFO = "info"
+    WARNING = "warning"
     ERROR = "error"
 
 
@@ -168,6 +169,16 @@ class CreateCheckoutRequest(BaseModel):
     fulfillment_address: AddressInput | None = Field(
         default=None, description="Shipping address"
     )
+    capabilities: dict[str, object] | None = Field(
+        default=None, description="Agent capabilities declaration"
+    )
+    discounts: dict[str, list[str]] | None = Field(
+        default=None, description="Discount extension request payload"
+    )
+    coupons: list[str] | None = Field(
+        default=None,
+        description="DEPRECATED alias for discounts.codes",
+    )
 
 
 class UpdateCheckoutRequest(BaseModel):
@@ -182,6 +193,13 @@ class UpdateCheckoutRequest(BaseModel):
     )
     fulfillment_option_id: str | None = Field(
         default=None, description="Selected fulfillment option ID"
+    )
+    discounts: dict[str, list[str]] | None = Field(
+        default=None, description="Discount extension request payload"
+    )
+    coupons: list[str] | None = Field(
+        default=None,
+        description="DEPRECATED alias for discounts.codes",
     )
 
 
@@ -313,6 +331,89 @@ class Total(BaseModel):
     amount: Annotated[int, Field(ge=0, description="Amount in minor units")]
 
 
+class Allocation(BaseModel):
+    """Allocation breakdown for a discount."""
+
+    path: str = Field(..., description="JSONPath to allocation target")
+    amount: Annotated[int, Field(ge=0, description="Allocated amount")]
+
+
+class Coupon(BaseModel):
+    """Coupon or promotion metadata for an applied discount."""
+
+    id: str = Field(..., description="Coupon identifier")
+    name: str = Field(..., description="Coupon display name")
+    percent_off: float | None = Field(default=None, description="Percentage discount")
+    amount_off: int | None = Field(default=None, description="Fixed discount amount")
+    currency: str | None = Field(
+        default=None, description="Currency for fixed discounts"
+    )
+
+
+class AppliedDiscount(BaseModel):
+    """Discount successfully applied to the checkout session."""
+
+    id: str = Field(..., description="Applied discount ID")
+    code: str | None = Field(default=None, description="Submitted discount code")
+    coupon: Coupon = Field(..., description="Underlying coupon details")
+    amount: Annotated[int, Field(ge=0, description="Applied amount")]
+    automatic: bool = Field(default=False, description="Whether discount was automatic")
+    method: str | None = Field(default=None, description="Allocation method")
+    priority: int | None = Field(default=None, description="Stacking priority")
+    allocations: list[Allocation] | None = Field(
+        default=None, description="Allocation breakdown"
+    )
+
+
+class RejectedDiscount(BaseModel):
+    """Discount code that could not be applied."""
+
+    code: str = Field(..., description="Rejected discount code")
+    reason: str = Field(..., description="Rejection reason code")
+    message: str | None = Field(
+        default=None, description="Human-readable rejection reason"
+    )
+
+
+class DiscountsResponse(BaseModel):
+    """Discount extension response payload."""
+
+    codes: list[str] = Field(
+        default_factory=list, description="Submitted discount codes (echo)"
+    )
+    applied: list[AppliedDiscount] = Field(
+        default_factory=list, description="Successfully applied discounts"
+    )
+    rejected: list[RejectedDiscount] = Field(
+        default_factory=list, description="Rejected discount codes"
+    )
+
+
+class ExtensionDeclaration(BaseModel):
+    """Active extension declaration for checkout sessions."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(..., description="Extension identifier")
+    extends: list[str] = Field(
+        default_factory=list, description="JSONPath fields extended by this extension"
+    )
+    schema_url: str | None = Field(
+        default=None,
+        alias="schema",
+        serialization_alias="schema",
+        description="Schema URL for this extension",
+    )
+
+
+class Capabilities(BaseModel):
+    """Minimal seller capabilities for extension negotiation."""
+
+    extensions: list[ExtensionDeclaration] = Field(
+        default_factory=list, description="Active protocol extensions"
+    )
+
+
 class MessageInfo(BaseModel):
     """Info message."""
 
@@ -332,8 +433,18 @@ class MessageError(BaseModel):
     content: str = Field(..., description="Message content")
 
 
+class MessageWarning(BaseModel):
+    """Warning message."""
+
+    type: MessageTypeEnum = MessageTypeEnum.WARNING
+    code: str = Field(..., description="Warning code")
+    param: str | None = Field(default=None, description="JSONPath to related component")
+    content_type: ContentTypeEnum = Field(..., description="Content format")
+    content: str = Field(..., description="Message content")
+
+
 # Union type for messages
-Message = MessageInfo | MessageError
+Message = MessageInfo | MessageWarning | MessageError
 
 
 class Link(BaseModel):
@@ -356,6 +467,9 @@ class CheckoutSessionResponse(BaseModel):
 
     id: str = Field(..., description="Checkout session ID")
     buyer: Buyer | None = Field(default=None, description="Buyer information")
+    capabilities: Capabilities | None = Field(
+        default=None, description="Session capabilities"
+    )
     payment_provider: PaymentProvider = Field(
         ..., description="Payment provider config"
     )
@@ -372,7 +486,10 @@ class CheckoutSessionResponse(BaseModel):
         default=None, description="Selected fulfillment option"
     )
     totals: list[Total] = Field(..., description="Price totals")
-    messages: list[MessageInfo | MessageError] = Field(
+    discounts: DiscountsResponse | None = Field(
+        default=None, description="Discount extension response"
+    )
+    messages: list[MessageInfo | MessageWarning | MessageError] = Field(
         ..., description="Info and error messages"
     )
     links: list[Link] = Field(..., description="HATEOAS links")

--- a/src/merchant/services/checkout.py
+++ b/src/merchant/services/checkout.py
@@ -26,6 +26,7 @@ from src.merchant.services.helpers import (
     DEFAULT_CURRENCY,
     DEFAULT_SHOP_URL,
     address_input_to_dict,
+    apply_discount_codes,
     buyer_input_to_dict,
     calculate_line_item_with_promotion,
     calculate_totals,
@@ -90,6 +91,35 @@ class InvalidStateTransitionError(CheckoutServiceError):
 # =============================================================================
 
 
+def _extract_discount_codes_from_request(
+    discounts: dict[str, list[str]] | None,
+    coupons: list[str] | None,
+) -> list[str] | None:
+    """Extract submitted discount codes from request fields."""
+    if discounts is not None:
+        return discounts.get("codes", [])
+    if coupons is not None:
+        return coupons
+    return None
+
+
+def _get_existing_discount_codes(session: CheckoutSession) -> list[str]:
+    """Read previously submitted discount codes from session metadata."""
+    if not session.metadata_json:
+        return []
+    try:
+        metadata = json.loads(session.metadata_json)
+    except json.JSONDecodeError:
+        return []
+    raw_discounts = metadata.get("discounts", {})
+    if not isinstance(raw_discounts, dict):
+        return []
+    raw_codes = raw_discounts.get("codes", [])
+    if not isinstance(raw_codes, list):
+        return []
+    return [str(code) for code in raw_codes]
+
+
 async def create_checkout_session(
     db: Session, request: CreateCheckoutRequest, protocol: str = "acp"
 ) -> CheckoutSessionResponse:
@@ -119,15 +149,26 @@ async def create_checkout_session(
 
     # Build line items from products with promotion discounts
     line_items: list[dict[str, Any]] = []
+    products_by_id: dict[str, Product] = {}
     for item in request.items:
         product = db.exec(select(Product).where(Product.id == item.id)).first()
         if product is None:
             logger.warning(f"Product not found: {item.id}")
             raise ProductNotFoundError(item.id)
+        products_by_id[item.id] = product
 
         # Get line item with promotion discount (async call to agent)
         line_item = await calculate_line_item_with_promotion(db, product, item.quantity)
         line_items.append(line_item)
+
+    submitted_codes = _extract_discount_codes_from_request(
+        request.discounts, request.coupons
+    )
+    (
+        line_items,
+        discounts_payload,
+        discount_warning_messages,
+    ) = apply_discount_codes(line_items, products_by_id, submitted_codes)
 
     # Process optional buyer
     buyer_json = None
@@ -164,6 +205,8 @@ async def create_checkout_session(
             "content": "Welcome to checkout! Please complete all required fields.",
         }
     ]
+    messages.extend(discount_warning_messages)
+    metadata = {"discounts": discounts_payload}
 
     # Create database record
     checkout_session = CheckoutSession(
@@ -178,6 +221,7 @@ async def create_checkout_session(
         totals_json=json.dumps(totals),
         messages_json=json.dumps(messages),
         links_json=json.dumps(links),
+        metadata_json=json.dumps(metadata),
     )
 
     db.add(checkout_session)
@@ -266,10 +310,13 @@ async def update_checkout_session(
         update_fields.append("address")
     if request.fulfillment_option_id is not None:
         update_fields.append("shipping")
+    if request.discounts is not None or request.coupons is not None:
+        update_fields.append("discounts")
 
     logger.debug(f"Updating session {session_id} | fields={update_fields}")
 
     # Update items if provided (reuse existing promotion data, no agent call)
+    products_by_id: dict[str, Product] = {}
     if request.items is not None:
         # Build lookup of existing line items by product ID
         existing_line_items: list[dict[str, Any]] = json.loads(session.line_items_json)
@@ -282,6 +329,7 @@ async def update_checkout_session(
             product = db.exec(select(Product).where(Product.id == item.id)).first()
             if product is None:
                 raise ProductNotFoundError(item.id)
+            products_by_id[item.id] = product
 
             # Check if this product has existing promotion data
             existing_li = existing_by_product_id.get(item.id)
@@ -297,6 +345,13 @@ async def update_checkout_session(
                 )
             new_line_items.append(line_item)
         session.line_items_json = json.dumps(new_line_items)
+    else:
+        current_line_items: list[dict[str, Any]] = json.loads(session.line_items_json)
+        for line_item in current_line_items:
+            product_id = str(line_item["item"]["id"])
+            product = db.exec(select(Product).where(Product.id == product_id)).first()
+            if product is not None:
+                products_by_id[product_id] = product
 
     # Update buyer if provided
     if request.buyer is not None:
@@ -325,6 +380,19 @@ async def update_checkout_session(
 
     # Recalculate totals
     current_line_items: list[dict[str, Any]] = json.loads(session.line_items_json)
+    submitted_codes = _extract_discount_codes_from_request(
+        request.discounts, request.coupons
+    )
+    if submitted_codes is None:
+        submitted_codes = _get_existing_discount_codes(session)
+
+    (
+        current_line_items,
+        discounts_payload,
+        discount_warning_messages,
+    ) = apply_discount_codes(current_line_items, products_by_id, submitted_codes)
+    session.line_items_json = json.dumps(current_line_items)
+
     current_fulfillment_options: list[dict[str, Any]] = json.loads(
         session.fulfillment_options_json
     )
@@ -336,18 +404,25 @@ async def update_checkout_session(
     session.totals_json = json.dumps(updated_totals)
 
     # Check if ready for payment and update status
+    base_message = "Welcome to checkout! Please complete all required fields."
     if check_ready_for_payment(session):
         session.status = CheckoutStatus.READY_FOR_PAYMENT
-        # Update message
-        ready_messages: list[dict[str, Any]] = [
+        base_message = "Ready for payment! Review your order and proceed."
+
+    session.messages_json = json.dumps(
+        [
             {
                 "type": "info",
                 "param": "$",
                 "content_type": "plain",
-                "content": "Ready for payment! Review your order and proceed.",
-            }
+                "content": base_message,
+            },
+            *discount_warning_messages,
         ]
-        session.messages_json = json.dumps(ready_messages)
+    )
+    metadata = json.loads(session.metadata_json) if session.metadata_json else {}
+    metadata["discounts"] = discounts_payload
+    session.metadata_json = json.dumps(metadata)
 
     session.updated_at = datetime.now(UTC)
     db.add(session)

--- a/src/merchant/services/checkout.py
+++ b/src/merchant/services/checkout.py
@@ -10,7 +10,7 @@ hybrid architecture (see services/promotion.py).
 import json
 import logging
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 from sqlmodel import Session, select
 
@@ -108,15 +108,20 @@ def _get_existing_discount_codes(session: CheckoutSession) -> list[str]:
     if not session.metadata_json:
         return []
     try:
-        metadata = json.loads(session.metadata_json)
+        metadata_obj = json.loads(session.metadata_json)
     except json.JSONDecodeError:
         return []
-    raw_discounts = metadata.get("discounts", {})
-    if not isinstance(raw_discounts, dict):
+    if not isinstance(metadata_obj, dict):
         return []
-    raw_codes = raw_discounts.get("codes", [])
-    if not isinstance(raw_codes, list):
+    metadata = cast(dict[str, Any], metadata_obj)
+    raw_discounts_obj = metadata.get("discounts", {})
+    if not isinstance(raw_discounts_obj, dict):
         return []
+    raw_discounts = cast(dict[str, Any], raw_discounts_obj)
+    raw_codes_obj = raw_discounts.get("codes", [])
+    if not isinstance(raw_codes_obj, list):
+        return []
+    raw_codes = cast(list[Any], raw_codes_obj)
     return [str(code) for code in raw_codes]
 
 
@@ -420,7 +425,14 @@ async def update_checkout_session(
             *discount_warning_messages,
         ]
     )
-    metadata = json.loads(session.metadata_json) if session.metadata_json else {}
+    metadata: dict[str, Any] = {}
+    if session.metadata_json:
+        try:
+            metadata_obj = json.loads(session.metadata_json)
+        except json.JSONDecodeError:
+            metadata_obj = {}
+        if isinstance(metadata_obj, dict):
+            metadata = cast(dict[str, Any], metadata_obj)
     metadata["discounts"] = discounts_payload
     session.metadata_json = json.dumps(metadata)
 

--- a/src/merchant/services/helpers.py
+++ b/src/merchant/services/helpers.py
@@ -7,7 +7,7 @@ calculating line items, totals, and generating IDs.
 import json
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 from sqlmodel import Session
 
@@ -67,7 +67,7 @@ DISCOUNT_EXTENSION_DECLARATION = ExtensionDeclaration(
         "$.CheckoutSessionUpdateRequest.discounts",
         "$.CheckoutSession.discounts",
     ],
-    schema_url=DISCOUNT_EXTENSION_SCHEMA_URL,
+    schema=DISCOUNT_EXTENSION_SCHEMA_URL,
 )
 COUPON_SAVE10 = "SAVE10"
 
@@ -199,7 +199,7 @@ def _build_automatic_applied_discounts(
         if promotion_discount <= 0:
             continue
 
-        promotion_data = line_item.get("promotion") or {}
+        promotion_data = cast(dict[str, Any], line_item.get("promotion") or {})
         action = str(promotion_data.get("action", "AUTOMATIC_PROMOTION"))
         percent_off = _promotion_percent_from_action(action)
         coupon = Coupon(

--- a/src/merchant/services/helpers.py
+++ b/src/merchant/services/helpers.py
@@ -14,27 +14,41 @@ from sqlmodel import Session
 from src.merchant.api.schemas import (
     Address,
     AddressInput,
+    Allocation,
+    AppliedDiscount,
     Buyer,
     BuyerInput,
+    Capabilities,
     CheckoutSessionResponse,
     CheckoutStatusEnum,
     ContentTypeEnum,
+    Coupon,
+    DiscountsResponse,
+    ErrorCodeEnum,
+    ExtensionDeclaration,
     Item,
     LineItem,
     Link,
     LinkTypeEnum,
+    MessageError,
     MessageInfo,
+    MessageTypeEnum,
+    MessageWarning,
     Order,
     PaymentMethodEnum,
     PaymentProvider,
     PaymentProviderEnum,
     PromotionMetadata,
+    RejectedDiscount,
     ShippingFulfillmentOption,
     Total,
     TotalTypeEnum,
 )
 from src.merchant.db.models import CheckoutSession, Product
-from src.merchant.services.promotion import get_promotion_for_product
+from src.merchant.services.promotion import (
+    get_promotion_for_product,
+    validate_discount_against_margin,
+)
 
 # =============================================================================
 # Constants
@@ -43,6 +57,19 @@ from src.merchant.services.promotion import get_promotion_for_product
 TAX_RATE = 0.10  # 10% tax rate
 DEFAULT_CURRENCY = "usd"
 DEFAULT_SHOP_URL = "https://shop.example.com"
+DISCOUNT_EXTENSION_SCHEMA_URL = (
+    "https://agenticcommerce.dev/schemas/discount/2026-01-27.json"
+)
+DISCOUNT_EXTENSION_DECLARATION = ExtensionDeclaration(
+    name="discount",
+    extends=[
+        "$.CheckoutSessionCreateRequest.discounts",
+        "$.CheckoutSessionUpdateRequest.discounts",
+        "$.CheckoutSession.discounts",
+    ],
+    schema_url=DISCOUNT_EXTENSION_SCHEMA_URL,
+)
+COUPON_SAVE10 = "SAVE10"
 
 
 # =============================================================================
@@ -128,6 +155,235 @@ def dict_to_address(data: dict[str, Any]) -> Address:
 # =============================================================================
 
 
+def _recompute_line_item_totals(line_item: dict[str, Any]) -> None:
+    """Recompute subtotal, tax, and total after discount updates."""
+    subtotal = max(0, int(line_item["base_amount"]) - int(line_item["discount"]))
+    tax = int(subtotal * TAX_RATE)
+    line_item["subtotal"] = subtotal
+    line_item["tax"] = tax
+    line_item["total"] = subtotal + tax
+
+
+def _normalize_discount_codes(codes: list[str] | None) -> list[str]:
+    """Normalize submitted discount codes."""
+    if not codes:
+        return []
+    normalized: list[str] = []
+    for raw_code in codes:
+        code = raw_code.strip().upper()
+        if code:
+            normalized.append(code)
+    return normalized
+
+
+def _promotion_percent_from_action(action: str | None) -> float | None:
+    """Infer promotion percentage from action metadata."""
+    if not action:
+        return None
+    if action.startswith("DISCOUNT_") and action.endswith("_PCT"):
+        parts = action.split("_")
+        if len(parts) >= 3 and parts[1].isdigit():
+            return float(parts[1])
+    return None
+
+
+def _build_automatic_applied_discounts(
+    line_items: list[dict[str, Any]],
+) -> list[AppliedDiscount]:
+    """Build automatic discount entries from promotion metadata."""
+    applied: list[AppliedDiscount] = []
+    for idx, line_item in enumerate(line_items):
+        promotion_discount = int(
+            line_item.get("promotion_discount", line_item.get("discount", 0))
+        )
+        if promotion_discount <= 0:
+            continue
+
+        promotion_data = line_item.get("promotion") or {}
+        action = str(promotion_data.get("action", "AUTOMATIC_PROMOTION"))
+        percent_off = _promotion_percent_from_action(action)
+        coupon = Coupon(
+            id=f"promo_{line_item['id']}",
+            name=action.replace("_", " ").title(),
+            percent_off=percent_off,
+            currency=DEFAULT_CURRENCY,
+        )
+        applied.append(
+            AppliedDiscount(
+                id=f"applied_promo_{line_item['id']}",
+                coupon=coupon,
+                amount=promotion_discount,
+                automatic=True,
+                method="each",
+                priority=idx + 1,
+                allocations=[
+                    Allocation(path=f"$.line_items[{idx}]", amount=promotion_discount)
+                ],
+            )
+        )
+    return applied
+
+
+def apply_discount_codes(
+    line_items: list[dict[str, Any]],
+    products_by_id: dict[str, Product],
+    submitted_codes: list[str] | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+    """Apply coupon discounts on top of promotion discounts.
+
+    This MVP intentionally supports only SAVE10 while preserving
+    compatibility with the ACP discount extension response shape.
+    """
+    normalized_codes = _normalize_discount_codes(submitted_codes)
+
+    # Reset coupon discount before re-applying submitted codes.
+    for line_item in line_items:
+        promotion_discount = int(
+            line_item.get("promotion_discount", line_item.get("discount", 0))
+        )
+        line_item["promotion_discount"] = promotion_discount
+        line_item["coupon_discount"] = 0
+        line_item["discount"] = promotion_discount
+        _recompute_line_item_totals(line_item)
+
+    applied: list[AppliedDiscount] = _build_automatic_applied_discounts(line_items)
+    rejected: list[RejectedDiscount] = []
+    warning_messages: list[dict[str, Any]] = []
+    save10_applied = False
+
+    for code_index, code in enumerate(normalized_codes):
+        if code != COUPON_SAVE10:
+            message = f"Code '{code}' is not recognized."
+            rejected.append(
+                RejectedDiscount(
+                    code=code,
+                    reason="discount_code_invalid",
+                    message=message,
+                )
+            )
+            warning_messages.append(
+                {
+                    "type": MessageTypeEnum.WARNING.value,
+                    "code": "discount_code_invalid",
+                    "param": f"$.discounts.codes[{code_index}]",
+                    "content_type": ContentTypeEnum.PLAIN.value,
+                    "content": message,
+                }
+            )
+            continue
+
+        if save10_applied:
+            message = f"Code '{code}' is already applied."
+            rejected.append(
+                RejectedDiscount(
+                    code=code,
+                    reason="discount_code_already_applied",
+                    message=message,
+                )
+            )
+            warning_messages.append(
+                {
+                    "type": MessageTypeEnum.WARNING.value,
+                    "code": "discount_code_already_applied",
+                    "param": f"$.discounts.codes[{code_index}]",
+                    "content_type": ContentTypeEnum.PLAIN.value,
+                    "content": message,
+                }
+            )
+            continue
+
+        coupon_amount_total = 0
+        allocations: list[Allocation] = []
+        for line_index, line_item in enumerate(line_items):
+            product_id = str(line_item["item"]["id"])
+            product = products_by_id.get(product_id)
+            if product is None:
+                continue
+
+            promotion_discount = int(line_item.get("promotion_discount", 0))
+            subtotal_before_coupon = max(
+                0, int(line_item["base_amount"]) - promotion_discount
+            )
+            raw_coupon_discount = int(subtotal_before_coupon * 0.10)
+            if raw_coupon_discount <= 0:
+                continue
+
+            max_total_discount = max(
+                0,
+                int(line_item["base_amount"])
+                - int(line_item["base_amount"] * product.min_margin),
+            )
+            remaining_discount_budget = max(0, max_total_discount - promotion_discount)
+            coupon_discount = min(raw_coupon_discount, remaining_discount_budget)
+
+            proposed_total_discount = promotion_discount + coupon_discount
+            if coupon_discount <= 0 or not validate_discount_against_margin(
+                int(line_item["base_amount"]),
+                proposed_total_discount,
+                product.min_margin,
+            ):
+                continue
+
+            line_item["coupon_discount"] = coupon_discount
+            line_item["discount"] = proposed_total_discount
+            _recompute_line_item_totals(line_item)
+
+            coupon_amount_total += coupon_discount
+            allocations.append(
+                Allocation(path=f"$.line_items[{line_index}]", amount=coupon_discount)
+            )
+
+        if coupon_amount_total <= 0:
+            message = f"Code '{code}' could not be applied because pricing constraints were not met."
+            rejected.append(
+                RejectedDiscount(
+                    code=code,
+                    reason="discount_code_combination_disallowed",
+                    message=message,
+                )
+            )
+            warning_messages.append(
+                {
+                    "type": MessageTypeEnum.WARNING.value,
+                    "code": "discount_code_combination_disallowed",
+                    "param": f"$.discounts.codes[{code_index}]",
+                    "content_type": ContentTypeEnum.PLAIN.value,
+                    "content": message,
+                }
+            )
+            continue
+
+        applied.append(
+            AppliedDiscount(
+                id=f"applied_coupon_{code.lower()}",
+                code=code,
+                coupon=Coupon(
+                    id="coupon_save10",
+                    name="Save 10%",
+                    percent_off=10.0,
+                    currency=DEFAULT_CURRENCY,
+                ),
+                amount=coupon_amount_total,
+                automatic=False,
+                method="each",
+                priority=100,
+                allocations=allocations,
+            )
+        )
+        save10_applied = True
+
+    discounts_payload = DiscountsResponse(
+        codes=normalized_codes,
+        applied=applied,
+        rejected=rejected,
+    )
+    return (
+        line_items,
+        discounts_payload.model_dump(),
+        warning_messages,
+    )
+
+
 def calculate_line_item(
     product: Product,
     quantity: int,
@@ -162,6 +418,8 @@ def calculate_line_item(
         "name": product.name,
         "base_amount": base_amount,
         "discount": total_discount,
+        "promotion_discount": total_discount,
+        "coupon_discount": 0,
         "subtotal": subtotal,
         "tax": tax,
         "total": total,
@@ -228,7 +486,9 @@ def recalculate_line_item_from_existing(
     """
     # Extract per-unit discount from existing line item
     existing_quantity = existing_line_item["item"]["quantity"]
-    existing_discount = existing_line_item.get("discount", 0)
+    existing_discount = existing_line_item.get(
+        "promotion_discount", existing_line_item.get("discount", 0)
+    )
 
     # Calculate per-unit discount (avoid division by zero)
     if existing_quantity > 0:
@@ -437,6 +697,37 @@ def dict_to_total(data: dict[str, Any]) -> Total:
     )
 
 
+def dict_to_message(
+    data: dict[str, Any],
+) -> MessageInfo | MessageWarning | MessageError:
+    """Convert dictionary to message response model."""
+    message_type = data.get("type", MessageTypeEnum.INFO.value)
+    if message_type == MessageTypeEnum.ERROR.value:
+        raw_code = data.get("code", ErrorCodeEnum.INVALID.value)
+        try:
+            code = ErrorCodeEnum(raw_code)
+        except ValueError:
+            code = ErrorCodeEnum.INVALID
+        return MessageError(
+            code=code,
+            param=data.get("param"),
+            content_type=ContentTypeEnum(data["content_type"]),
+            content=data["content"],
+        )
+    if message_type == MessageTypeEnum.WARNING.value:
+        return MessageWarning(
+            code=data.get("code", "warning"),
+            param=data.get("param"),
+            content_type=ContentTypeEnum(data["content_type"]),
+            content=data["content"],
+        )
+    return MessageInfo(
+        param=data.get("param", "$"),
+        content_type=ContentTypeEnum(data["content_type"]),
+        content=data["content"],
+    )
+
+
 # =============================================================================
 # Link Functions
 # =============================================================================
@@ -519,6 +810,9 @@ def session_to_response(session: CheckoutSession) -> CheckoutSessionResponse:
     )
     messages_data: list[dict[str, Any]] = json.loads(session.messages_json)
     links_data: list[dict[str, Any]] = json.loads(session.links_json)
+    metadata_data: dict[str, Any] = (
+        json.loads(session.metadata_json) if session.metadata_json else {}
+    )
 
     # Convert to response models
     line_items = [dict_to_line_item(item) for item in line_items_data]
@@ -549,18 +843,23 @@ def session_to_response(session: CheckoutSession) -> CheckoutSessionResponse:
         )
 
     # Convert messages
-    messages: list[MessageInfo] = [
-        MessageInfo(
-            param=msg_data["param"],
-            content_type=ContentTypeEnum(msg_data["content_type"]),
-            content=msg_data["content"],
+    messages = [dict_to_message(msg_data) for msg_data in messages_data]
+
+    discounts = None
+    raw_discounts = metadata_data.get("discounts")
+    if isinstance(raw_discounts, dict):
+        discounts = DiscountsResponse.model_validate(raw_discounts)
+    else:
+        discounts = DiscountsResponse(
+            codes=[],
+            applied=_build_automatic_applied_discounts(line_items_data),
+            rejected=[],
         )
-        for msg_data in messages_data
-    ]
 
     return CheckoutSessionResponse(
         id=session.id,
         buyer=buyer,
+        capabilities=Capabilities(extensions=[DISCOUNT_EXTENSION_DECLARATION]),
         payment_provider=PaymentProvider(
             provider=PaymentProviderEnum.STRIPE,
             supported_payment_methods=[PaymentMethodEnum.CARD],
@@ -572,7 +871,8 @@ def session_to_response(session: CheckoutSession) -> CheckoutSessionResponse:
         fulfillment_options=list(fulfillment_options),  # Cast for type compatibility
         fulfillment_option_id=session.selected_fulfillment_option_id,
         totals=totals,
-        messages=list(messages),  # Cast for type compatibility
+        discounts=discounts,
+        messages=list(messages),
         links=links,
         order=order,
     )

--- a/src/merchant/services/ucp.py
+++ b/src/merchant/services/ucp.py
@@ -14,6 +14,7 @@ from src.merchant.api.schemas import (
     LineItem,
     MessageError,
     MessageInfo,
+    MessageWarning,
     Total,
     TotalTypeEnum,
 )
@@ -380,7 +381,9 @@ def _convert_totals(totals: list[Total]) -> list[UCPTotal]:
     return converted
 
 
-def _convert_messages(messages: list[MessageInfo | MessageError]) -> list[UCPMessage]:
+def _convert_messages(
+    messages: list[MessageInfo | MessageWarning | MessageError],
+) -> list[UCPMessage]:
     converted: list[UCPMessage] = []
     for message in messages:
         if isinstance(message, MessageError):
@@ -391,6 +394,18 @@ def _convert_messages(messages: list[MessageInfo | MessageError]) -> list[UCPMes
                     path=message.param,
                     content=message.content,
                     severity=UCPMessageSeverity.RECOVERABLE,
+                )
+            )
+            continue
+
+        if isinstance(message, MessageWarning):
+            converted.append(
+                UCPMessage(
+                    type=UCPMessageType.WARNING,
+                    code=message.code,
+                    path=message.param,
+                    content=message.content,
+                    severity=UCPMessageSeverity.REQUIRES_BUYER_REVIEW,
                 )
             )
             continue

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -400,6 +400,7 @@ export function AgentPanel() {
     selectProduct,
     updateQuantity,
     selectShipping,
+    applyCouponCode,
     submitPayment,
     reset,
     clearError,
@@ -439,6 +440,13 @@ export function AgentPanel() {
       updateQuantity(quantity);
     },
     [updateQuantity]
+  );
+
+  const handleApplyCoupon = useCallback(
+    (couponCode: string) => {
+      applyCouponCode(couponCode);
+    },
+    [applyCouponCode]
   );
 
   // Handle error retry
@@ -563,10 +571,12 @@ export function AgentPanel() {
           total: li.total,
         })),
         subtotal,
-        discount: 0,
+        discount: sessionTotals.find((t) => t.type === "items_discount")?.amount ?? 0,
         tax: sessionTotals.find((t) => t.type === "tax")?.amount ?? 0,
         shipping,
         total,
+        ...(context.session.discounts ? { discounts: context.session.discounts } : {}),
+        ...(context.session.messages ? { messages: context.session.messages } : {}),
         fulfillmentOptions,
         selectedFulfillmentOptionId: context.selectedShippingId,
         paymentProvider: {
@@ -692,6 +702,7 @@ export function AgentPanel() {
                 onContinue={handleContinueToPayment}
                 onQuantityChange={handleQuantityChange}
                 onShippingChange={handleShippingChange}
+                onApplyCoupon={handleApplyCoupon}
               />
             )}
 

--- a/src/ui/components/agent/CheckoutCard.test.tsx
+++ b/src/ui/components/agent/CheckoutCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { CheckoutCard } from "./CheckoutCard";
 import type { Product } from "@/types";
 
@@ -224,6 +224,54 @@ describe("CheckoutCard", () => {
       // The Select should be disabled during processing
       const selectTrigger = screen.getByRole("combobox");
       expect(selectTrigger).toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  describe("coupon input", () => {
+    it("renders coupon textbox and apply button", () => {
+      render(<CheckoutCard checkout={mockCheckout} />);
+
+      expect(screen.getByLabelText("Coupon code")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /apply coupon/i })).toBeInTheDocument();
+    });
+
+    it("calls onApplyCoupon with normalized code", () => {
+      const onApplyCoupon = vi.fn();
+      render(<CheckoutCard checkout={mockCheckout} onApplyCoupon={onApplyCoupon} />);
+
+      const input = screen.getByLabelText("Coupon code");
+      fireEvent.change(input, { target: { value: "save10" } });
+      screen.getByRole("button", { name: /apply coupon/i }).click();
+
+      expect(onApplyCoupon).toHaveBeenCalledWith("SAVE10");
+    });
+
+    it("shows one invalid-code message when warning duplicates rejected entry", () => {
+      const checkoutWithDuplicateWarning = {
+        ...mockCheckout,
+        discounts: {
+          codes: ["SAVE1"],
+          applied: [],
+          rejected: [
+            {
+              code: "SAVE1",
+              reason: "discount_code_invalid",
+              message: "Code 'SAVE1' is not recognized.",
+            },
+          ],
+        },
+        messages: [
+          {
+            type: "warning" as const,
+            code: "discount_code_invalid",
+            content: "Code 'SAVE1' is not recognized.",
+          },
+        ],
+      };
+
+      render(<CheckoutCard checkout={checkoutWithDuplicateWarning} />);
+
+      expect(screen.getAllByText("Code 'SAVE1' is not recognized.")).toHaveLength(1);
     });
   });
 

--- a/src/ui/components/agent/CheckoutCard.tsx
+++ b/src/ui/components/agent/CheckoutCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { Card, Text, Button, Stack, Flex, Divider, Select } from "@kui/foundations-react-external";
 import { CreditCard } from "@/components/icons";
@@ -63,6 +64,26 @@ interface LegacyCheckoutSession {
     provider: string;
     supportedPaymentMethods: string[];
   };
+  discounts?: {
+    codes: string[];
+    applied: Array<{
+      id: string;
+      code?: string;
+      amount: number;
+      coupon: { name: string };
+      automatic?: boolean;
+    }>;
+    rejected?: Array<{
+      code: string;
+      reason: string;
+      message?: string;
+    }>;
+  };
+  messages?: Array<{
+    type: "info" | "warning" | "error";
+    content: string;
+    code?: string;
+  }>;
   createdAt: string;
   updatedAt: string;
 }
@@ -76,6 +97,7 @@ interface CheckoutCardProps {
   onContinue?: () => void;
   onQuantityChange?: (quantity: number) => void;
   onShippingChange?: (optionId: string) => void;
+  onApplyCoupon?: (couponCode: string) => void;
 }
 
 /**
@@ -90,7 +112,9 @@ export function CheckoutCard({
   onContinue,
   onQuantityChange,
   onShippingChange,
+  onApplyCoupon,
 }: CheckoutCardProps) {
+  const [couponInput, setCouponInput] = useState("");
   const lineItem = checkout.lineItems[0];
   const fulfillmentOptions = (checkout.fulfillmentOptions ?? []) as LegacyFulfillmentOption[];
   const selectedOption = fulfillmentOptions.find(
@@ -133,6 +157,31 @@ export function CheckoutCard({
   const handleShippingChange = (value: string) => {
     onShippingChange?.(value);
   };
+
+  useEffect(() => {
+    setCouponInput(checkout.discounts?.codes?.[0] ?? "");
+  }, [checkout.discounts]);
+
+  const handleApplyCoupon = () => {
+    onApplyCoupon?.(couponInput.trim());
+  };
+
+  const appliedDiscounts = checkout.discounts?.applied ?? [];
+  const rejectedDiscounts = checkout.discounts?.rejected ?? [];
+  const warningMessages = (checkout.messages ?? []).filter((m) => m.type === "warning");
+  const rejectedMessages = rejectedDiscounts.map(
+    (rejected) => rejected.message ?? `Code ${rejected.code} could not be applied.`
+  );
+  const dedupedWarningMessages = warningMessages.filter((message) => {
+    const content = message.content.trim();
+    const matchesRejectedMessage = rejectedMessages.some(
+      (rejectedMessage) => rejectedMessage === content
+    );
+    const mentionsRejectedCode = rejectedDiscounts.some((rejected) =>
+      content.includes(`'${rejected.code}'`)
+    );
+    return !matchesRejectedMessage && !mentionsRejectedCode;
+  });
 
   // Build shipping options for Select component
   const shippingItems: Array<{ value: string; children: string }> = fulfillmentOptions.map(
@@ -250,6 +299,68 @@ export function CheckoutCard({
                 </Flex>
               </Flex>
             )
+          )}
+        </Stack>
+
+        <Divider />
+
+        {/* Coupon input */}
+        <Stack gap="2">
+          <Text kind="label/semibold/sm" className="text-primary">
+            Coupon code
+          </Text>
+          <Flex gap="2">
+            <div className="nv-input nv-text-input-root flex-1">
+              <input
+                type="text"
+                value={couponInput}
+                onChange={(event) => setCouponInput(event.target.value.toUpperCase())}
+                placeholder="Enter code (e.g. SAVE10)"
+                className="nv-text-input-element"
+                disabled={isProcessing}
+                aria-label="Coupon code"
+              />
+            </div>
+            <Button
+              kind="secondary"
+              onClick={handleApplyCoupon}
+              disabled={isProcessing || couponInput.trim().length === 0}
+              aria-label="Apply coupon"
+            >
+              Apply
+            </Button>
+          </Flex>
+          {appliedDiscounts.length > 0 && (
+            <Stack gap="1">
+              {appliedDiscounts.map((applied) => (
+                <Text key={applied.id} kind="body/regular/sm" className="text-secondary">
+                  {applied.automatic ? "Auto offer" : `Code ${applied.code}`}:{" "}
+                  -{formatCurrency(applied.amount)}
+                </Text>
+              ))}
+            </Stack>
+          )}
+          {(rejectedDiscounts.length > 0 || dedupedWarningMessages.length > 0) && (
+            <Stack gap="1">
+              {rejectedDiscounts.map((rejected) => (
+                <Text
+                  key={`${rejected.code}-${rejected.reason}`}
+                  kind="body/regular/sm"
+                  className="text-amber-600 dark:text-amber-400"
+                >
+                  {rejected.message ?? `Code ${rejected.code} could not be applied.`}
+                </Text>
+              ))}
+              {dedupedWarningMessages.map((message, index) => (
+                <Text
+                  key={`${message.code ?? "warning"}-${index}`}
+                  kind="body/regular/sm"
+                  className="text-amber-600 dark:text-amber-400"
+                >
+                  {message.content}
+                </Text>
+              ))}
+            </Stack>
           )}
         </Stack>
 

--- a/src/ui/components/agent/CheckoutCard.tsx
+++ b/src/ui/components/agent/CheckoutCard.tsx
@@ -334,8 +334,8 @@ export function CheckoutCard({
             <Stack gap="1">
               {appliedDiscounts.map((applied) => (
                 <Text key={applied.id} kind="body/regular/sm" className="text-secondary">
-                  {applied.automatic ? "Auto offer" : `Code ${applied.code}`}:{" "}
-                  -{formatCurrency(applied.amount)}
+                  {applied.automatic ? "Auto offer" : `Code ${applied.code}`}: -
+                  {formatCurrency(applied.amount)}
                 </Text>
               ))}
             </Stack>

--- a/src/ui/env.example
+++ b/src/ui/env.example
@@ -8,7 +8,7 @@
 # These are used by Next.js API proxy routes
 # =============================================================================
 MERCHANT_API_URL=http://localhost:8000
-MERCHANT_API_KEY=test-api-key
+MERCHANT_API_KEY=merchant-api-key-12345
 PSP_API_URL=http://localhost:8001
 PSP_API_KEY=psp-api-key-12345
 PHOENIX_API_URL=http://localhost:6006

--- a/src/ui/hooks/useCheckoutFlow.test.ts
+++ b/src/ui/hooks/useCheckoutFlow.test.ts
@@ -336,6 +336,36 @@ describe("useCheckoutFlow", () => {
     });
   });
 
+  describe("applyCouponCode", () => {
+    it("updates session with discounts codes payload", async () => {
+      vi.mocked(apiClient.createCheckoutSession).mockResolvedValueOnce(mockSession);
+      vi.mocked(apiClient.updateCheckoutSession).mockResolvedValue(mockReadySession);
+
+      const { result } = renderHook(() => useCheckoutFlow());
+
+      await act(async () => {
+        await result.current.selectProduct(mockProduct);
+      });
+
+      await waitFor(() => {
+        expect(result.current.context.state).toBe("checkout");
+      });
+
+      await act(async () => {
+        await result.current.applyCouponCode("save10");
+      });
+
+      expect(apiClient.updateCheckoutSession).toHaveBeenCalledWith(
+        "cs_test123",
+        expect.objectContaining({
+          discounts: {
+            codes: ["SAVE10"],
+          },
+        })
+      );
+    });
+  });
+
   // Mock payment and billing data for tests
   const mockPaymentInfo = {
     cardNumber: "4242424242424242",

--- a/src/ui/hooks/useCheckoutFlow.ts
+++ b/src/ui/hooks/useCheckoutFlow.ts
@@ -558,6 +558,53 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
   );
 
   /**
+   * Apply coupon code and update session discounts
+   */
+  const applyCouponCode = useCallback(
+    async (couponCode: string) => {
+      if (!context.sessionId) {
+        return;
+      }
+
+      dispatch({ type: "SET_LOADING", isLoading: true });
+
+      const normalized = couponCode.trim().toUpperCase();
+      const eventId = loggerRef.current?.logEvent(
+        "session_update",
+        "POST",
+        `/checkout_sessions/${truncateId(context.sessionId)}`,
+        normalized ? `Apply coupon: ${normalized}` : "Clear coupons"
+      );
+
+      try {
+        const session = await updateCheckoutSession(context.sessionId, {
+          discounts: {
+            codes: normalized ? [normalized] : [],
+          },
+        });
+
+        if (eventId) {
+          const total = session.totals.find((t) => t.type === "total")?.amount ?? 0;
+          loggerRef.current?.completeEvent(
+            eventId,
+            "success",
+            `Total: $${(total / 100).toFixed(2)}`,
+            200
+          );
+        }
+
+        dispatch({ type: "SESSION_UPDATED", session });
+      } catch (error) {
+        if (eventId) {
+          loggerRef.current?.completeEvent(eventId, "error", "Coupon update failed", 400);
+        }
+        dispatch({ type: "SET_ERROR", error: createAPIError(error) });
+      }
+    },
+    [context.sessionId]
+  );
+
+  /**
    * Submit payment - delegates to PSP and completes checkout
    * Accepts optional payment info and billing address to support immediate submission
    * without waiting for context state to update
@@ -800,6 +847,7 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
     selectProduct,
     updateQuantity,
     selectShipping,
+    applyCouponCode,
     submitPayment,
     reset,
     clearError,

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -223,6 +223,73 @@ export interface AgentCapabilities {
   };
 }
 
+/**
+ * Extension declaration in capabilities.extensions
+ */
+export interface ExtensionDeclaration {
+  name: string;
+  extends?: string[];
+  schema?: string;
+}
+
+/**
+ * Session capabilities (minimal extension-focused model)
+ */
+export interface CheckoutCapabilities {
+  extensions?: ExtensionDeclaration[];
+}
+
+/**
+ * Discount allocation target
+ */
+export interface DiscountAllocation {
+  path: string;
+  amount: number;
+}
+
+/**
+ * Coupon details for applied discounts
+ */
+export interface CouponDetails {
+  id: string;
+  name: string;
+  percent_off?: number;
+  amount_off?: number;
+  currency?: string;
+}
+
+/**
+ * Applied discount
+ */
+export interface AppliedDiscount {
+  id: string;
+  code?: string;
+  coupon: CouponDetails;
+  amount: number;
+  automatic?: boolean;
+  method?: "each" | "across" | string;
+  priority?: number;
+  allocations?: DiscountAllocation[];
+}
+
+/**
+ * Rejected discount code
+ */
+export interface RejectedDiscount {
+  code: string;
+  reason: string;
+  message?: string;
+}
+
+/**
+ * Discounts extension response
+ */
+export interface DiscountsResponse {
+  codes: string[];
+  applied: AppliedDiscount[];
+  rejected?: RejectedDiscount[];
+}
+
 // =============================================================================
 // Totals & Messages
 // =============================================================================
@@ -253,7 +320,7 @@ export interface Total {
 /**
  * Message types
  */
-export type MessageType = "info" | "error";
+export type MessageType = "info" | "warning" | "error";
 
 /**
  * Error codes
@@ -288,9 +355,20 @@ export interface ErrorMessage {
 }
 
 /**
+ * Warning message
+ */
+export interface WarningMessage {
+  type: "warning";
+  code: string;
+  param?: string;
+  content_type: "plain" | "markdown";
+  content: string;
+}
+
+/**
  * Union type for messages
  */
-export type Message = InfoMessage | ErrorMessage;
+export type Message = InfoMessage | WarningMessage | ErrorMessage;
 
 /**
  * Link types
@@ -418,8 +496,10 @@ export interface CheckoutSessionResponse {
   status: CheckoutStatus;
   currency: string;
   buyer?: Buyer;
+  capabilities?: CheckoutCapabilities;
   payment_provider: PaymentProvider;
   seller_capabilities?: SellerCapabilities;
+  discounts?: DiscountsResponse;
   line_items: LineItem[];
   fulfillment_details?: FulfillmentDetails;
   fulfillment_options: FulfillmentOption[];
@@ -474,6 +554,13 @@ export interface CreateCheckoutRequest {
   items: ItemInput[];
   buyer?: Buyer;
   fulfillment_address?: Address;
+  capabilities?: {
+    extensions?: string[];
+  };
+  discounts?: {
+    codes: string[];
+  };
+  coupons?: string[];
 }
 
 /**
@@ -484,6 +571,10 @@ export interface UpdateCheckoutRequest {
   buyer?: Buyer;
   fulfillment_address?: Address;
   fulfillment_option_id?: string;
+  discounts?: {
+    codes: string[];
+  };
+  coupons?: string[];
 }
 
 /**

--- a/tests/merchant/api/test_checkout.py
+++ b/tests/merchant/api/test_checkout.py
@@ -114,6 +114,40 @@ class TestCreateCheckoutSession:
         assert data["payment_provider"]["provider"] == "stripe"
         assert "card" in data["payment_provider"]["supported_payment_methods"]
 
+    def test_create_session_includes_capabilities_and_discounts(
+        self, auth_client: TestClient
+    ) -> None:
+        """Session response includes discount extension capabilities payload."""
+        response = auth_client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        data = response.json()
+
+        assert response.status_code == 201
+        assert data["capabilities"]["extensions"][0]["name"] == "discount"
+        assert data["discounts"]["codes"] == []
+        assert isinstance(data["discounts"]["applied"], list)
+        assert isinstance(data["discounts"]["rejected"], list)
+
+    def test_create_session_applies_save10_coupon(
+        self, auth_client: TestClient
+    ) -> None:
+        """Submitting SAVE10 applies a stacked coupon discount."""
+        response = auth_client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "discounts": {"codes": ["save10"]},
+            },
+        )
+        data = response.json()
+
+        assert response.status_code == 201
+        assert data["discounts"]["codes"] == ["SAVE10"]
+        assert any(d.get("code") == "SAVE10" for d in data["discounts"]["applied"])
+        assert data["line_items"][0]["discount"] > 0
+
     def test_create_session_includes_totals(self, auth_client: TestClient) -> None:
         """Happy path: Response includes calculated totals."""
         response = auth_client.post(
@@ -447,6 +481,27 @@ class TestUpdateCheckoutSession:
         new_total = next(t["amount"] for t in data["totals"] if t["type"] == "total")
 
         assert new_total == original_total * 2
+
+    def test_update_session_rejects_invalid_coupon(
+        self, auth_client: TestClient
+    ) -> None:
+        """Invalid coupon codes are rejected and surfaced in warning messages."""
+        create_response = auth_client.post(
+            "/checkout_sessions",
+            json={"items": [{"id": "prod_1", "quantity": 1}]},
+        )
+        session_id = create_response.json()["id"]
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"discounts": {"codes": ["NOTREAL"]}},
+        )
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["discounts"]["codes"] == ["NOTREAL"]
+        assert data["discounts"]["rejected"][0]["reason"] == "discount_code_invalid"
+        assert any(msg["type"] == "warning" for msg in data["messages"])
 
     def test_update_nonexistent_session_returns_404(
         self, auth_client: TestClient

--- a/tests/merchant/services/test_checkout.py
+++ b/tests/merchant/services/test_checkout.py
@@ -10,6 +10,7 @@ import pytest
 
 from src.merchant.db.models import Product
 from src.merchant.services.helpers import (
+    apply_discount_codes,
     calculate_line_item,
     recalculate_line_item_from_existing,
 )
@@ -440,3 +441,75 @@ class TestUpdateSessionSkipsPromotionAgent:
         # Existing product should be found
         assert "prod_existing" in existing_by_product_id
         assert existing_by_product_id["prod_existing"]["discount"] == 100
+
+
+class TestCouponStacking:
+    """Tests for coupon stacking and margin protection logic."""
+
+    def test_save10_stacks_on_existing_promotion(self, sample_product: Product) -> None:
+        """SAVE10 applies on top of promotion discount when margin allows."""
+        line_items = [
+            {
+                "id": "li_1",
+                "item": {"id": sample_product.id, "quantity": 1},
+                "base_amount": 2500,
+                "promotion_discount": 250,
+                "coupon_discount": 0,
+                "discount": 250,
+                "subtotal": 2250,
+                "tax": 225,
+                "total": 2475,
+                "promotion": {"action": "DISCOUNT_10_PCT"},
+            }
+        ]
+
+        updated_items, discounts, warnings = apply_discount_codes(
+            line_items=line_items,
+            products_by_id={sample_product.id: sample_product},
+            submitted_codes=["SAVE10"],
+        )
+
+        assert warnings == []
+        assert discounts["codes"] == ["SAVE10"]
+        assert any(
+            applied.get("code") == "SAVE10" for applied in discounts.get("applied", [])
+        )
+        assert updated_items[0]["discount"] > 250
+
+    def test_margin_guard_clamps_coupon_discount(self, sample_product: Product) -> None:
+        """Coupon is clamped when stacked discount would break margin."""
+        constrained_product = Product(
+            id=sample_product.id,
+            sku=sample_product.sku,
+            name=sample_product.name,
+            base_price=sample_product.base_price,
+            stock_count=sample_product.stock_count,
+            min_margin=0.96,
+            image_url=sample_product.image_url,
+        )
+        line_items = [
+            {
+                "id": "li_2",
+                "item": {"id": constrained_product.id, "quantity": 1},
+                "base_amount": 2500,
+                "promotion_discount": 100,
+                "coupon_discount": 0,
+                "discount": 100,
+                "subtotal": 2400,
+                "tax": 240,
+                "total": 2640,
+                "promotion": {"action": "DISCOUNT_5_PCT"},
+            }
+        ]
+
+        updated_items, discounts, warnings = apply_discount_codes(
+            line_items=line_items,
+            products_by_id={constrained_product.id: constrained_product},
+            submitted_codes=["SAVE10"],
+        )
+
+        assert discounts["codes"] == ["SAVE10"]
+        assert len(discounts["applied"]) == 1  # only automatic promotion remains
+        assert len(discounts["rejected"]) == 1
+        assert warnings[0]["type"] == "warning"
+        assert updated_items[0]["discount"] == 100


### PR DESCRIPTION
## Summary
- Add ACP discount-extension support end-to-end, including `discounts` request/response fields, `capabilities.extensions` projection, and merchant-side coupon evaluation with promotion stacking and margin guard.
- Wire coupon apply UX in both native UI and Apps SDK widget, including applied/rejected feedback and warning de-duplication.
- Update setup docs and `src/ui/env.example` to reflect current local setup/API key defaults.

## Test plan
- [x] `uv run ruff check src/merchant/api/schemas.py src/merchant/services/helpers.py src/merchant/services/checkout.py src/apps_sdk/main.py tests/merchant/api/test_checkout.py tests/merchant/services/test_checkout.py`
- [x] `uv run ruff format --check src/merchant/api/schemas.py src/merchant/services/helpers.py src/merchant/services/checkout.py src/apps_sdk/main.py tests/merchant/api/test_checkout.py tests/merchant/services/test_checkout.py`
- [x] `uv run pytest tests/merchant/api/test_checkout.py tests/merchant/services/test_checkout.py -q`
- [x] `pnpm test:run components/agent/CheckoutCard.test.tsx hooks/useCheckoutFlow.test.ts` (from `src/ui`)
- [x] `pnpm typecheck` (from `src/ui`)
- [x] `pnpm typecheck` (from `src/apps_sdk/web`)
- [x] Manual API verification via curl for coupon apply/reject on merchant backend (`HTTP 201` create with `SAVE10`, `HTTP 200` update with invalid code + warning).

Made with [Cursor](https://cursor.com)