### PR TITLE
[backend] Adopt UCP SDK hybrid schema bridge

### DIFF
--- a/docs/features/feature-17-ucp-integration.md
+++ b/docs/features/feature-17-ucp-integration.md
@@ -103,6 +103,21 @@ This is deferred until Phase 6 to keep scope tight and avoid advertising unsuppo
 - Deleted: `src/merchant/api/routes/ucp/checkout.py`, `tests/merchant/api/test_ucp_checkout.py`
 - Ruff linting and Pyright type checking passed
 
+### Schema Contract Strategy (Hybrid SDK Adoption)
+
+The UCP schema layer now uses a **hybrid strategy**:
+
+- `src/merchant/api/ucp_schemas.py` is the compatibility bridge for current
+  wire contracts while importing and using `ucp_sdk` as canonical schema
+  dependency.
+- Existing API wire payloads remain unchanged for discovery and A2A checkout
+  responses to avoid UI/integration regressions.
+- `src/merchant/services/ucp.py` validates both business discovery profiles and
+  checkout responses against SDK-backed models via bridge adapters before
+  returning payloads.
+
+This keeps protocol behavior stable while moving schema authority to the SDK.
+
 ---
 
 ## User Experience

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "httpx==0.28.1",
     "mcp==1.26.0",
     "pymilvus==2.6.7",
+    "ucp-sdk==0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -77,3 +78,6 @@ testpaths = ["tests"]
 pythonpath = ["."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.uv.sources]
+ucp-sdk = { path = "vendor-python-sdk" }

--- a/src/merchant/api/ucp_schemas.py
+++ b/src/merchant/api/ucp_schemas.py
@@ -1,13 +1,53 @@
-"""Pydantic schemas for UCP discovery profile and checkout responses."""
+"""UCP schema bridge using local wire models plus SDK validation adapters.
+
+This module preserves the current project wire contracts while adopting
+`ucp_sdk` as the canonical schema dependency for contract validation.
+"""
 
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field
+from ucp_sdk.models._internal import (
+    Discovery as SDKDiscoveryCapability,
+)
+from ucp_sdk.models._internal import (
+    DiscoveryProfile as SDKDiscoveryProfile,
+)
+from ucp_sdk.models._internal import (
+    Response as SDKResponseCapability,
+)
+from ucp_sdk.models._internal import (
+    ResponseCheckout as SDKResponseCheckout,
+)
+from ucp_sdk.models._internal import (
+    UcpService as SDKService,
+)
+from ucp_sdk.models.discovery.profile_schema import (
+    Payment as SDKDiscoveryPayment,
+)
+from ucp_sdk.models.discovery.profile_schema import (
+    UcpDiscoveryProfile as SDKUcpDiscoveryProfile,
+)
+from ucp_sdk.models.schemas.shopping.checkout_resp import (
+    CheckoutResponse as SDKCheckoutResponse,
+)
+from ucp_sdk.models.schemas.shopping.payment_resp import PaymentResponse as SDKPayment
+from ucp_sdk.models.schemas.shopping.types.payment_handler_resp import (
+    PaymentHandlerResponse as SDKPaymentHandler,
+)
 
 from src.merchant.api.schemas import PaymentDataInput
+
+DEFAULT_UCP_SPEC_URL = "https://ucp.dev/specification/overview"
+DEFAULT_PAYMENT_HANDLER_SPEC_URL = "https://ucp.dev/specification/checkout"
+DEFAULT_PAYMENT_HANDLER_SCHEMA_URL = (
+    "https://ucp.dev/schemas/shopping/payment_handler_config.json"
+)
+DEFAULT_TOS_URL = "https://merchant.example/terms"
+DEFAULT_PRIVACY_URL = "https://merchant.example/privacy"
 
 
 class UCPService(BaseModel):
@@ -16,19 +56,14 @@ class UCPService(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     version: str
-    transport: str  # "rest" for Phase 1
+    transport: str
     endpoint: str
     spec: str | None = None
     schema_url: str | None = Field(default=None, serialization_alias="schema")
 
 
 class UCPCapabilityVersion(BaseModel):
-    """UCP capability with version and optional extension parent.
-
-    ``extends`` may be a single parent (str) or multiple parents (list[str]).
-    Multi-parent extensions (e.g. discount extends checkout AND cart) are kept
-    during pruning when at least one parent is present in the intersection.
-    """
+    """UCP capability with version and optional extension parent(s)."""
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -39,7 +74,7 @@ class UCPCapabilityVersion(BaseModel):
 
 
 class UCPPaymentHandler(BaseModel):
-    """Optional payment handler definition."""
+    """Optional payment handler definition in current project wire shape."""
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -47,23 +82,18 @@ class UCPPaymentHandler(BaseModel):
     version: str
     spec: str | None = None
     schema_url: str | None = Field(default=None, serialization_alias="schema")
-    config: dict[str, Any] | None = None  # Optional handler config per spec
+    config: dict[str, Any] | None = None
 
 
 class UCPSigningKey(BaseModel):
-    """JWK signing key for webhook verification.
+    """JWK signing key for webhook verification."""
 
-    Supports both EC (P-256) and OKP (Ed25519) key types per spec.
-    - EC P-256: kty="EC", crv="P-256", alg="ES256", x and y required
-    - OKP Ed25519: kty="OKP", crv="Ed25519", alg="EdDSA", x required, y omitted
-    """
-
-    kid: str  # Key ID (e.g., "business_2025")
-    kty: str  # Key type: "EC" or "OKP"
-    crv: str  # Curve: "P-256" or "Ed25519"
-    x: str  # Public key x coordinate (base64url)
-    y: str | None = None  # Public key y coordinate (base64url, EC only)
-    alg: str  # Algorithm: "ES256" or "EdDSA"
+    kid: str
+    kty: str
+    crv: str
+    x: str
+    y: str | None = None
+    alg: str
 
 
 class UCPMetadata(BaseModel):
@@ -83,12 +113,12 @@ class UCPBusinessProfile(BaseModel):
 
 
 # =============================================================================
-# UCP Checkout Schemas (Phase 2 - minimal fields)
+# UCP Checkout Schemas (current project wire subset)
 # =============================================================================
 
 
 class UCPCheckoutStatus(StrEnum):
-    """UCP checkout status values (Phase 2 subset)."""
+    """UCP checkout status values used by this implementation."""
 
     INCOMPLETE = "incomplete"
     READY_FOR_COMPLETE = "ready_for_complete"
@@ -97,7 +127,7 @@ class UCPCheckoutStatus(StrEnum):
 
 
 class UCPTotalType(StrEnum):
-    """UCP total types (Phase 2 subset)."""
+    """UCP total types used by this implementation."""
 
     SUBTOTAL = "subtotal"
     DISCOUNT = "discount"
@@ -165,7 +195,7 @@ class UCPUpdateCheckoutRequest(BaseModel):
 
 
 class UCPCompleteCheckoutRequest(BaseModel):
-    """Request body for completing a UCP checkout session (Phase 2)."""
+    """Request body for completing a UCP checkout session."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -210,7 +240,7 @@ class UCPMessage(BaseModel):
     """UCP message for checkout responses."""
 
     type: UCPMessageType = Field(..., description="Message type")
-    code: str | None = Field(default=None, description="Optional error code")
+    code: str | None = Field(default=None, description="Optional code")
     path: str | None = Field(default=None, description="JSONPath for related field")
     content: str = Field(..., description="Message content")
     severity: UCPMessageSeverity | None = Field(
@@ -227,7 +257,7 @@ class UCPResponseMetadata(BaseModel):
 
 
 class UCPCheckoutResponse(BaseModel):
-    """UCP checkout response (Phase 2 minimal fields)."""
+    """UCP checkout response in the current project wire shape."""
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -238,3 +268,285 @@ class UCPCheckoutResponse(BaseModel):
     line_items: list[UCPLineItem]
     totals: list[UCPTotal]
     messages: Annotated[list[UCPMessage], Field(default_factory=list)]
+
+
+# =============================================================================
+# SDK Bridge Adapters
+# =============================================================================
+
+
+def _capability_parent_list(version: UCPCapabilityVersion) -> list[str]:
+    if version.extends is None:
+        return []
+    if isinstance(version.extends, str):
+        return [version.extends]
+    return list(version.extends)
+
+
+def _to_sdk_service(service: UCPService) -> SDKService:
+    payload: dict[str, Any] = {
+        "version": service.version,
+        "spec": service.spec or DEFAULT_UCP_SPEC_URL,
+    }
+
+    if service.transport == "a2a":
+        payload["a2a"] = {"endpoint": service.endpoint}
+    elif service.transport == "rest":
+        payload["rest"] = {
+            "endpoint": service.endpoint,
+            "schema": service.schema_url
+            or "https://ucp.dev/services/shopping/rest.openapi.json",
+        }
+    elif service.transport == "mcp":
+        payload["mcp"] = {
+            "endpoint": service.endpoint,
+            "schema": service.schema_url
+            or "https://ucp.dev/services/shopping/mcp.openrpc.json",
+        }
+    elif service.transport == "embedded":
+        payload["embedded"] = {
+            "schema": service.schema_url
+            or "https://ucp.dev/services/shopping/embedded.openrpc.json"
+        }
+    else:
+        # Preserve backward compatibility: treat unknown transport as a2a.
+        payload["a2a"] = {"endpoint": service.endpoint}
+
+    return SDKService.model_validate(payload)
+
+
+def _to_sdk_discovery_capability(
+    name: str,
+    version: UCPCapabilityVersion,
+) -> SDKDiscoveryCapability:
+    payload: dict[str, Any] = {
+        "name": name,
+        "version": version.version,
+    }
+    if version.spec:
+        payload["spec"] = version.spec
+    if version.schema_url:
+        payload["schema"] = version.schema_url
+
+    parents = _capability_parent_list(version)
+    if parents:
+        payload["extends"] = parents[0]
+        if len(parents) > 1:
+            payload["x_extends_all"] = parents
+
+    return SDKDiscoveryCapability.model_validate(payload)
+
+
+def _to_sdk_response_capability(
+    name: str,
+    version: UCPCapabilityVersion,
+) -> SDKResponseCapability:
+    payload: dict[str, Any] = {
+        "name": name,
+        "version": version.version,
+    }
+    if version.spec:
+        payload["spec"] = version.spec
+    if version.schema_url:
+        payload["schema"] = version.schema_url
+
+    parents = _capability_parent_list(version)
+    if parents:
+        payload["extends"] = parents[0]
+        if len(parents) > 1:
+            payload["x_extends_all"] = parents
+
+    return SDKResponseCapability.model_validate(payload)
+
+
+def _to_sdk_payment_handler(
+    handler_namespace: str,
+    handler: UCPPaymentHandler,
+) -> SDKPaymentHandler:
+    spec = handler.spec or DEFAULT_PAYMENT_HANDLER_SPEC_URL
+    schema_url = handler.schema_url or DEFAULT_PAYMENT_HANDLER_SCHEMA_URL
+    payload: dict[str, Any] = {
+        "id": handler.id,
+        "name": handler_namespace,
+        "version": handler.version,
+        "spec": spec,
+        "config_schema": schema_url,
+        "instrument_schemas": [schema_url],
+        "config": handler.config or {},
+    }
+    return SDKPaymentHandler.model_validate(payload)
+
+
+def _flatten_payment_handlers(
+    payment_handlers: dict[str, list[UCPPaymentHandler]] | None,
+) -> list[SDKPaymentHandler]:
+    if payment_handlers is None:
+        return []
+
+    handlers: list[SDKPaymentHandler] = []
+    for namespace, versions in payment_handlers.items():
+        for handler in versions:
+            handlers.append(_to_sdk_payment_handler(namespace, handler))
+    return handlers
+
+
+def _iter_capabilities(
+    capabilities: dict[str, list[UCPCapabilityVersion]],
+) -> list[tuple[str, UCPCapabilityVersion]]:
+    flattened: list[tuple[str, UCPCapabilityVersion]] = []
+    for capability_name, versions in capabilities.items():
+        for version in versions:
+            flattened.append((capability_name, version))
+    return flattened
+
+
+def to_sdk_discovery_profile(profile: UCPBusinessProfile) -> SDKUcpDiscoveryProfile:
+    """Convert local discovery profile shape to SDK discovery model."""
+    services_payload: dict[str, SDKService] = {}
+    for service_name, versions in profile.ucp.services.items():
+        if not versions:
+            continue
+        services_payload[service_name] = _to_sdk_service(versions[0])
+
+    capabilities_payload = [
+        _to_sdk_discovery_capability(name, version)
+        for name, version in _iter_capabilities(profile.ucp.capabilities)
+    ]
+
+    payload: dict[str, Any] = {
+        "ucp": SDKDiscoveryProfile.model_validate(
+            {
+                "version": profile.ucp.version,
+                "services": services_payload,
+                "capabilities": capabilities_payload,
+            }
+        )
+    }
+
+    payment_handlers = _flatten_payment_handlers(profile.ucp.payment_handlers)
+    if payment_handlers:
+        payload["payment"] = SDKDiscoveryPayment(handlers=payment_handlers)
+
+    if profile.signing_keys:
+        payload["signing_keys"] = [
+            signing_key.model_dump(exclude_none=True)
+            for signing_key in profile.signing_keys
+        ]
+
+    return SDKUcpDiscoveryProfile.model_validate(payload)
+
+
+def _to_sdk_message(message: UCPMessage) -> dict[str, Any]:
+    if message.type == UCPMessageType.ERROR:
+        return {
+            "type": "error",
+            "code": message.code or "invalid",
+            "path": message.path,
+            "content": message.content,
+            "severity": (
+                message.severity.value
+                if message.severity is not None
+                else UCPMessageSeverity.RECOVERABLE.value
+            ),
+        }
+
+    if message.type == UCPMessageType.WARNING:
+        return {
+            "type": "warning",
+            "code": message.code or "warning",
+            "path": message.path,
+            "content": message.content,
+        }
+
+    return {
+        "type": "info",
+        "code": message.code,
+        "path": message.path,
+        "content": message.content,
+    }
+
+
+def to_sdk_checkout_response(response: UCPCheckoutResponse) -> SDKCheckoutResponse:
+    """Convert local checkout response shape to SDK checkout model."""
+    response_caps = [
+        _to_sdk_response_capability(name, version)
+        for name, version in _iter_capabilities(response.ucp.capabilities)
+    ]
+
+    sdk_payment_handlers = _flatten_payment_handlers(response.ucp.payment_handlers)
+
+    payload: dict[str, Any] = {
+        "ucp": SDKResponseCheckout.model_validate(
+            {
+                "version": response.ucp.version,
+                "capabilities": response_caps,
+            }
+        ),
+        "id": response.id,
+        "status": response.status.value,
+        "currency": response.currency,
+        "line_items": [
+            {
+                "id": line_item.id,
+                "item": {
+                    "id": line_item.item.id,
+                    "title": line_item.item.title,
+                    "price": line_item.item.price,
+                },
+                "quantity": line_item.quantity,
+                "totals": [
+                    {
+                        "type": total.type.value,
+                        "display_text": total.label,
+                        "amount": total.amount,
+                    }
+                    for total in line_item.totals
+                ],
+            }
+            for line_item in response.line_items
+        ],
+        "totals": [
+            {
+                "type": total.type.value,
+                "display_text": total.label,
+                "amount": total.amount,
+            }
+            for total in response.totals
+        ],
+        "messages": [_to_sdk_message(message) for message in response.messages],
+        "links": [
+            {"type": "terms_of_service", "url": DEFAULT_TOS_URL},
+            {"type": "privacy_policy", "url": DEFAULT_PRIVACY_URL},
+        ],
+        "payment": SDKPayment.model_validate({"handlers": sdk_payment_handlers}),
+    }
+
+    return SDKCheckoutResponse.model_validate(payload)
+
+
+def validate_business_profile_with_sdk(profile: UCPBusinessProfile) -> None:
+    """Validate discovery profile against SDK models."""
+    to_sdk_discovery_profile(profile)
+
+
+def validate_checkout_response_with_sdk(response: UCPCheckoutResponse) -> None:
+    """Validate checkout response against SDK models."""
+    to_sdk_checkout_response(response)
+
+
+def sdk_summary_for_checkout(response: UCPCheckoutResponse) -> dict[str, Any]:
+    """Return a compact summary of SDK-transformed checkout data for diagnostics."""
+    sdk = to_sdk_checkout_response(response)
+    checkout_data = sdk.model_dump(mode="json")
+    return {
+        "status": checkout_data.get("status"),
+        "line_items": len(cast(list[Any], checkout_data.get("line_items", []))),
+        "handlers": len(
+            cast(
+                list[Any],
+                cast(dict[str, Any], checkout_data.get("payment", {})).get(
+                    "handlers", []
+                ),
+            )
+        ),
+    }

--- a/src/merchant/services/ucp.py
+++ b/src/merchant/services/ucp.py
@@ -35,6 +35,8 @@ from src.merchant.api.ucp_schemas import (
     UCPSigningKey,
     UCPTotal,
     UCPTotalType,
+    validate_business_profile_with_sdk,
+    validate_checkout_response_with_sdk,
 )
 from src.merchant.config import get_settings
 
@@ -94,7 +96,7 @@ def build_business_profile(request_base_url: str | None = None) -> UCPBusinessPr
 
     agent_card_url = f"{base_url.rstrip('/')}/.well-known/agent-card.json"
 
-    return UCPBusinessProfile(
+    profile = UCPBusinessProfile(
         ucp=UCPMetadata(
             version=settings.ucp_version,
             services={
@@ -139,6 +141,10 @@ def build_business_profile(request_base_url: str | None = None) -> UCPBusinessPr
         ),
         signing_keys=signing_keys,
     )
+
+    # Validate using canonical SDK models while preserving current wire shape.
+    validate_business_profile_with_sdk(profile)
+    return profile
 
 
 def clear_profile_cache() -> None:
@@ -307,7 +313,7 @@ def transform_to_ucp_response(
     being included in the response.
     """
     filtered = filter_capabilities_for_checkout(negotiated_capabilities)
-    return UCPCheckoutResponse(
+    response = UCPCheckoutResponse(
         ucp=UCPResponseMetadata(
             version=get_settings().ucp_version,
             capabilities=filtered,
@@ -322,6 +328,8 @@ def transform_to_ucp_response(
         totals=_convert_totals(acp_response.totals),
         messages=_convert_messages(acp_response.messages),
     )
+    validate_checkout_response_with_sdk(response)
+    return response
 
 
 def _map_ucp_status(status: str) -> UCPCheckoutStatus:

--- a/tests/merchant/api/test_ucp_schema_bridge.py
+++ b/tests/merchant/api/test_ucp_schema_bridge.py
@@ -1,0 +1,121 @@
+"""Tests for the UCP schema bridge adapters backed by ucp_sdk."""
+
+from __future__ import annotations
+
+from src.merchant.api.ucp_schemas import (
+    UCPBusinessProfile,
+    UCPCapabilityVersion,
+    UCPCheckoutResponse,
+    UCPCheckoutStatus,
+    UCPItem,
+    UCPLineItem,
+    UCPMessage,
+    UCPMessageType,
+    UCPMetadata,
+    UCPPaymentHandler,
+    UCPResponseMetadata,
+    UCPService,
+    UCPTotal,
+    UCPTotalType,
+    to_sdk_checkout_response,
+    to_sdk_discovery_profile,
+)
+from src.merchant.services.ucp import build_business_profile
+
+
+def test_to_sdk_discovery_profile_supports_current_wire_shape() -> None:
+    profile = UCPBusinessProfile(
+        ucp=UCPMetadata(
+            version="2026-01-11",
+            services={
+                "dev.ucp.shopping": [
+                    UCPService(
+                        version="2026-01-11",
+                        transport="a2a",
+                        endpoint="http://localhost:8000/.well-known/agent-card.json",
+                    )
+                ]
+            },
+            capabilities={
+                "dev.ucp.shopping.checkout": [
+                    UCPCapabilityVersion(version="2026-01-11")
+                ],
+                "dev.ucp.shopping.discount": [
+                    UCPCapabilityVersion(
+                        version="2026-01-11",
+                        extends=[
+                            "dev.ucp.shopping.checkout",
+                            "dev.ucp.shopping.cart",
+                        ],
+                    )
+                ],
+            },
+            payment_handlers={
+                "com.example.processor_tokenizer": [
+                    UCPPaymentHandler(id="processor_tokenizer", version="2026-01-11")
+                ]
+            },
+        )
+    )
+
+    sdk_profile = to_sdk_discovery_profile(profile)
+    dumped = sdk_profile.model_dump(mode="json")
+
+    assert dumped["ucp"]["version"] == "2026-01-11"
+    cap_names = {cap["name"] for cap in dumped["ucp"]["capabilities"]}
+    assert "dev.ucp.shopping.checkout" in cap_names
+    assert "dev.ucp.shopping.discount" in cap_names
+
+
+def test_to_sdk_checkout_response_supports_current_wire_shape() -> None:
+    response = UCPCheckoutResponse(
+        ucp=UCPResponseMetadata(
+            version="2026-01-11",
+            capabilities={
+                "dev.ucp.shopping.checkout": [
+                    UCPCapabilityVersion(version="2026-01-11")
+                ]
+            },
+            payment_handlers={
+                "com.example.processor_tokenizer": [
+                    UCPPaymentHandler(id="processor_tokenizer", version="2026-01-11")
+                ]
+            },
+        ),
+        id="checkout_123",
+        status=UCPCheckoutStatus.INCOMPLETE,
+        currency="USD",
+        line_items=[
+            UCPLineItem(
+                id="li_123",
+                item=UCPItem(id="prod_1", title="Classic Tee", price=2500),
+                quantity=1,
+                totals=[
+                    UCPTotal(type=UCPTotalType.SUBTOTAL, label="Subtotal", amount=2500),
+                    UCPTotal(type=UCPTotalType.TAX, label="Tax", amount=250),
+                    UCPTotal(type=UCPTotalType.TOTAL, label="Total", amount=2750),
+                ],
+            )
+        ],
+        totals=[UCPTotal(type=UCPTotalType.TOTAL, label="Total", amount=2750)],
+        messages=[
+            UCPMessage(
+                type=UCPMessageType.INFO,
+                content="Welcome to checkout",
+                path="$",
+            )
+        ],
+    )
+
+    sdk_response = to_sdk_checkout_response(response)
+    dumped = sdk_response.model_dump(mode="json")
+
+    assert dumped["status"] == "incomplete"
+    assert dumped["id"] == "checkout_123"
+    assert dumped["payment"]["handlers"][0]["id"] == "processor_tokenizer"
+
+
+def test_build_business_profile_remains_sdk_validated() -> None:
+    profile = build_business_profile(request_base_url="http://localhost:8000")
+    assert profile.ucp.version == "2026-01-11"
+    assert "dev.ucp.shopping.checkout" in profile.ucp.capabilities

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ dependencies = [
     { name = "pymilvus" },
     { name = "python-dotenv" },
     { name = "sqlmodel" },
+    { name = "ucp-sdk" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -50,6 +51,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.13" },
     { name = "sqlmodel", specifier = "==0.0.31" },
+    { name = "ucp-sdk", directory = "vendor-python-sdk" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.40.0" },
 ]
 provides-extras = ["dev"]
@@ -244,6 +246,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/6e/1c8331ddf91ca4730ab3086a0f1be19c65510a33b5a441cb334e7a2d2560/cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df", size = 3036695, upload-time = "2025-10-15T23:18:08.672Z" },
     { url = "https://files.pythonhosted.org/packages/90/45/b0d691df20633eff80955a0fc7695ff9051ffce8b69741444bd9ed7bd0db/cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f", size = 3501720, upload-time = "2025-10-15T23:18:10.632Z" },
     { url = "https://files.pythonhosted.org/packages/e8/cb/2da4cc83f5edb9c3257d09e1e7ab7b23f049c7962cae8d842bbef0a9cec9/cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372", size = 2918740, upload-time = "2025-10-15T23:18:12.277Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1220,6 +1244,24 @@ sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf3
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
+
+[[package]]
+name = "ucp-sdk"
+version = "0.1.0"
+source = { directory = "vendor-python-sdk" }
+dependencies = [
+    { name = "email-validator" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "email-validator", specifier = ">=2.0.0" },
+    { name = "pydantic", specifier = ">=2.5.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "datamodel-code-generator", extras = ["http", "ruff"], specifier = ">=0.50.0" }]
 
 [[package]]
 name = "uvicorn"


### PR DESCRIPTION
## Summary
- introduce a hybrid UCP schema bridge in `src/merchant/api/ucp_schemas.py` that preserves current wire contracts while validating against `ucp_sdk` models
- wire SDK-backed validation into discovery profile and checkout response builders in `src/merchant/services/ucp.py`
- add targeted bridge tests and document the hybrid strategy in Feature 17 docs

## Test plan
- `uv run ruff check src/merchant/api/ucp_schemas.py src/merchant/services/ucp.py tests/merchant/api/test_ucp_schema_bridge.py`
- `uv run ruff format --check src/merchant/api/ucp_schemas.py src/merchant/services/ucp.py tests/merchant/api/test_ucp_schema_bridge.py`
- `uv run pyright src/merchant/api/ucp_schemas.py src/merchant/services/ucp.py src/merchant/services/a2a.py`
- `uv run pytest tests/merchant/api/test_ucp_schema_bridge.py tests/merchant/api/test_ucp_discovery.py tests/merchant/api/test_ucp_a2a.py tests/merchant/api/test_ucp_negotiation.py -q`
- runtime curl checks against local uvicorn instance on `127.0.0.1:8012`: health, discovery, and A2A create/missing-header paths

## Notes
- full repo-wide lint currently reports pre-existing unrelated issues in `src/agents/scripts/seed_milvus.py`; this PR scopes checks to touched UCP files/tests
