### PR TITLE
[ucp] Complete Phase 5B UI + post-purchase webhook integration

### DIFF
--- a/.cursor/skills/features/SKILL.md
+++ b/.cursor/skills/features/SKILL.md
@@ -49,6 +49,21 @@ Cursor MUST follow this order when generating or modifying code:
 
 If any step fails or is missing, the work is incomplete.
 
+## Retail-Agentic-Commerce CI Parity (Mandatory)
+Before committing backend-related changes in this repo, run the same checks used in CI from the repo root:
+
+```bash
+uv run ruff check src/merchant/ src/payment/ src/apps_sdk/ tests/
+uv run ruff format --check src/merchant/ src/payment/ src/apps_sdk/ tests/
+uv run pyright src/merchant/ src/payment/ src/apps_sdk/
+uv run pytest tests/ -v --tb=short
+```
+
+Rules:
+- Do not commit if any command above fails.
+- If changes touch both backend and UI, run the UI CI parity commands too (see `.cursor/skills/ui/SKILL.md`).
+- For fast iteration, targeted tests are allowed while developing, but full commands above are required before commit.
+
 ## Python Coding Standards
 - Follow PEP 8 where applicable (Ruff is the source of truth)
 - Use 4-space indentation

--- a/.cursor/skills/ui/SKILL.md
+++ b/.cursor/skills/ui/SKILL.md
@@ -53,6 +53,21 @@ Cursor MUST follow this order when generating or modifying frontend code:
 
 If any step fails or is missing, the work is incomplete.
 
+## Retail-Agentic-Commerce UI CI Parity (Mandatory)
+Before committing UI-related changes in this repo, run the same checks used in CI from `src/ui`:
+
+```bash
+pnpm lint
+pnpm format:check
+pnpm typecheck
+pnpm test:run
+```
+
+Rules:
+- Do not commit if any command above fails.
+- Run from `src/ui` to match CI environment and scripts.
+- If the change also touches backend code, run backend CI parity commands in `.cursor/skills/features/SKILL.md` before commit.
+
 ## Browser Validation (Mandatory When Available)
 When browser MCP tools are available (cursor-browser-extension or cursor-ide-browser), you MUST use them to validate UI changes:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ ACP lets AI agents negotiate with merchants on behalf of users. The merchant sta
 flowchart TB
     subgraph Client["Client Layer"]
         CA[🤖 Client Agent]
+        subgraph Webhooks["UI Webhook Receivers"]
+            WH_ACP["/api/webhooks/acp"]
+            WH_UCP["/api/webhooks/ucp"]
+            BRIDGE["Webhook → Agent Activity Bridge"]
+        end
     end
 
     subgraph Integration["Integration Options"]
@@ -39,10 +44,14 @@ flowchart TB
             WIDGET["🛒 Autonomous Widget<br/>(cart, checkout, recs)"]
         end
 
-        subgraph Native["Native ACP Layer"]
-            ACP["🔗 Direct ACP Protocol"]
-            subgraph endpoints["ACP Endpoints"]
-                E1["checkout_sessions/*"]
+        subgraph Native["Native Protocol Layer"]
+            ACP["🔗 ACP REST Transport"]
+            UCP["🔗 UCP A2A Transport"]
+            subgraph endpoints["Protocol Endpoints"]
+                E1["ACP: /checkout_sessions/*"]
+                E2["UCP: /.well-known/ucp"]
+                E3["UCP: /.well-known/agent-card.json"]
+                E4["UCP: /a2a (message/send)"]
             end
         end
     end
@@ -83,16 +92,27 @@ flowchart TB
 
     CA -->|MCP| MCP
     CA -->|REST| ACP
+    CA -->|A2A JSON-RPC| UCP
     MCP -.->|loads| WIDGET
     WIDGET -->|MCP tools| MCP
     MCP --> MERCHANT
-    ACP --> MERCHANT
+    ACP --> E1
+    UCP --> E2
+    UCP --> E3
+    UCP --> E4
+    E1 --> MERCHANT
+    E4 --> MERCHANT
     MERCHANT --> PSP
     MERCHANT --> PROMO
     MERCHANT --> POST
     MERCHANT --> RECS
     MERCHANT --> SEARCH
     MERCHANT --> SQLITE
+    MERCHANT -->|ACP post-purchase webhook| WH_ACP
+    MERCHANT -->|UCP order webhook| WH_UCP
+    WH_ACP --> BRIDGE
+    WH_UCP --> BRIDGE
+    BRIDGE --> CA
     PROMO --> LLM
     POST --> LLM
     RECS --> LLM
@@ -368,23 +388,39 @@ curl http://localhost:2091/health  # Apps SDK
 ### UCP Endpoints
 
 ```bash
-# Discovery (Phase 1)
+# Discovery
 curl http://localhost:8000/.well-known/ucp
 
-# Checkout (Phase 2) - requires UCP-Agent header
-curl -X POST http://localhost:8000/checkout-sessions \
+# Agent Card
+curl http://localhost:8000/.well-known/agent-card.json
+
+# A2A checkout create (message/send action:create_checkout)
+curl -X POST http://localhost:8000/a2a \
   -H "Authorization: Bearer test-api-key" \
   -H "UCP-Agent: profile=\"https://platform.example/profile\"" \
+  -H "X-A2A-Extensions: https://ucp.dev/2026-01-23/specification/reference/" \
   -H "Content-Type: application/json" \
-  -d '{"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]}'
+  -d '{
+    "jsonrpc":"2.0",
+    "id":"req_1",
+    "method":"message/send",
+    "params":{
+      "message":{
+        "role":"user",
+        "messageId":"msg_1",
+        "kind":"message",
+        "parts":[{"type":"data","data":{"action":"create_checkout","product_id":"prod_1","quantity":1}}]
+      }
+    }
+  }'
 ```
 
 Optional environment variables for UCP:
 
 ```env
-UCP_VERSION=2026-01-11
+UCP_VERSION=2026-01-23
 UCP_BASE_URL=http://localhost:8000
-UCP_SERVICE_PATH=/ucp/v1
+UCP_ORDER_WEBHOOK_URL=http://localhost:3000/api/webhooks/ucp
 UCP_SIGNING_KEY_ID=ucp-key-1
 UCP_SIGNING_KEY_KTY=EC
 UCP_SIGNING_KEY_CRV=P-256

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       # Webhook delivery to client agent (Docker-internal URL by default).
       # Uses a dedicated env var so local WEBHOOK_URL (localhost) does not break container routing.
       - WEBHOOK_URL=${WEBHOOK_URL_DOCKER:-http://ui:3000/api/webhooks/acp}
+      - UCP_ORDER_WEBHOOK_URL=${UCP_ORDER_WEBHOOK_URL_DOCKER:-http://ui:3000/api/webhooks/ucp}
       - WEBHOOK_SECRET=${WEBHOOK_SECRET:-whsec_demo_secret}
     volumes:
       - acp-data:/data
@@ -115,6 +116,7 @@ services:
       - MERCHANT_API_URL=http://merchant:8000
       - PSP_API_URL=http://psp:8001
       - PHOENIX_API_URL=${PHOENIX_API_URL:-http://phoenix:6006}
+      - NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL=${NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL:-http://merchant:8000/.well-known/ucp}
       # Server-side API keys (NOT exposed to browser) - used by proxy routes
       - MERCHANT_API_KEY=${MERCHANT_API_KEY:-merchant-api-key-12345}
       - PSP_API_KEY=${PSP_API_KEY:-psp-api-key-12345}

--- a/docs/features/feature-17-ucp-integration.md
+++ b/docs/features/feature-17-ucp-integration.md
@@ -2,7 +2,7 @@
 
 **Priority**: P1
 
-**Status**: 🟡 In Progress (Phase 4 Complete)
+**Status**: 🟡 In Progress (Phase 5B UI Integration + UCP Order Webhook Complete)
 
 **Dependencies**: Features 3, 4, 5, 6, 7, 8
 
@@ -28,7 +28,7 @@ This feature adds UCP-compliant endpoints that share the same intelligent agent 
 | **Phase 2** | A2A Checkout + Checkout-Only Capability Negotiation | ✅ Complete |
 | **Phase 3** | A2A Transport (JSON-RPC 2.0) | ✅ Complete |
 | **Phase 4** | Full Capability Negotiation (extension pruning) + REST removal | ✅ Complete |
-| **Phase 5** | Frontend Protocol Toggle | 🔲 Planned |
+| **Phase 5** | Frontend Protocol Toggle + Basic UCP Routing + UCP post-purchase webhook UI bridge | ✅ Complete (Phase 5A + 5B) |
 | **Phase 6** | Fulfillment Extension (`dev.ucp.shopping.fulfillment`) | 🔲 Planned |
 
 ### Phase 6: Fulfillment Extension (Deferred)
@@ -103,6 +103,38 @@ This is deferred until Phase 6 to keep scope tight and avoid advertising unsuppo
 - Deleted: `src/merchant/api/routes/ucp/checkout.py`, `tests/merchant/api/test_ucp_checkout.py`
 - Ruff linting and Pyright type checking passed
 
+### Phase 5A Deliverables (Complete - Minimal UI Integration)
+
+| File | Description |
+|------|-------------|
+| `src/ui/components/business/BusinessPanel.tsx` | Added Merchant panel protocol tabs (`ACP` / `UCP`) and protocol-aware panel copy |
+| `src/ui/app/page.tsx` | Added shared protocol state between Merchant and Client panels |
+| `src/ui/components/agent/AgentPanel.tsx` | Wired protocol into checkout flow; reset flow on protocol switch |
+| `src/ui/hooks/useCheckoutFlow.ts` | Protocol-aware checkout calls/logging and UCP context propagation |
+| `src/ui/lib/api-client.ts` | Added UCP A2A adapter and protocol-aware checkout methods |
+| `src/ui/app/api/proxy/merchant/[...path]/route.ts` | Forwarded `UCP-Agent` and `X-A2A-Extensions` headers |
+| `src/ui/types/index.ts` | Added `CheckoutProtocol`, optional `ucpContextId`, `continue_url` fields |
+| `src/ui/components/agent/ModeTabSwitcher.tsx` | Updated client mode label from `Native ACP` to `Native` |
+| `src/ui/lib/api-client.test.ts` | Added protocol routing + A2A parsing tests |
+| `src/ui/hooks/useCheckoutFlow.test.ts` | Added UCP routing/context coverage |
+| `src/ui/components/business/BusinessPanel.test.tsx` | Added ACP/UCP tab rendering assertions |
+| `src/ui/app/api/proxy/merchant/__tests__/route.test.ts` | Added header forwarding assertions for UCP headers |
+
+- UI quality gates passed in `src/ui`: `pnpm test:run`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`
+- Scope intentionally remains minimal for this phase: advanced UCP capability/payment handler visualization deferred
+
+### Phase 5B Deliverables (Complete - UCP Post-Purchase UI Bridge)
+
+| File | Description |
+|------|-------------|
+| `src/ui/app/api/webhooks/ucp/route.ts` | Added UCP order webhook receiver (`POST/GET/DELETE /api/webhooks/ucp`) for `dev.ucp.shopping.order` events |
+| `src/ui/lib/webhook-emitter.ts` | Extended webhook event contract with protocol source (`acp` / `ucp`) |
+| `src/ui/components/WebhookToAgentActivityBridge.tsx` | Protocol-aware webhook log routing in Merchant Activity (`/api/webhooks/acp` vs `/api/webhooks/ucp`) |
+| `src/ui/components/WebhookToAgentActivityBridge.test.tsx` | Added regression test that UCP shipping updates log `/api/webhooks/ucp` |
+
+- UCP post-purchase events now flow into the same Agent Activity + notification UX as ACP
+- Merchant Activity no longer hardcodes `/api/webhooks/acp` for UCP events
+
 ### Schema Contract Strategy (Hybrid SDK Adoption)
 
 The UCP schema layer now uses a **hybrid strategy**:
@@ -153,7 +185,7 @@ This keeps protocol behavior stable while moving schema authority to the SDK.
 
 ## Goals
 
-1. Implement UCP v2026-01-11 specification alongside existing ACP v2026-01-16
+1. Implement UCP v2026-01-23 specification alongside existing ACP v2026-01-16
 2. Add UCP discovery endpoint for profile negotiation
 3. Implement A2A transport for agent-to-agent UCP communication (JSON-RPC 2.0)
 4. Implement capability negotiation with platform profiles
@@ -386,27 +418,34 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. All UCP 
 ### Frontend Tasks
 
 1. **Add Protocol Toggle to Merchant Activity Panel**
-   - [ ] Tab switcher component (ACP | UCP)
-   - [ ] Toggle determines which backend protocol is used
-   - [ ] Protocol state shared with Client Agent via context/API
+   - [x] Tab switcher component (ACP | UCP) ✅ Phase 5A
+   - [x] Toggle determines which backend protocol is used ✅ Phase 5A
+   - [x] Protocol state shared with Client Agent via context/API ✅ Phase 5A
 
 2. **UCP Event Log Display**
-   - [ ] A2A JSON-RPC request/response visualization
-   - [ ] Capability negotiation visualization
+   - [x] A2A operation event visualization (`/a2a`, action summary, status) ✅ Phase 5A
+   - [x] Capability negotiation visualization (status summaries include negotiated capability names) ✅ Phase 5A
    - [ ] Payment handler display
-   - [ ] UCP-specific status values
+   - [x] UCP-specific status values mapped for native flow compatibility ✅ Phase 5A
 
 3. **Update Protocol Logger**
-   - [ ] Detect UCP vs ACP protocol from response
+   - [x] Detect UCP vs ACP protocol from active panel mode and request path ✅ Phase 5A
    - [ ] Format UCP-specific metadata (`ucp` object)
-   - [ ] Display negotiated capabilities
+   - [x] Display negotiated capabilities in UCP status summaries ✅ Phase 5A
+   - [x] Route post-purchase webhook log entries to protocol-specific endpoint (`/api/webhooks/acp` vs `/api/webhooks/ucp`) ✅ Phase 5B
    - [ ] Show platform profile URL
 
 4. **Client Agent Integration** (No UI changes - same native flow)
-   - [ ] Read active protocol from Merchant Panel toggle
-   - [ ] Send `UCP-Agent` header when UCP is active
-   - [ ] Route requests to `/a2a` endpoint when UCP is active
-   - [ ] Handle UCP-specific status values and messages
+   - [x] Read active protocol from Merchant Panel toggle ✅ Phase 5A
+   - [x] Send `UCP-Agent` header when UCP is active ✅ Phase 5A
+   - [x] Route requests to `/a2a` endpoint when UCP is active ✅ Phase 5A
+   - [x] Handle UCP-specific status values and messages ✅ Phase 5A
+   - [x] Receive and process UCP order webhooks at `/api/webhooks/ucp` for post-purchase events ✅ Phase 5B
+
+5. **UCP Post-Purchase Integration**
+   - [x] Negotiate `dev.ucp.shopping.order` and capture `config.webhook_url` when provided ✅ Phase 5B
+   - [x] Trigger post-purchase agent on UCP checkout completion via background task ✅ Phase 5B
+   - [x] Dispatch UCP order webhook to negotiated URL or `UCP_ORDER_WEBHOOK_URL` fallback ✅ Phase 5B
 
 ### Testing Tasks (Mandatory per `.cursor/skills/features/SKILL.md`)
 
@@ -424,7 +463,8 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. All UCP 
 3. **Integration Tests**
    - [ ] End-to-end UCP checkout flow via A2A
    - [ ] A2A transport with NAT agents
-   - [ ] Protocol toggle behavior
+   - [x] Protocol toggle behavior (UI protocol state/reset coverage) ✅ Phase 5A
+   - [x] UCP complete_checkout selects negotiated/fallback order webhook URL ✅ Phase 5B
 
 ---
 
@@ -467,7 +507,7 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. All UCP 
 2. **Agent Integration**
    - [ ] Verify Promotion Agent invoked for UCP sessions
    - [ ] Verify Recommendation Agent invoked for UCP sessions
-   - [ ] Verify Post-Purchase Agent triggers for UCP orders
+   - [x] Verify Post-Purchase Agent triggers for UCP orders ✅ Phase 5B
 
 ---
 
@@ -492,11 +532,12 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. All UCP 
 - [x] UCP sessions are stored with `protocol: "ucp"` field
 
 ### UI Requirements
-- [ ] Merchant Activity Panel has UCP tab
-- [ ] UCP tab displays A2A JSON-RPC request/response events
-- [ ] UCP tab shows capability negotiation results
-- [ ] Protocol logger distinguishes UCP from ACP events
-- [ ] Agent Activity panel shows agent decisions for both protocols
+- [x] Merchant Activity Panel has UCP tab ✅ Phase 5A
+- [x] UCP tab displays A2A operation events in the protocol timeline ✅ Phase 5A
+- [x] UCP tab shows capability negotiation results (capability names in update/create summaries) ✅ Phase 5A
+- [x] Protocol logger distinguishes UCP from ACP events ✅ Phase 5A
+- [x] Agent Activity panel shows agent decisions for both protocols (shared flow) ✅ Phase 5A
+- [x] UCP post-purchase webhook events are logged as `POST /api/webhooks/ucp` (not ACP) ✅ Phase 5B
 
 ---
 
@@ -534,7 +575,7 @@ The A2A transport uses JSON-RPC 2.0 for structured agent communication. All UCP 
 - [ ] All A2A checkout actions return correct JSON-RPC responses
 - [ ] NAT agents respond in <10s for UCP sessions (same as ACP)
 - [ ] Zero protocol confusion errors in logs
-- [ ] UCP tab correctly displays all protocol events
+- [ ] UCP tab correctly displays full protocol metadata (capabilities/payment handlers)
 - [ ] Demo successfully shows dual protocol support (ACP + UCP via A2A)
 
 ---

--- a/env.example
+++ b/env.example
@@ -46,10 +46,12 @@ MERCHANT_API_KEY=merchant-api-key-12345
 WEBHOOK_URL=http://localhost:3000/api/webhooks/acp
 # Docker deployment webhook URL (container-to-container routing)
 WEBHOOK_URL_DOCKER=http://ui:3000/api/webhooks/acp
+UCP_ORDER_WEBHOOK_URL=http://localhost:3000/api/webhooks/ucp
+UCP_ORDER_WEBHOOK_URL_DOCKER=http://ui:3000/api/webhooks/ucp
 WEBHOOK_SECRET=whsec_demo_secret
 
 # UCP Discovery Configuration
-UCP_VERSION=2026-01-11
+UCP_VERSION=2026-01-23
 UCP_BASE_URL=
 UCP_SERVICE_PATH=/ucp/v1
 UCP_BUSINESS_NAME=
@@ -105,3 +107,8 @@ PSP_API_URL=http://localhost:8001
 
 # Note: MERCHANT_API_KEY and PSP_API_KEY already exist above
 # They are used by both the backend services AND the UI proxy routes
+
+# UI client-side UCP profile (used by UCP-Agent header in A2A requests)
+# Local dev example: http://localhost:8000/.well-known/ucp
+# Docker example (ui + merchant containers): http://merchant:8000/.well-known/ucp
+NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL=http://localhost:8000/.well-known/ucp

--- a/src/merchant/api/routes/ucp/a2a.py
+++ b/src/merchant/api/routes/ucp/a2a.py
@@ -189,9 +189,11 @@ async def handle_a2a_request(
     # ---- 8. Negotiate capabilities ----
     base_url = str(http_request.base_url).rstrip("/")
     try:
-        negotiated, payment_handlers, order_webhook_url = await negotiate_a2a_capabilities(
-            ucp_agent_value, base_url
-        )
+        (
+            negotiated,
+            payment_handlers,
+            order_webhook_url,
+        ) = await negotiate_a2a_capabilities(ucp_agent_value, base_url)
     except NegotiationFailureError as exc:
         # Per spec: negotiation failure → JSON-RPC result, not error
         settings = get_settings()

--- a/src/merchant/api/routes/ucp/a2a.py
+++ b/src/merchant/api/routes/ucp/a2a.py
@@ -13,7 +13,7 @@ import uuid
 from typing import Any, cast
 
 import httpx
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
 from fastapi.responses import JSONResponse
 from sqlmodel import Session
 
@@ -63,6 +63,7 @@ router = APIRouter(
 )
 async def handle_a2a_request(
     http_request: Request,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_session),
 ) -> JSONResponse:
     """Process an A2A JSON-RPC 2.0 request.
@@ -188,7 +189,7 @@ async def handle_a2a_request(
     # ---- 8. Negotiate capabilities ----
     base_url = str(http_request.base_url).rstrip("/")
     try:
-        negotiated, payment_handlers = await negotiate_a2a_capabilities(
+        negotiated, payment_handlers, order_webhook_url = await negotiate_a2a_capabilities(
             ucp_agent_value, base_url
         )
     except NegotiationFailureError as exc:
@@ -251,6 +252,8 @@ async def handle_a2a_request(
             db=db,
             negotiated=negotiated,
             payment_handlers=payment_handlers,
+            order_webhook_url=order_webhook_url,
+            background_tasks=background_tasks,
         )
     except SessionNotFoundError:
         return JSONResponse(

--- a/src/merchant/config.py
+++ b/src/merchant/config.py
@@ -34,12 +34,13 @@ class Settings(BaseSettings):
     merchant_api_key: str = ""
 
     # UCP Discovery Configuration
-    ucp_version: str = "2026-01-11"
+    ucp_version: str = "2026-01-23"
     ucp_base_url: str | None = (
         None  # Fully qualified base URL; None derives from request
     )
     ucp_business_name: str | None = None
     ucp_continue_url: str | None = None  # Fallback URL for negotiation failures
+    ucp_order_webhook_url: str = "http://localhost:3000/api/webhooks/ucp"
 
     # UCP Signing Key (public key for webhook verification)
     ucp_signing_key_id: str = "ucp-key-1"

--- a/src/merchant/services/a2a.py
+++ b/src/merchant/services/a2a.py
@@ -25,8 +25,6 @@ from src.merchant.api.schemas import (
 )
 from src.merchant.api.ucp_schemas import UCPCapabilityVersion, UCPPaymentHandler
 from src.merchant.config import get_settings
-from src.merchant.services.post_purchase import OrderItem
-from src.merchant.services.post_purchase_webhook import trigger_post_purchase_flow_ucp
 from src.merchant.services.checkout import (
     SessionNotFoundError,
     cancel_checkout_session,
@@ -36,6 +34,8 @@ from src.merchant.services.checkout import (
     update_checkout_session,
 )
 from src.merchant.services.idempotency import get_idempotency_store
+from src.merchant.services.post_purchase import OrderItem
+from src.merchant.services.post_purchase_webhook import trigger_post_purchase_flow_ucp
 from src.merchant.services.ucp import (
     NegotiationFailureError,
     build_business_profile,
@@ -497,7 +497,9 @@ async def handle_complete(
     if not token_val:
         raise ValueError("Payment credential token is required")
 
-    handler_id: str = str(instrument.get("handler_id") or instrument.get("handler") or "")
+    handler_id: str = str(
+        instrument.get("handler_id") or instrument.get("handler") or ""
+    )
     provider = _resolve_payment_provider(handler_id)
 
     payment_data = PaymentDataInput(token=token_val, provider=provider)

--- a/src/merchant/services/a2a.py
+++ b/src/merchant/services/a2a.py
@@ -513,7 +513,9 @@ async def handle_complete(
     if not token_val:
         raise ValueError("Payment credential token is required")
 
-    handler_id: str = str(instrument.get("handler_id") or instrument.get("handler") or "")
+    handler_id: str = str(
+        instrument.get("handler_id") or instrument.get("handler") or ""
+    )
     if not handler_id:
         raise ValueError("Payment instrument handler_id is required")
     if not _is_advertised_payment_handler(handler_id, payment_handlers):

--- a/src/merchant/services/a2a.py
+++ b/src/merchant/services/a2a.py
@@ -11,6 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any, cast
 
+from fastapi import BackgroundTasks
 from sqlmodel import Session
 
 from src.merchant.api.a2a_schemas import A2AMessage, A2APart
@@ -24,6 +25,8 @@ from src.merchant.api.schemas import (
 )
 from src.merchant.api.ucp_schemas import UCPCapabilityVersion, UCPPaymentHandler
 from src.merchant.config import get_settings
+from src.merchant.services.post_purchase import OrderItem
+from src.merchant.services.post_purchase_webhook import trigger_post_purchase_flow_ucp
 from src.merchant.services.checkout import (
     SessionNotFoundError,
     cancel_checkout_session,
@@ -38,6 +41,7 @@ from src.merchant.services.ucp import (
     build_business_profile,
     compute_capability_intersection,
     fetch_platform_profile,
+    get_platform_order_webhook_url,
     parse_ucp_agent_header,
     transform_to_ucp_response,
 )
@@ -48,7 +52,7 @@ logger = logging.getLogger(__name__)
 # A2A UCP Constants (sourced from official spec: checkout-a2a.md)
 # ---------------------------------------------------------------------------
 
-A2A_UCP_EXTENSION_URL = "https://ucp.dev/specification/reference?v=2026-01-11"
+A2A_UCP_EXTENSION_URL = "https://ucp.dev/2026-01-23/specification/reference/"
 UCP_CHECKOUT_KEY = "a2a.ucp.checkout"
 UCP_PAYMENT_DATA_KEY = "a2a.ucp.checkout.payment"
 UCP_RISK_SIGNALS_KEY = "a2a.ucp.checkout.risk_signals"
@@ -71,6 +75,7 @@ JSONRPC_DISCOVERY_FAILURE = -32002
 # ---------------------------------------------------------------------------
 
 _context_sessions: dict[str, str] = {}
+_context_order_webhook_urls: dict[str, str] = {}
 
 
 def get_checkout_id_for_context(context_id: str) -> str | None:
@@ -83,9 +88,20 @@ def set_checkout_id_for_context(context_id: str, checkout_id: str) -> None:
     _context_sessions[context_id] = checkout_id
 
 
+def get_order_webhook_url_for_context(context_id: str) -> str | None:
+    """Look up negotiated order webhook URL for an A2A contextId."""
+    return _context_order_webhook_urls.get(context_id)
+
+
+def set_order_webhook_url_for_context(context_id: str, webhook_url: str) -> None:
+    """Store negotiated order webhook URL for an A2A contextId."""
+    _context_order_webhook_urls[context_id] = webhook_url
+
+
 def clear_context_sessions() -> None:
     """Clear all context-to-session mappings (for testing)."""
     _context_sessions.clear()
+    _context_order_webhook_urls.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +192,7 @@ def store_message_idempotency(
 _A2ANegotiationResult = tuple[
     dict[str, list[UCPCapabilityVersion]],
     dict[str, list[UCPPaymentHandler]] | None,
+    str | None,
 ]
 
 
@@ -185,7 +202,7 @@ async def negotiate_a2a_capabilities(
 ) -> _A2ANegotiationResult:
     """Run UCP capability negotiation from UCP-Agent header value.
 
-    Returns (negotiated_capabilities, payment_handlers).
+    Returns (negotiated_capabilities, payment_handlers, order_webhook_url).
 
     Raises:
         ValueError / httpx.RequestError  -- discovery failures (JSON-RPC error)
@@ -219,7 +236,8 @@ async def negotiate_a2a_capabilities(
             code="CAPABILITIES_INCOMPATIBLE",
             content="No compatible capabilities in intersection",
         )
-    return negotiated, business_profile.ucp.payment_handlers
+    order_webhook_url = get_platform_order_webhook_url(platform_profile, negotiated)
+    return negotiated, business_profile.ucp.payment_handlers, order_webhook_url
 
 
 # ---------------------------------------------------------------------------
@@ -265,10 +283,11 @@ def extract_payment_data(
 
 async def handle_create(
     data: dict[str, Any],
-    _context_id: str,
+    context_id: str,
     db: Session,
     negotiated: dict[str, list[UCPCapabilityVersion]],
     payment_handlers: dict[str, list[UCPPaymentHandler]] | None = None,
+    order_webhook_url: str | None = None,
 ) -> dict[str, Any]:
     """Handle create_checkout action."""
     items_raw: Any = data.get("line_items") or data.get("items") or []
@@ -291,10 +310,26 @@ async def handle_create(
     if not items:
         raise ValueError("No items provided for create_checkout")
 
-    request = CreateCheckoutRequest(items=items)
+    request_payload: dict[str, Any] = {"items": items}
+    buyer = data.get("buyer")
+    if buyer is not None:
+        request_payload["buyer"] = buyer
+    fulfillment_address = data.get("fulfillment_address")
+    if fulfillment_address is not None:
+        request_payload["fulfillment_address"] = fulfillment_address
+    discounts = data.get("discounts")
+    if discounts is not None:
+        request_payload["discounts"] = discounts
+    coupons = data.get("coupons")
+    if coupons is not None:
+        request_payload["coupons"] = coupons
+
+    request = CreateCheckoutRequest.model_validate(request_payload)
     acp_response = await create_checkout_session(db, request, protocol="ucp")
 
-    set_checkout_id_for_context(_context_id, acp_response.id)
+    set_checkout_id_for_context(context_id, acp_response.id)
+    if order_webhook_url:
+        set_order_webhook_url_for_context(context_id, order_webhook_url)
     return _to_checkout_data_part(acp_response, negotiated, payment_handlers)
 
 
@@ -356,7 +391,23 @@ async def handle_update(
                 pid = str(ri.get("product_id") or ri.get("id", ""))
                 qty = int(ri.get("quantity", 1))
                 items.append(ItemInput(id=pid, quantity=qty))
-        request = UpdateCheckoutRequest(items=items if items else None)
+        request_payload: dict[str, Any] = {"items": items if items else None}
+        buyer = data.get("buyer")
+        if buyer is not None:
+            request_payload["buyer"] = buyer
+        fulfillment_address = data.get("fulfillment_address")
+        if fulfillment_address is not None:
+            request_payload["fulfillment_address"] = fulfillment_address
+        fulfillment_option_id = data.get("fulfillment_option_id")
+        if fulfillment_option_id is not None:
+            request_payload["fulfillment_option_id"] = fulfillment_option_id
+        discounts = data.get("discounts")
+        if discounts is not None:
+            request_payload["discounts"] = discounts
+        coupons = data.get("coupons")
+        if coupons is not None:
+            request_payload["coupons"] = coupons
+        request = UpdateCheckoutRequest.model_validate(request_payload)
 
     acp_response = await update_checkout_session(db, session_id, request)
     return _to_checkout_data_part(acp_response, negotiated, payment_handlers)
@@ -395,12 +446,29 @@ def _resolve_payment_provider(handler_id: str) -> PaymentProviderEnum:
     return handler_map.get(handler_id, PaymentProviderEnum.STRIPE)
 
 
-def handle_complete(
+def _extract_customer_name(session: CheckoutSessionResponse) -> str:
+    if session.buyer and session.buyer.first_name:
+        return session.buyer.first_name
+    return "Customer"
+
+
+def _extract_order_items(session: CheckoutSessionResponse) -> list[OrderItem]:
+    items: list[OrderItem] = []
+    for line_item in session.line_items:
+        item_name = line_item.name or line_item.item.id
+        items.append({"name": item_name, "quantity": line_item.item.quantity})
+    if not items:
+        return [{"name": "your order", "quantity": 1}]
+    return items
+
+
+async def handle_complete(
     parts: list[A2APart],
     context_id: str,
     db: Session,
     negotiated: dict[str, list[UCPCapabilityVersion]],
     payment_handlers: dict[str, list[UCPPaymentHandler]] | None = None,
+    background_tasks: BackgroundTasks | None = None,
 ) -> dict[str, Any]:
     """Handle complete_checkout action with payment data from DataParts.
 
@@ -425,11 +493,11 @@ def handle_complete(
 
     instrument = cast(dict[str, Any], instruments_list[0])
     credential = cast(dict[str, Any], instrument.get("credential", {}))
-    token_val: str = str(credential.get("token", ""))
+    token_val: str = str(credential.get("token") or credential.get("id") or "")
     if not token_val:
         raise ValueError("Payment credential token is required")
 
-    handler_id: str = str(instrument.get("handler_id", ""))
+    handler_id: str = str(instrument.get("handler_id") or instrument.get("handler") or "")
     provider = _resolve_payment_provider(handler_id)
 
     payment_data = PaymentDataInput(token=token_val, provider=provider)
@@ -442,6 +510,26 @@ def handle_complete(
             "id": acp_response.order.id,
             "permalink_url": acp_response.order.permalink_url,
         }
+        negotiated_webhook_url = get_order_webhook_url_for_context(context_id)
+        fallback_webhook_url = get_settings().ucp_order_webhook_url
+        webhook_url = negotiated_webhook_url or fallback_webhook_url
+
+        if background_tasks:
+            background_tasks.add_task(
+                trigger_post_purchase_flow_ucp,
+                checkout_session=acp_response,
+                customer_name=_extract_customer_name(acp_response),
+                items=_extract_order_items(acp_response),
+                language="en",
+                webhook_url=webhook_url,
+                negotiated=negotiated,
+            )
+        else:
+            logger.warning(
+                "UCP order %s completed without background task context; "
+                "post-purchase webhook skipped",
+                acp_response.order.id,
+            )
 
     return result
 
@@ -500,6 +588,8 @@ async def dispatch_action(
     db: Session,
     negotiated: dict[str, list[UCPCapabilityVersion]],
     payment_handlers: dict[str, list[UCPPaymentHandler]] | None = None,
+    order_webhook_url: str | None = None,
+    background_tasks: BackgroundTasks | None = None,
 ) -> dict[str, Any]:
     """Route an action string to the appropriate handler.
 
@@ -509,7 +599,14 @@ async def dispatch_action(
         raise ValueError(f"Unknown action: {action}")
 
     if action == "create_checkout":
-        return await handle_create(data, context_id, db, negotiated, payment_handlers)
+        return await handle_create(
+            data,
+            context_id,
+            db,
+            negotiated,
+            payment_handlers,
+            order_webhook_url=order_webhook_url,
+        )
 
     if action in ("add_to_checkout", "remove_from_checkout", "update_checkout"):
         return await handle_update(
@@ -525,8 +622,13 @@ async def dispatch_action(
         return handle_get(context_id, db, negotiated, payment_handlers)
 
     if action == "complete_checkout":
-        return handle_complete(
-            message.parts, context_id, db, negotiated, payment_handlers
+        return await handle_complete(
+            message.parts,
+            context_id,
+            db,
+            negotiated,
+            payment_handlers,
+            background_tasks=background_tasks,
         )
 
     # cancel_checkout

--- a/src/merchant/services/a2a.py
+++ b/src/merchant/services/a2a.py
@@ -437,13 +437,29 @@ def _resolve_payment_provider(handler_id: str) -> PaymentProviderEnum:
     that handler_id to the internal provider enum used by the checkout
     service.
 
-    Falls back to STRIPE for this reference implementation since it is
-    the only PSP currently configured.
+    This reference implementation currently supports one negotiated
+    handler (processor_tokenizer -> Stripe). Unknown handlers are rejected.
     """
     handler_map: dict[str, PaymentProviderEnum] = {
         "processor_tokenizer": PaymentProviderEnum.STRIPE,
     }
-    return handler_map.get(handler_id, PaymentProviderEnum.STRIPE)
+    provider = handler_map.get(handler_id)
+    if provider is None:
+        raise ValueError(f"Unsupported payment handler_id: {handler_id}")
+    return provider
+
+
+def _is_advertised_payment_handler(
+    handler_id: str,
+    payment_handlers: dict[str, list[UCPPaymentHandler]] | None,
+) -> bool:
+    if payment_handlers is None:
+        return False
+    for versions in payment_handlers.values():
+        for handler in versions:
+            if handler.id == handler_id:
+                return True
+    return False
 
 
 def _extract_customer_name(session: CheckoutSessionResponse) -> str:
@@ -497,9 +513,11 @@ async def handle_complete(
     if not token_val:
         raise ValueError("Payment credential token is required")
 
-    handler_id: str = str(
-        instrument.get("handler_id") or instrument.get("handler") or ""
-    )
+    handler_id: str = str(instrument.get("handler_id") or instrument.get("handler") or "")
+    if not handler_id:
+        raise ValueError("Payment instrument handler_id is required")
+    if not _is_advertised_payment_handler(handler_id, payment_handlers):
+        raise ValueError(f"Unsupported payment handler_id: {handler_id}")
     provider = _resolve_payment_provider(handler_id)
 
     payment_data = PaymentDataInput(token=token_val, provider=provider)

--- a/src/merchant/services/post_purchase_webhook.py
+++ b/src/merchant/services/post_purchase_webhook.py
@@ -5,7 +5,7 @@ This service implements the correct ACP flow for post-purchase notifications:
 2. Merchant calls Post-Purchase Agent → generates message
 3. Merchant sends webhook to Client Agent → delivers message
 
-Architecture (per ACP spec and Feature 11):
+Architecture (protocol-specific webhook target):
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  Merchant Backend                    Client Agent (UI)                  │
 │        │                                   │                            │
@@ -13,7 +13,8 @@ Architecture (per ACP spec and Feature 11):
 │        │  2. Call Post-Purchase Agent      │                            │
 │        │     (generate message)            │                            │
 │        │                                   │                            │
-│        │  POST /api/webhooks/acp           │                            │
+│        │  ACP: POST /api/webhooks/acp      │                            │
+│        │  UCP: POST /api/webhooks/ucp      │                            │
 │        │  {type: "shipping_update", ...}   │                            │
 │        │ ─────────────────────────────────▶│                            │
 │        │                                   │                            │
@@ -27,7 +28,15 @@ checkout completion, so it doesn't block the checkout response.
 """
 
 import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
 
+from ucp_sdk.models.schemas.shopping.order import Order as SDKOrder
+
+from src.merchant.api.schemas import CheckoutSessionResponse, Total, TotalTypeEnum
+from src.merchant.api.ucp_schemas import UCPCapabilityVersion
+from src.merchant.config import get_settings
 from src.merchant.services.post_purchase import (
     OrderItem,
     ShippingMessageRequest,
@@ -35,9 +44,132 @@ from src.merchant.services.post_purchase import (
     SupportedLanguage,
     generate_shipping_message,
 )
-from src.merchant.services.webhook import send_shipping_update_webhook
+from src.merchant.services.webhook import (
+    UCPOrderWebhookEvent,
+    send_shipping_update_webhook,
+    send_ucp_order_webhook,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _map_order_line_item_status(shipping_status: str) -> str:
+    if shipping_status == ShippingStatus.DELIVERED.value:
+        return "fulfilled"
+    return "processing"
+
+
+def _to_ucp_total_lines(totals: list[Total]) -> list[dict[str, Any]]:
+    allowed_types = {
+        TotalTypeEnum.ITEMS_DISCOUNT.value,
+        TotalTypeEnum.SUBTOTAL.value,
+        TotalTypeEnum.DISCOUNT.value,
+        TotalTypeEnum.FULFILLMENT.value,
+        TotalTypeEnum.TAX.value,
+        TotalTypeEnum.FEE.value,
+        TotalTypeEnum.TOTAL.value,
+    }
+    converted: list[dict[str, Any]] = []
+    for total in totals:
+        if total.type.value not in allowed_types:
+            continue
+        converted.append(
+            {
+                "type": total.type.value,
+                "display_text": total.display_text,
+                "amount": total.amount,
+            }
+        )
+    return converted
+
+
+def _build_ucp_capabilities(
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> list[dict[str, str]]:
+    flattened: list[dict[str, str]] = []
+    for name, versions in negotiated.items():
+        for version in versions:
+            flattened.append({"name": name, "version": version.version})
+    return flattened
+
+
+def _build_ucp_order_event(
+    checkout_session: CheckoutSessionResponse,
+    message_subject: str,
+    message_body: str,
+    status: str,
+    tracking_url: str,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> UCPOrderWebhookEvent:
+    if checkout_session.order is None:
+        raise ValueError("Missing order in completed checkout session")
+
+    now_iso = datetime.now(UTC).isoformat()
+    line_items = []
+    line_item_refs = []
+    for line_item in checkout_session.line_items:
+        quantity_total = line_item.item.quantity
+        fulfilled_quantity = (
+            quantity_total if status == ShippingStatus.DELIVERED.value else 0
+        )
+        line_items.append(
+            {
+                "id": line_item.id,
+                "item": {
+                    "id": line_item.item.id,
+                    "title": line_item.name or line_item.item.id,
+                    "price": line_item.base_amount // max(quantity_total, 1),
+                },
+                "quantity": {"total": quantity_total, "fulfilled": fulfilled_quantity},
+                "totals": [
+                    {
+                        "type": "subtotal",
+                        "display_text": "Subtotal",
+                        "amount": line_item.subtotal,
+                    },
+                    {"type": "tax", "display_text": "Tax", "amount": line_item.tax},
+                    {
+                        "type": "total",
+                        "display_text": "Total",
+                        "amount": line_item.total,
+                    },
+                ],
+                "status": _map_order_line_item_status(status),
+            }
+        )
+        line_item_refs.append({"id": line_item.item.id, "quantity": quantity_total})
+
+    description = f"{message_subject}\n\n{message_body}".strip()
+    order_payload: dict[str, Any] = {
+        "ucp": {
+            "version": get_settings().ucp_version,
+            "capabilities": _build_ucp_capabilities(negotiated),
+        },
+        "id": checkout_session.order.id,
+        "checkout_id": checkout_session.id,
+        "permalink_url": checkout_session.order.permalink_url,
+        "line_items": line_items,
+        "fulfillment": {
+            "events": [
+                {
+                    "id": f"ful_{uuid.uuid4().hex[:12]}",
+                    "occurred_at": now_iso,
+                    "type": status,
+                    "line_items": line_item_refs,
+                    "tracking_url": tracking_url,
+                    "description": description,
+                }
+            ]
+        },
+        "totals": _to_ucp_total_lines(checkout_session.totals),
+    }
+
+    validated_order = SDKOrder.model_validate(order_payload).model_dump(mode="json")
+    return {
+        "event_id": f"evt_{uuid.uuid4().hex}",
+        "created_time": now_iso,
+        "order": validated_order,
+    }
 
 
 async def trigger_post_purchase_flow(
@@ -137,3 +269,73 @@ async def trigger_post_purchase_flow(
             order_id,
             str(e),
         )
+
+
+async def trigger_post_purchase_flow_ucp(
+    checkout_session: CheckoutSessionResponse,
+    customer_name: str,
+    items: list[OrderItem],
+    language: str,
+    webhook_url: str,
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> None:
+    """Trigger post-purchase flow and deliver a UCP order webhook event."""
+    if checkout_session.order is None:
+        logger.warning(
+            "Skipping UCP post-purchase flow: order missing for session %s",
+            checkout_session.id,
+        )
+        return
+
+    order_id = checkout_session.order.id
+    logger.info(
+        "Triggering UCP post-purchase flow for order %s (session: %s)",
+        order_id,
+        checkout_session.id,
+    )
+
+    try:
+        lang = SupportedLanguage(language)
+    except ValueError:
+        lang = SupportedLanguage.ENGLISH
+        logger.warning("Invalid language '%s', defaulting to English", language)
+
+    request: ShippingMessageRequest = {
+        "brand_persona": {
+            "company_name": "NVShop",
+            "tone": "friendly",
+            "preferred_language": lang.value,
+        },
+        "order": {
+            "order_id": order_id,
+            "customer_name": customer_name,
+            "items": items,
+            "tracking_url": f"https://track.nvshop.demo/orders/{order_id}",
+            "estimated_delivery": None,
+        },
+        "status": ShippingStatus.ORDER_CONFIRMED.value,
+    }
+
+    try:
+        response = await generate_shipping_message(request)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(
+            "Failed to generate UCP post-purchase message for order %s: %s",
+            order_id,
+            str(exc),
+        )
+        return
+
+    event = _build_ucp_order_event(
+        checkout_session=checkout_session,
+        message_subject=response["subject"],
+        message_body=response["message"],
+        status=response["status"],
+        tracking_url=f"https://track.nvshop.demo/orders/{order_id}",
+        negotiated=negotiated,
+    )
+    success = await send_ucp_order_webhook(event=event, webhook_url=webhook_url)
+    if success:
+        logger.info("UCP order webhook delivered for order %s", order_id)
+    else:
+        logger.warning("UCP order webhook delivery failed for order %s", order_id)

--- a/src/merchant/services/post_purchase_webhook.py
+++ b/src/merchant/services/post_purchase_webhook.py
@@ -105,8 +105,8 @@ def _build_ucp_order_event(
         raise ValueError("Missing order in completed checkout session")
 
     now_iso = datetime.now(UTC).isoformat()
-    line_items = []
-    line_item_refs = []
+    line_items: list[dict[str, Any]] = []
+    line_item_refs: list[dict[str, Any]] = []
     for line_item in checkout_session.line_items:
         quantity_total = line_item.item.quantity
         fulfilled_quantity = (

--- a/src/merchant/services/ucp.py
+++ b/src/merchant/services/ucp.py
@@ -318,25 +318,29 @@ def get_platform_order_webhook_url(
     if ORDER_CAPABILITY not in negotiated:
         return None
 
-    ucp_block = platform_profile.get("ucp")
+    ucp_block: Any = platform_profile.get("ucp")
     if not isinstance(ucp_block, dict):
         return None
+    ucp_dict = cast(dict[str, Any], ucp_block)
 
-    capabilities = ucp_block.get("capabilities")
+    capabilities: Any = ucp_dict.get("capabilities")
     if not isinstance(capabilities, dict):
         return None
+    capabilities_dict = cast(dict[str, Any], capabilities)
 
-    order_versions_raw = capabilities.get(ORDER_CAPABILITY)
+    order_versions_raw: Any = capabilities_dict.get(ORDER_CAPABILITY)
     if not isinstance(order_versions_raw, list):
         return None
 
     for raw_version in cast(list[Any], order_versions_raw):
         if not isinstance(raw_version, dict):
             continue
-        config = raw_version.get("config")
+        raw_version_dict = cast(dict[str, Any], raw_version)
+        config: Any = raw_version_dict.get("config")
         if not isinstance(config, dict):
             continue
-        webhook_url = config.get("webhook_url")
+        config_dict = cast(dict[str, Any], config)
+        webhook_url: Any = config_dict.get("webhook_url")
         if isinstance(webhook_url, str) and webhook_url.strip():
             return webhook_url.strip()
 

--- a/src/merchant/services/ucp.py
+++ b/src/merchant/services/ucp.py
@@ -42,6 +42,7 @@ from src.merchant.config import get_settings
 
 CACHE_TTL = timedelta(minutes=10)
 CHECKOUT_CAPABILITY = "dev.ucp.shopping.checkout"
+ORDER_CAPABILITY = "dev.ucp.shopping.order"
 _profile_cache: dict[str, tuple[dict[str, Any], datetime]] = {}
 
 
@@ -111,6 +112,9 @@ def build_business_profile(request_base_url: str | None = None) -> UCPBusinessPr
             },
             capabilities={
                 "dev.ucp.shopping.checkout": [
+                    UCPCapabilityVersion(version=settings.ucp_version)
+                ],
+                "dev.ucp.shopping.order": [
                     UCPCapabilityVersion(version=settings.ucp_version)
                 ],
                 "dev.ucp.shopping.fulfillment": [
@@ -300,6 +304,43 @@ def filter_capabilities_for_checkout(
                 result[cap_name] = versions
                 break
     return result
+
+
+def get_platform_order_webhook_url(
+    platform_profile: dict[str, Any],
+    negotiated: dict[str, list[UCPCapabilityVersion]],
+) -> str | None:
+    """Extract UCP order webhook URL from platform profile capability config.
+
+    The platform advertises order webhook callback support in
+    ``dev.ucp.shopping.order[].config.webhook_url``.
+    """
+    if ORDER_CAPABILITY not in negotiated:
+        return None
+
+    ucp_block = platform_profile.get("ucp")
+    if not isinstance(ucp_block, dict):
+        return None
+
+    capabilities = ucp_block.get("capabilities")
+    if not isinstance(capabilities, dict):
+        return None
+
+    order_versions_raw = capabilities.get(ORDER_CAPABILITY)
+    if not isinstance(order_versions_raw, list):
+        return None
+
+    for raw_version in cast(list[Any], order_versions_raw):
+        if not isinstance(raw_version, dict):
+            continue
+        config = raw_version.get("config")
+        if not isinstance(config, dict):
+            continue
+        webhook_url = config.get("webhook_url")
+        if isinstance(webhook_url, str) and webhook_url.strip():
+            return webhook_url.strip()
+
+    return None
 
 
 def transform_to_ucp_response(

--- a/src/merchant/services/webhook.py
+++ b/src/merchant/services/webhook.py
@@ -19,8 +19,12 @@ import hashlib
 import hmac
 import json
 import logging
+import time
+import uuid
+from base64 import urlsafe_b64encode
 from datetime import UTC, datetime
 from typing import Any, TypedDict
+from urllib.parse import urlparse
 
 import httpx
 
@@ -65,6 +69,14 @@ class WebhookEvent(TypedDict):
     data: OrderEventData | ShippingUpdateData
 
 
+class UCPOrderWebhookEvent(TypedDict):
+    """UCP order webhook envelope."""
+
+    event_id: str
+    created_time: str
+    order: dict[str, Any]
+
+
 # =============================================================================
 # Signature Generation
 # =============================================================================
@@ -88,6 +100,52 @@ def generate_webhook_signature(payload: str, timestamp: str, secret: str) -> str
         hashlib.sha256,
     ).hexdigest()
     return signature
+
+
+def _base64url_encode(raw: bytes) -> str:
+    return urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+
+def _base64url_encode_json(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return _base64url_encode(encoded)
+
+
+def generate_ucp_request_signature(
+    payload: str,
+    webhook_url: str,
+    secret: str,
+    ttl_seconds: int = 300,
+) -> str:
+    """Generate Request-Signature header value for UCP webhooks.
+
+    This implementation emits a compact JWT-like token carrying the request
+    integrity claims referenced by UCP webhook docs:
+    iat, exp, aud, htu, htm, and body_sha256.
+    """
+    issued_at = int(time.time())
+    body_sha256 = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    audience = urlparse(webhook_url).netloc
+    claims: dict[str, Any] = {
+        "iat": issued_at,
+        "exp": issued_at + ttl_seconds,
+        "aud": audience,
+        "htu": webhook_url,
+        "htm": "POST",
+        "body_sha256": body_sha256,
+        "nonce": str(uuid.uuid4()),
+    }
+
+    header = {"alg": "HS256", "typ": "JWT"}
+    signing_input = (
+        f"{_base64url_encode_json(header)}.{_base64url_encode_json(claims)}"
+    )
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        signing_input.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return f"{signing_input}.{_base64url_encode(signature)}"
 
 
 # =============================================================================
@@ -240,3 +298,50 @@ async def send_order_created_webhook(
     }
 
     return await send_webhook(event)
+
+
+async def send_ucp_order_webhook(
+    event: UCPOrderWebhookEvent,
+    webhook_url: str | None = None,
+    shared_secret: str | None = None,
+    timeout: float = 10.0,
+) -> bool:
+    """Send a UCP order webhook event to the platform callback URL."""
+    settings = get_settings()
+    url = webhook_url or settings.ucp_order_webhook_url
+    secret = shared_secret or settings.webhook_secret
+
+    if not url:
+        logger.warning("UCP order webhook URL not configured, skipping delivery")
+        return False
+    if not secret:
+        logger.warning("Webhook secret not configured, skipping UCP delivery")
+        return False
+
+    payload = json.dumps(event)
+    request_signature = generate_ucp_request_signature(payload, url, secret)
+    headers = {
+        "Content-Type": "application/json",
+        "Request-Signature": request_signature,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(url, content=payload, headers=headers)
+
+        if 200 <= response.status_code < 300:
+            logger.info("UCP order webhook delivered to %s", url)
+            return True
+
+        logger.warning(
+            "UCP order webhook delivery failed: %s (status: %d)",
+            url,
+            response.status_code,
+        )
+        return False
+    except httpx.TimeoutException:
+        logger.warning("UCP order webhook delivery timed out: %s", url)
+        return False
+    except httpx.RequestError as exc:
+        logger.warning("UCP order webhook delivery error: %s - %s", url, str(exc))
+        return False

--- a/src/merchant/services/webhook.py
+++ b/src/merchant/services/webhook.py
@@ -137,9 +137,7 @@ def generate_ucp_request_signature(
     }
 
     header = {"alg": "HS256", "typ": "JWT"}
-    signing_input = (
-        f"{_base64url_encode_json(header)}.{_base64url_encode_json(claims)}"
-    )
+    signing_input = f"{_base64url_encode_json(header)}.{_base64url_encode_json(claims)}"
     signature = hmac.new(
         secret.encode("utf-8"),
         signing_input.encode("utf-8"),

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -32,8 +32,10 @@ COPY src/ui ./
 
 # Set build-time environment variables
 # Note: API keys are handled server-side via proxy routes (never exposed to browser)
+ARG NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL=http://merchant:8000/.well-known/ucp
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_MCP_SERVER_URL=/apps-sdk
+ENV NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL=${NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL}
 
 # Build the application
 RUN pnpm build

--- a/src/ui/app/api/proxy/merchant/[...path]/route.ts
+++ b/src/ui/app/api/proxy/merchant/[...path]/route.ts
@@ -29,7 +29,15 @@ if (!MERCHANT_API_KEY) {
 }
 
 // Headers to forward from client to upstream
-const FORWARD_HEADERS = ["request-id", "idempotency-key", "api-version", "content-type", "accept"];
+const FORWARD_HEADERS = [
+  "request-id",
+  "idempotency-key",
+  "api-version",
+  "content-type",
+  "accept",
+  "ucp-agent",
+  "x-a2a-extensions",
+];
 
 /**
  * Validate path segments to prevent SSRF/open proxy attacks.

--- a/src/ui/app/api/proxy/merchant/__tests__/route.test.ts
+++ b/src/ui/app/api/proxy/merchant/__tests__/route.test.ts
@@ -99,6 +99,8 @@ describe("Merchant Proxy Route", () => {
           "API-Version": "2026-01-16",
           "Content-Type": "application/json",
           Accept: "application/json",
+          "UCP-Agent": 'profile="https://platform.example/profile"',
+          "X-A2A-Extensions": "https://ucp.dev/2026-01-23/specification/reference/",
           // These should be stripped/replaced
           Authorization: "Bearer client-key-should-be-stripped",
           "X-API-Key": "should-be-ignored",
@@ -117,6 +119,10 @@ describe("Merchant Proxy Route", () => {
       expect(headers.get("API-Version")).toBe("2026-01-16");
       expect(headers.get("Content-Type")).toBe("application/json");
       expect(headers.get("Accept")).toBe("application/json");
+      expect(headers.get("UCP-Agent")).toBe('profile="https://platform.example/profile"');
+      expect(headers.get("X-A2A-Extensions")).toBe(
+        "https://ucp.dev/2026-01-23/specification/reference/"
+      );
 
       // Server-side auth should be injected
       expect(headers.get("Authorization")).toBe("Bearer test-api-key");

--- a/src/ui/app/api/webhooks/acp/route.ts
+++ b/src/ui/app/api/webhooks/acp/route.ts
@@ -32,6 +32,7 @@ export interface WebhookEvent {
   id: string;
   type: "order_created" | "order_updated" | "shipping_update";
   receivedAt: string;
+  protocol?: "acp" | "ucp";
   data: OrderEventData | ShippingUpdateData;
 }
 
@@ -146,6 +147,7 @@ export async function POST(request: NextRequest) {
       id: generateEventId(),
       type: payload.type,
       receivedAt: new Date().toISOString(),
+      protocol: "acp",
       data: payload.data,
     };
 

--- a/src/ui/app/api/webhooks/ucp/route.ts
+++ b/src/ui/app/api/webhooks/ucp/route.ts
@@ -1,0 +1,269 @@
+/* eslint-disable no-console */
+
+import crypto from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { webhookEmitter } from "@/lib/webhook-emitter";
+
+type ShippingStatus = "order_confirmed" | "order_shipped" | "out_for_delivery" | "delivered";
+
+interface ShippingUpdateData {
+  type: "shipping_update";
+  checkout_session_id: string;
+  order_id: string;
+  status: ShippingStatus;
+  language: "en" | "es" | "fr";
+  subject: string;
+  message: string;
+  tracking_url?: string;
+}
+
+interface WebhookEvent {
+  id: string;
+  type: "shipping_update";
+  receivedAt: string;
+  protocol?: "acp" | "ucp";
+  data: ShippingUpdateData;
+}
+
+interface UCPFulfillmentEvent {
+  type?: string;
+  description?: string;
+  tracking_url?: string;
+  occurred_at?: string;
+}
+
+interface UCPOrderWebhookPayload {
+  event_id: string;
+  created_time: string;
+  order: {
+    id: string;
+    checkout_id: string;
+    fulfillment?: {
+      events?: UCPFulfillmentEvent[];
+    };
+  };
+}
+
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || "whsec_demo_secret";
+const webhookEvents: WebhookEvent[] = [];
+
+function decodeBase64Url(input: string): Buffer {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(padded, "base64");
+}
+
+function verifyRequestSignature(
+  payload: string,
+  requestSignature: string | null,
+  requestUrl: string
+): boolean {
+  if (!requestSignature && process.env.NODE_ENV === "development") {
+    console.warn("[UCP Webhook] Skipping Request-Signature verification in development");
+    return true;
+  }
+
+  if (!requestSignature) {
+    return false;
+  }
+
+  const parts = requestSignature.split(".");
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  const [encodedHeader, encodedClaims, encodedSignature] = parts;
+  if (!encodedHeader || !encodedClaims || !encodedSignature) {
+    return false;
+  }
+
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const expectedSignature = crypto
+    .createHmac("sha256", WEBHOOK_SECRET)
+    .update(signingInput)
+    .digest();
+
+  let providedSignature: Buffer;
+  try {
+    providedSignature = decodeBase64Url(encodedSignature);
+  } catch {
+    return false;
+  }
+
+  if (providedSignature.length !== expectedSignature.length) {
+    return false;
+  }
+  if (!crypto.timingSafeEqual(providedSignature, expectedSignature)) {
+    return false;
+  }
+
+  let claims: Record<string, unknown>;
+  try {
+    claims = JSON.parse(decodeBase64Url(encodedClaims).toString("utf-8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return false;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const exp = typeof claims.exp === "number" ? claims.exp : -1;
+  const iat = typeof claims.iat === "number" ? claims.iat : -1;
+  const aud = typeof claims.aud === "string" ? claims.aud : "";
+  const htu = typeof claims.htu === "string" ? claims.htu : "";
+  const htm = typeof claims.htm === "string" ? claims.htm : "";
+  const bodySha = typeof claims.body_sha256 === "string" ? claims.body_sha256 : "";
+
+  if (exp < now || iat > now + 60) {
+    return false;
+  }
+  if (aud !== new URL(requestUrl).host) {
+    return false;
+  }
+  if (htu !== requestUrl || htm.toUpperCase() !== "POST") {
+    return false;
+  }
+
+  const computedBodySha = crypto.createHash("sha256").update(payload).digest("hex");
+  return bodySha === computedBodySha;
+}
+
+function mapFulfillmentTypeToShippingStatus(type: string | undefined): ShippingStatus {
+  switch (type) {
+    case "delivered":
+      return "delivered";
+    case "out_for_delivery":
+      return "out_for_delivery";
+    case "order_shipped":
+    case "shipped":
+      return "order_shipped";
+    default:
+      return "order_confirmed";
+  }
+}
+
+function getLatestFulfillmentEvent(payload: UCPOrderWebhookPayload): UCPFulfillmentEvent | null {
+  const events = payload.order.fulfillment?.events;
+  if (!events || events.length === 0) {
+    return null;
+  }
+  const sorted = [...events].sort((a, b) => {
+    const aTime = a.occurred_at ? Date.parse(a.occurred_at) : 0;
+    const bTime = b.occurred_at ? Date.parse(b.occurred_at) : 0;
+    return aTime - bTime;
+  });
+  return sorted[sorted.length - 1] ?? null;
+}
+
+function splitSubjectAndMessage(description: string): { subject: string; message: string } {
+  const trimmed = description.trim();
+  if (!trimmed) {
+    return {
+      subject: "Order Update",
+      message: "Your order has been updated.",
+    };
+  }
+
+  const lines = trimmed
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return {
+      subject: "Order Update",
+      message: trimmed,
+    };
+  }
+  return {
+    subject: lines[0] ?? "Order Update",
+    message: trimmed,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const rawBody = await request.text();
+    const requestSignature = request.headers.get("Request-Signature");
+
+    if (process.env.NODE_ENV === "production") {
+      if (!verifyRequestSignature(rawBody, requestSignature, request.url)) {
+        console.error("[UCP Webhook] Invalid Request-Signature");
+        return NextResponse.json({ error: "Invalid webhook signature" }, { status: 401 });
+      }
+    }
+
+    let payload: UCPOrderWebhookPayload;
+    try {
+      payload = JSON.parse(rawBody) as UCPOrderWebhookPayload;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+
+    if (!payload.event_id || !payload.order?.id || !payload.order?.checkout_id) {
+      return NextResponse.json(
+        { error: "Missing required fields: event_id, order.id, order.checkout_id" },
+        { status: 400 }
+      );
+    }
+
+    const latestEvent = getLatestFulfillmentEvent(payload);
+    const status = mapFulfillmentTypeToShippingStatus(latestEvent?.type);
+    const { subject, message } = splitSubjectAndMessage(
+      latestEvent?.description ?? "Your order has been confirmed."
+    );
+
+    const event: WebhookEvent = {
+      id: payload.event_id,
+      type: "shipping_update",
+      receivedAt: new Date().toISOString(),
+      protocol: "ucp",
+      data: {
+        type: "shipping_update",
+        checkout_session_id: payload.order.checkout_id,
+        order_id: payload.order.id,
+        status,
+        language: "en",
+        subject,
+        message,
+        ...(latestEvent?.tracking_url ? { tracking_url: latestEvent.tracking_url } : {}),
+      },
+    };
+
+    webhookEvents.push(event);
+    if (webhookEvents.length > 100) {
+      webhookEvents.shift();
+    }
+
+    webhookEmitter.emitWebhook(event);
+    return NextResponse.json({ received: true, event_id: event.id }, { status: 200 });
+  } catch (error) {
+    console.error("[UCP Webhook] Error processing webhook:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const checkoutSessionId = searchParams.get("checkout_session_id");
+  const since = searchParams.get("since");
+
+  let filteredEvents = webhookEvents;
+  if (checkoutSessionId) {
+    filteredEvents = filteredEvents.filter(
+      (event) => event.data.checkout_session_id === checkoutSessionId
+    );
+  }
+  if (since) {
+    const sinceDate = new Date(since);
+    filteredEvents = filteredEvents.filter((event) => new Date(event.receivedAt) > sinceDate);
+  }
+
+  return NextResponse.json({ events: filteredEvents, count: filteredEvents.length });
+}
+
+export async function DELETE() {
+  const count = webhookEvents.length;
+  webhookEvents.length = 0;
+  return NextResponse.json({ cleared: count });
+}

--- a/src/ui/app/page.tsx
+++ b/src/ui/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Navbar, PanelDivider } from "@/components/layout";
 import { AgentPanel } from "@/components/agent";
 import { BusinessPanel } from "@/components/business";
@@ -8,6 +9,7 @@ import { WebhookToAgentActivityBridge } from "@/components/WebhookToAgentActivit
 import { ACPLogProvider } from "@/hooks/useACPLog";
 import { AgentActivityLogProvider } from "@/hooks/useAgentActivityLog";
 import { Nebula } from "@/kui-foundations-react-external/nebula";
+import type { CheckoutProtocol } from "@/types";
 
 /**
  * Main page - Three-panel layout with Agent simulator, Merchant view, and Agent Activity
@@ -16,6 +18,8 @@ import { Nebula } from "@/kui-foundations-react-external/nebula";
  * Features NVIDIA-style Nebula animated background with gradient overlays
  */
 export default function Home() {
+  const [protocol, setProtocol] = useState<CheckoutProtocol>("acp");
+
   return (
     <ACPLogProvider>
       <AgentActivityLogProvider>
@@ -90,14 +94,14 @@ export default function Home() {
               >
                 {/* Agent Panel Container */}
                 <div className="flex-1 flex min-w-0">
-                  <AgentPanel />
+                  <AgentPanel protocol={protocol} />
                 </div>
 
                 <PanelDivider />
 
                 {/* Merchant Panel Container */}
                 <div className="flex-1 flex min-w-0">
-                  <BusinessPanel />
+                  <BusinessPanel protocol={protocol} onProtocolChange={setProtocol} />
                 </div>
 
                 {/* Agent Activity Panel Container - no divider, same visual group as Merchant */}

--- a/src/ui/components/WebhookToAgentActivityBridge.test.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.test.tsx
@@ -55,6 +55,7 @@ describe("WebhookToAgentActivityBridge", () => {
       id: "evt_1",
       type: "shipping_update",
       receivedAt: new Date().toISOString(),
+      protocol: "acp",
       data: {
         type: "shipping_update",
         checkout_session_id: "checkout_123",
@@ -92,6 +93,52 @@ describe("WebhookToAgentActivityBridge", () => {
           message: "Tracking details inside",
         }),
         "success"
+      );
+    });
+
+    expect(logEvent).toHaveBeenCalledWith(
+      "webhook_post",
+      "POST",
+      "/api/webhooks/acp",
+      "Shipping update: order_shipped"
+    );
+  });
+
+  it("logs UCP webhook endpoint for UCP events", async () => {
+    const shippingEvent = {
+      id: "evt_2",
+      type: "shipping_update",
+      receivedAt: new Date().toISOString(),
+      protocol: "ucp",
+      data: {
+        type: "shipping_update",
+        checkout_session_id: "checkout_456",
+        order_id: "order_456",
+        status: "delivered",
+        language: "en",
+        subject: "Delivered",
+        message: "Package delivered",
+      },
+    };
+
+    render(<WebhookToAgentActivityBridge />);
+
+    await waitFor(() => {
+      expect(mockEventSourceInstance).not.toBeNull();
+    });
+
+    act(() => {
+      mockEventSourceInstance?.onmessage?.(
+        new MessageEvent("message", { data: JSON.stringify(shippingEvent) })
+      );
+    });
+
+    await waitFor(() => {
+      expect(logEvent).toHaveBeenCalledWith(
+        "webhook_post",
+        "POST",
+        "/api/webhooks/ucp",
+        "Shipping update: delivered"
       );
     });
   });

--- a/src/ui/components/WebhookToAgentActivityBridge.tsx
+++ b/src/ui/components/WebhookToAgentActivityBridge.tsx
@@ -28,6 +28,7 @@ interface WebhookEvent {
   id: string;
   type: "order_created" | "order_updated" | "shipping_update";
   receivedAt: string;
+  protocol?: "acp" | "ucp";
   data: ShippingUpdateData | Record<string, unknown>;
 }
 
@@ -75,11 +76,12 @@ export function WebhookToAgentActivityBridge() {
     };
     addPostPurchaseEventRef.current(inputSignals, decision, "success");
 
-    // Update ACP panel
+    // Update Merchant Activity panel with protocol-aware webhook endpoint
+    const webhookEndpoint = event.protocol === "ucp" ? "/api/webhooks/ucp" : "/api/webhooks/acp";
     const acpEventId = logEventRef.current(
       "webhook_post",
       "POST",
-      "/api/webhooks/acp",
+      webhookEndpoint,
       `Shipping update: ${shippingData.status}`
     );
     completeEventRef.current(
@@ -135,7 +137,10 @@ export function WebhookToAgentActivityBridge() {
       // On fresh page load, clear server-side stored events to start fresh
       // This ensures refreshing the page resets all logs to 0
       try {
-        await fetch("/api/webhooks/acp", { method: "DELETE" });
+        await Promise.allSettled([
+          fetch("/api/webhooks/acp", { method: "DELETE" }),
+          fetch("/api/webhooks/ucp", { method: "DELETE" }),
+        ]);
       } catch {
         // Ignore errors - server may not be running
       }

--- a/src/ui/components/agent-activity/AgentActivityItem.test.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.test.tsx
@@ -92,11 +92,7 @@ describe("AgentActivityItem", () => {
       },
     };
     render(<AgentActivityItem event={noPromoEvent} isLast={false} />);
-    expect(
-      screen.getByText(
-        "No promotion was applied — the agent determined pricing was already optimal."
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText("No promotion discount was applied.")).toBeInTheDocument();
     expect(screen.getByText("No change")).toBeInTheDocument();
   });
 

--- a/src/ui/components/agent-activity/AgentActivityItem.tsx
+++ b/src/ui/components/agent-activity/AgentActivityItem.tsx
@@ -98,13 +98,26 @@ function getOutcomeInfo(
       return { label: "Free shipping applied", valueText: "Free", isPositive: true, actionInfo };
     case "NO_PROMO":
       return {
-        label: "No promotion was applied — the agent determined pricing was already optimal.",
+        label: "No promotion discount was applied.",
         valueText: "$0.00",
         isPositive: false,
         actionInfo,
       };
     default:
-      return { label: action, valueText: "$0.00", isPositive: false, actionInfo };
+      if (amount > 0) {
+        return {
+          label: "Promotion discount applied.",
+          valueText: `−${formattedAmount}`,
+          isPositive: true,
+          actionInfo,
+        };
+      }
+      return {
+        label: "Promotion decision metadata unavailable.",
+        valueText: "$0.00",
+        isPositive: false,
+        actionInfo,
+      };
   }
 }
 

--- a/src/ui/components/agent/AgentPanel.tsx
+++ b/src/ui/components/agent/AgentPanel.tsx
@@ -20,6 +20,7 @@ import { getErrorMessage, getSuggestedAction } from "@/lib/errors";
 import { Close } from "@/components/icons";
 import type {
   ChatMessage as ChatMessageType,
+  CheckoutProtocol,
   FulfillmentOption,
   Product,
   PaymentFormData,
@@ -369,7 +370,11 @@ interface WebhookNotification {
   orderId: string;
 }
 
-export function AgentPanel() {
+interface AgentPanelProps {
+  protocol: CheckoutProtocol;
+}
+
+export function AgentPanel({ protocol }: AgentPanelProps) {
   const [messages] = useState<ChatMessageType[]>(mockChatMessages);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showProducts, setShowProducts] = useState(false);
@@ -408,7 +413,12 @@ export function AgentPanel() {
     setBillingAddress,
     proceedToPayment,
     backToSummary,
-  } = useCheckoutFlow(acpLog, agentActivityLog);
+  } = useCheckoutFlow(acpLog, agentActivityLog, protocol);
+
+  useEffect(() => {
+    reset();
+    setIsModalOpen(false);
+  }, [protocol, reset]);
 
   // Handle product selection - opens modal
   const handleSelectProduct = useCallback(
@@ -473,7 +483,10 @@ export function AgentPanel() {
       acpLog.clear();
       agentActivityLog.clear();
       // Clear server-side webhook store to ensure clean slate
-      fetch("/api/webhooks/acp", { method: "DELETE" }).catch(() => {
+      Promise.allSettled([
+        fetch("/api/webhooks/acp", { method: "DELETE" }),
+        fetch("/api/webhooks/ucp", { method: "DELETE" }),
+      ]).catch(() => {
         // Ignore errors - server may not be running
       });
       // Clear any post-purchase notification when switching tabs

--- a/src/ui/components/agent/ModeTabSwitcher.tsx
+++ b/src/ui/components/agent/ModeTabSwitcher.tsx
@@ -27,7 +27,7 @@ interface TabConfig {
 const TABS: TabConfig[] = [
   {
     mode: "native",
-    label: "Native ACP",
+    label: "Native",
     description: "Standard ACP checkout flow",
   },
   {
@@ -41,10 +41,10 @@ const TABS: TabConfig[] = [
  * ModeTabSwitcher Component
  *
  * A tab interface at the top of the Client Agent panel to switch between
- * Native ACP checkout and Apps SDK (merchant iframe) modes.
+ * Native checkout and Apps SDK (merchant iframe) modes.
  *
  * Features:
- * - Two tabs: "Native ACP" and "Apps SDK"
+ * - Two tabs: "Native" and "Apps SDK"
  * - Glassmorphic styling matching the existing design system
  * - Active tab uses NVIDIA green accent
  * - Smooth transition animations

--- a/src/ui/components/business/BusinessPanel.test.tsx
+++ b/src/ui/components/business/BusinessPanel.test.tsx
@@ -3,44 +3,52 @@ import { render, screen } from "@testing-library/react";
 import { BusinessPanel } from "./BusinessPanel";
 import { ACPLogProvider } from "@/hooks/useACPLog";
 import { AgentActivityLogProvider } from "@/hooks/useAgentActivityLog";
+import type { CheckoutProtocol } from "@/types";
 
-// Wrapper component to provide required context
-function renderWithProviders(ui: React.ReactElement) {
+function renderWithProviders(protocol: CheckoutProtocol = "acp") {
   return render(
     <AgentActivityLogProvider>
-      <ACPLogProvider>{ui}</ACPLogProvider>
+      <ACPLogProvider>
+        <BusinessPanel protocol={protocol} onProtocolChange={() => {}} />
+      </ACPLogProvider>
     </AgentActivityLogProvider>
   );
 }
 
 describe("BusinessPanel", () => {
   it("renders the Merchant Server badge", () => {
-    renderWithProviders(<BusinessPanel />);
+    renderWithProviders();
     expect(screen.getByText("Merchant Server")).toBeInTheDocument();
   });
 
   it("renders with section aria-label", () => {
-    renderWithProviders(<BusinessPanel />);
+    renderWithProviders();
     expect(screen.getByRole("region", { name: "Merchant Panel" })).toBeInTheDocument();
   });
 
   it("renders empty state message when no checkout is active", () => {
-    renderWithProviders(<BusinessPanel />);
+    renderWithProviders();
     // Glassmorphic empty state with waiting message
     expect(screen.getByText("No active session")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Select a product from the Client Agent panel to start an ACP checkout session."
+        "Select a product from the Client Agent panel to start a checkout session using ACP."
       )
     ).toBeInTheDocument();
   });
 
   it("renders glass panel header with badge", () => {
-    const { container } = renderWithProviders(<BusinessPanel />);
+    const { container } = renderWithProviders();
     // Check for glassmorphic styling classes
     const header = container.querySelector(".glass-panel-header");
     expect(header).toBeInTheDocument();
     const badge = container.querySelector(".glass-badge");
     expect(badge).toBeInTheDocument();
+  });
+
+  it("renders ACP and UCP protocol tabs", () => {
+    renderWithProviders();
+    expect(screen.getByRole("tab", { name: "ACP" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "UCP" })).toBeInTheDocument();
   });
 });

--- a/src/ui/components/business/BusinessPanel.tsx
+++ b/src/ui/components/business/BusinessPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import { useACPLog, type ACPEvent, type ACPEventType } from "@/hooks/useACPLog";
 import { useCheckoutEvents } from "@/hooks/useCheckoutEvents";
+import type { CheckoutProtocol } from "@/types";
 
 /**
  * MCP Server base URL - uses nginx proxy in Docker, direct in development
@@ -105,7 +106,9 @@ function ACPEventItem({ event }: { event: ACPEvent }) {
 /**
  * Empty state with waiting message
  */
-function EmptyState() {
+function EmptyState({ protocol }: { protocol: CheckoutProtocol }) {
+  const protocolLabel = protocol === "ucp" ? "UCP" : "ACP";
+
   return (
     <div
       className="glass-content"
@@ -166,7 +169,8 @@ function EmptyState() {
           maxWidth: "240px",
         }}
       >
-        Select a product from the Client Agent panel to start an ACP checkout session.
+        Select a product from the Client Agent panel to start a checkout session using{" "}
+        {protocolLabel}.
       </p>
     </div>
   );
@@ -175,7 +179,15 @@ function EmptyState() {
 /**
  * Active session view with event timeline (glass style)
  */
-function ActiveSession({ events, onClear }: { events: ACPEvent[]; onClear: () => void }) {
+function ActiveSession({
+  events,
+  onClear,
+  protocol,
+}: {
+  events: ACPEvent[];
+  onClear: () => void;
+  protocol: CheckoutProtocol;
+}) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll to top when new events arrive (newest first)
@@ -184,6 +196,8 @@ function ActiveSession({ events, onClear }: { events: ACPEvent[]; onClear: () =>
       scrollRef.current.scrollTop = 0;
     }
   }, [events.length]);
+
+  const protocolLabel = protocol === "ucp" ? "UCP" : "ACP";
 
   return (
     <div
@@ -208,7 +222,7 @@ function ActiveSession({ events, onClear }: { events: ACPEvent[]; onClear: () =>
             textTransform: "uppercase",
           }}
         >
-          ACP Communication
+          {protocolLabel} Communication
         </h3>
         <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
           <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>
@@ -256,11 +270,69 @@ function ActiveSession({ events, onClear }: { events: ACPEvent[]; onClear: () =>
   );
 }
 
+function ProtocolToggle({
+  protocol,
+  onProtocolChange,
+}: {
+  protocol: CheckoutProtocol;
+  onProtocolChange: (protocol: CheckoutProtocol) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        gap: "4px",
+        padding: "4px",
+        borderRadius: "10px",
+        border: "1px solid var(--glass-border-subtle, rgba(255, 255, 255, 0.08))",
+        background: "var(--block-bg, rgba(255, 255, 255, 0.045))",
+      }}
+      role="tablist"
+      aria-label="Protocol selector"
+    >
+      {(["acp", "ucp"] as const).map((tab) => {
+        const active = protocol === tab;
+        return (
+          <button
+            key={tab}
+            role="tab"
+            aria-selected={active}
+            type="button"
+            onClick={() => onProtocolChange(tab)}
+            style={{
+              minWidth: "52px",
+              padding: "6px 12px",
+              borderRadius: "8px",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontWeight: 600,
+              letterSpacing: "0.4px",
+              color: active ? "var(--accent-green, #76b900)" : "var(--text-muted)",
+              background: active
+                ? "var(--accent-green-bg, rgba(118, 185, 0, 0.12))"
+                : "transparent",
+              transition: "all 0.2s ease",
+            }}
+          >
+            {tab.toUpperCase()}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 /**
  * Right panel showing merchant/retailer view with ACP communication log
  * Uses glassmorphic design system
  */
-export function BusinessPanel() {
+interface BusinessPanelProps {
+  protocol: CheckoutProtocol;
+  onProtocolChange: (protocol: CheckoutProtocol) => void;
+}
+
+export function BusinessPanel({ protocol, onProtocolChange }: BusinessPanelProps) {
   const { state, clear } = useACPLog();
   const hasEvents = state.events.length > 0;
 
@@ -282,6 +354,17 @@ export function BusinessPanel() {
     }
   }, [clear]);
 
+  const handleProtocolChange = useCallback(
+    (nextProtocol: CheckoutProtocol) => {
+      if (nextProtocol === protocol) {
+        return;
+      }
+      clear();
+      onProtocolChange(nextProtocol);
+    },
+    [clear, onProtocolChange, protocol]
+  );
+
   return (
     <section
       className="glass-panel flex-1 flex flex-col h-full overflow-hidden"
@@ -289,17 +372,27 @@ export function BusinessPanel() {
     >
       {/* Glass Panel Header */}
       <div className="glass-panel-header">
-        <div className={`glass-badge ${hasEvents ? "yellow" : "gray"}`}>
-          <span className={`glass-dot ${hasEvents ? "live" : ""}`}></span>
-          Merchant Server
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "12px",
+          }}
+        >
+          <div className={`glass-badge ${hasEvents ? "yellow" : "gray"}`}>
+            <span className={`glass-dot ${hasEvents ? "live" : ""}`}></span>
+            Merchant Server
+          </div>
+          <ProtocolToggle protocol={protocol} onProtocolChange={handleProtocolChange} />
         </div>
       </div>
 
       {/* Content - either empty state or active session */}
       {state.events.length === 0 ? (
-        <EmptyState />
+        <EmptyState protocol={protocol} />
       ) : (
-        <ActiveSession events={state.events} onClear={handleClear} />
+        <ActiveSession events={state.events} onClear={handleClear} protocol={protocol} />
       )}
     </section>
   );

--- a/src/ui/env.example
+++ b/src/ui/env.example
@@ -17,6 +17,10 @@ PHOENIX_API_URL=http://localhost:6006
 # Client-side (safe to expose)
 # =============================================================================
 NEXT_PUBLIC_API_VERSION=2026-01-16
+# UCP platform profile used in UCP-Agent header for A2A negotiation
+# Local dev example: http://localhost:8000/.well-known/ucp
+# Docker example (ui + merchant containers): http://merchant:8000/.well-known/ucp
+NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL=http://localhost:8000/.well-known/ucp
 
 # Webhook Configuration
 # Secret for validating incoming webhooks from the merchant

--- a/src/ui/hooks/useCheckoutFlow.test.ts
+++ b/src/ui/hooks/useCheckoutFlow.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useCheckoutFlow } from "./useCheckoutFlow";
-import type { Product, CheckoutSessionResponse } from "@/types";
+import type {
+  Product,
+  CheckoutSessionResponse,
+  CreateCheckoutRequest,
+  UpdateCheckoutRequest,
+  CompleteCheckoutRequest,
+} from "@/types";
 import * as apiClient from "@/lib/api-client";
 
 // Mock the API client module
@@ -9,6 +15,44 @@ vi.mock("@/lib/api-client", () => ({
   createCheckoutSession: vi.fn(),
   updateCheckoutSession: vi.fn(),
   completeCheckout: vi.fn(),
+  createCheckoutSessionByProtocol: vi.fn(
+    (protocol: "acp" | "ucp", request: CreateCheckoutRequest) => {
+      if (protocol !== "acp" && protocol !== "ucp") {
+        throw new Error("Invalid protocol");
+      }
+      return vi.mocked(apiClient.createCheckoutSession)(request);
+    }
+  ),
+  updateCheckoutSessionByProtocol: vi.fn(
+    (
+      protocol: "acp" | "ucp",
+      sessionRef: { sessionId: string | null },
+      request: UpdateCheckoutRequest
+    ) => {
+      if (protocol !== "acp" && protocol !== "ucp") {
+        throw new Error("Invalid protocol");
+      }
+      if (!sessionRef.sessionId) {
+        throw new Error("Missing session ID");
+      }
+      return vi.mocked(apiClient.updateCheckoutSession)(sessionRef.sessionId, request);
+    }
+  ),
+  completeCheckoutByProtocol: vi.fn(
+    (
+      protocol: "acp" | "ucp",
+      sessionRef: { sessionId: string | null },
+      request: CompleteCheckoutRequest
+    ) => {
+      if (protocol !== "acp" && protocol !== "ucp") {
+        throw new Error("Invalid protocol");
+      }
+      if (!sessionRef.sessionId) {
+        throw new Error("Missing session ID");
+      }
+      return vi.mocked(apiClient.completeCheckout)(sessionRef.sessionId, request);
+    }
+  ),
   delegatePayment: vi.fn(),
   generatePostPurchaseMessage: vi.fn(),
   postWebhookShippingUpdate: vi.fn(),
@@ -566,6 +610,35 @@ describe("useCheckoutFlow", () => {
     });
   });
 
+  describe("protocol routing", () => {
+    it("uses protocol-aware create call when protocol is ucp", async () => {
+      vi.mocked(apiClient.createCheckoutSession).mockResolvedValueOnce({
+        ...mockSession,
+        protocol: "ucp",
+        ucpContextId: "ctx_123",
+      });
+      vi.mocked(apiClient.updateCheckoutSession).mockResolvedValueOnce({
+        ...mockReadySession,
+        protocol: "ucp",
+        ucpContextId: "ctx_123",
+      });
+
+      const { result } = renderHook(() => useCheckoutFlow(undefined, undefined, "ucp"));
+
+      await act(async () => {
+        await result.current.selectProduct(mockProduct);
+      });
+
+      expect(apiClient.createCheckoutSessionByProtocol).toHaveBeenCalledWith(
+        "ucp",
+        expect.objectContaining({
+          items: [{ id: "prod_1", quantity: 1 }],
+        })
+      );
+      expect(result.current.context.ucpContextId).toBe("ctx_123");
+    });
+  });
+
   describe("reset", () => {
     it("resets all state to initial values", async () => {
       vi.mocked(apiClient.createCheckoutSession).mockResolvedValueOnce(mockSession);
@@ -605,6 +678,7 @@ describe("useCheckoutFlow", () => {
       expect(result.current.context.selectedProduct).toBeNull();
       expect(result.current.context.session).toBeNull();
       expect(result.current.context.sessionId).toBeNull();
+      expect(result.current.context.ucpContextId).toBeNull();
       expect(result.current.context.vaultToken).toBeNull();
       expect(result.current.context.orderId).toBeNull();
       expect(result.current.context.error).toBeNull();

--- a/src/ui/hooks/useCheckoutFlow.ts
+++ b/src/ui/hooks/useCheckoutFlow.ts
@@ -40,10 +40,17 @@ function truncateId(id: string): string {
   return `...${id.slice(-8)}`;
 }
 
-function buildProtocolSessionRef(sessionId: string, contextId?: string | null): ProtocolSessionRef {
+function buildProtocolSessionRef(
+  sessionId: string,
+  contextId?: string | null,
+  paymentHandlerId?: string | null
+): ProtocolSessionRef {
   const sessionRef: ProtocolSessionRef = { sessionId };
   if (contextId != null) {
     sessionRef.contextId = contextId;
+  }
+  if (paymentHandlerId != null) {
+    sessionRef.paymentHandlerId = paymentHandlerId;
   }
   return sessionRef;
 }
@@ -493,7 +500,11 @@ export function useCheckoutFlow(
           try {
             const updatedSession = await updateCheckoutSessionByProtocol(
               protocol,
-              buildProtocolSessionRef(session.id, session.ucpContextId),
+              buildProtocolSessionRef(
+                session.id,
+                session.ucpContextId,
+                session.ucpPaymentHandlerId
+              ),
               firstOption ? { fulfillment_option_id: firstOption.id } : {}
             );
 
@@ -555,7 +566,11 @@ export function useCheckoutFlow(
 
         const session = await updateCheckoutSessionByProtocol(
           protocol,
-          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          buildProtocolSessionRef(
+            context.sessionId,
+            context.ucpContextId,
+            context.session?.ucpPaymentHandlerId
+          ),
           request
         );
 
@@ -579,7 +594,7 @@ export function useCheckoutFlow(
         dispatch({ type: "SET_ERROR", error: createAPIError(error) });
       }
     },
-    [context.sessionId, context.selectedProduct, context.ucpContextId, protocol]
+    [context.sessionId, context.selectedProduct, context.session, context.ucpContextId, protocol]
   );
 
   /**
@@ -611,7 +626,11 @@ export function useCheckoutFlow(
       try {
         const session = await updateCheckoutSessionByProtocol(
           protocol,
-          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          buildProtocolSessionRef(
+            context.sessionId,
+            context.ucpContextId,
+            context.session?.ucpPaymentHandlerId
+          ),
           {
             fulfillment_option_id: shippingId,
           }
@@ -668,7 +687,11 @@ export function useCheckoutFlow(
       try {
         const session = await updateCheckoutSessionByProtocol(
           protocol,
-          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          buildProtocolSessionRef(
+            context.sessionId,
+            context.ucpContextId,
+            context.session?.ucpPaymentHandlerId
+          ),
           {
             discounts: {
               codes: normalized ? [normalized] : [],
@@ -696,7 +719,7 @@ export function useCheckoutFlow(
         dispatch({ type: "SET_ERROR", error: createAPIError(error) });
       }
     },
-    [context.sessionId, context.ucpContextId, protocol]
+    [context.sessionId, context.session, context.ucpContextId, protocol]
   );
 
   /**
@@ -799,7 +822,11 @@ export function useCheckoutFlow(
 
         const completedSession = await completeCheckoutByProtocol(
           protocol,
-          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          buildProtocolSessionRef(
+            context.sessionId,
+            context.ucpContextId,
+            context.session?.ucpPaymentHandlerId
+          ),
           {
             payment_data: {
               token: delegateResponse.id,
@@ -830,7 +857,11 @@ export function useCheckoutFlow(
             try {
               const finalSession = await completeCheckoutByProtocol(
                 protocol,
-                buildProtocolSessionRef(context.sessionId!, context.ucpContextId),
+                buildProtocolSessionRef(
+                  context.sessionId!,
+                  context.ucpContextId,
+                  context.session?.ucpPaymentHandlerId
+                ),
                 {
                   payment_data: {
                     token: delegateResponse.id,

--- a/src/ui/hooks/useCheckoutFlow.ts
+++ b/src/ui/hooks/useCheckoutFlow.ts
@@ -2,6 +2,7 @@
 
 import { useReducer, useCallback, useRef } from "react";
 import type {
+  CheckoutProtocol,
   CheckoutFlowState,
   CheckoutFlowContext,
   CheckoutFlowAction,
@@ -12,11 +13,12 @@ import type {
   BillingAddressFormData,
 } from "@/types";
 import {
-  createCheckoutSession,
-  updateCheckoutSession,
-  completeCheckout,
+  createCheckoutSessionByProtocol,
+  updateCheckoutSessionByProtocol,
+  completeCheckoutByProtocol,
   delegatePayment,
 } from "@/lib/api-client";
+import type { ProtocolSessionRef } from "@/lib/api-client";
 import { createAPIError } from "@/lib/errors";
 import type { ACPEventType, ACPEventStatus } from "@/hooks/useACPLog";
 import type {
@@ -36,6 +38,48 @@ const DEFAULT_SHIPPING_ID = "ship_standard";
 function truncateId(id: string): string {
   if (id.length <= 12) return id;
   return `...${id.slice(-8)}`;
+}
+
+function buildProtocolSessionRef(sessionId: string, contextId?: string | null): ProtocolSessionRef {
+  const sessionRef: ProtocolSessionRef = { sessionId };
+  if (contextId != null) {
+    sessionRef.contextId = contextId;
+  }
+  return sessionRef;
+}
+
+function getUCPLogEndpoint(action: string): string {
+  return `/api/proxy/merchant/a2a -> /a2a (jsonrpc:message/send action:${action})`;
+}
+
+function formatUCPStatusSummary(session: CheckoutSessionResponse, details?: string): string {
+  const statusText = `Status: ${session.status}`;
+  const capabilities =
+    session.capabilities?.extensions?.map((extension) => extension.name).join(", ") ?? "";
+  const detailText = details ? ` | ${details}` : "";
+
+  if (capabilities) {
+    return `${statusText}${detailText} | caps: ${capabilities}`;
+  }
+  return `${statusText}${detailText}`;
+}
+
+function inferPromotionAction(baseAmount: number, discountAmount: number): string {
+  if (discountAmount <= 0 || baseAmount <= 0) {
+    return "NO_PROMO";
+  }
+
+  const ratio = discountAmount / baseAmount;
+  if (Math.abs(ratio - 0.05) <= 0.015) {
+    return "DISCOUNT_5_PCT";
+  }
+  if (Math.abs(ratio - 0.1) <= 0.015) {
+    return "DISCOUNT_10_PCT";
+  }
+  if (Math.abs(ratio - 0.15) <= 0.02) {
+    return "DISCOUNT_15_PCT";
+  }
+  return "DISCOUNT_APPLIED";
 }
 
 /**
@@ -114,21 +158,22 @@ function logPromotionAgentActivity(
 
       agentLogger.addAgentEvent("promotion", inputSignals, decision, "success");
     } else if (lineItem.discount > 0) {
-      // Discount exists but no metadata - agent ran but metadata not exposed
+      // Discount exists but promotion metadata is unavailable in this response shape.
       const decision: PromotionDecision = {
-        action: "DISCOUNT",
+        action: inferPromotionAction(lineItem.base_amount, lineItem.discount),
         discountAmount: lineItem.discount,
-        reasonCodes: [],
-        reasoning: "Promotion applied (details not available)",
+        reasonCodes: ["PROMOTION_METADATA_UNAVAILABLE"],
+        reasoning:
+          "A promotion discount was applied in checkout totals, but detailed promotion reasoning was not included in this response.",
       };
       agentLogger.addAgentEvent("promotion", inputSignals, decision, "success");
     } else {
-      // No discount - either no promo or agent skipped
+      // No discount in totals. Avoid inferring additional agent reasoning here.
       const decision: PromotionDecision = {
         action: "NO_PROMO",
         discountAmount: 0,
-        reasonCodes: [],
-        reasoning: "No promotion applied",
+        reasonCodes: ["NO_DISCOUNT_IN_TOTALS"],
+        reasoning: "No promotion discount is present in the checkout totals for this response.",
       };
       agentLogger.addAgentEvent("promotion", inputSignals, decision, "success");
     }
@@ -160,6 +205,7 @@ const initialContext: CheckoutFlowContext = {
   selectedShippingId: DEFAULT_SHIPPING_ID,
   orderId: null,
   sessionId: null,
+  ucpContextId: null,
   session: null,
   vaultToken: null,
   isLoading: false,
@@ -226,6 +272,7 @@ function checkoutFlowReducer(
         ...context,
         state: "checkout",
         sessionId: action.session.id,
+        ucpContextId: action.session.ucpContextId ?? null,
         session: action.session,
         selectedShippingId: firstShippingId,
         isLoading: false,
@@ -236,6 +283,8 @@ function checkoutFlowReducer(
     case "SESSION_UPDATED": {
       return {
         ...context,
+        sessionId: action.session.id,
+        ucpContextId: action.session.ucpContextId ?? context.ucpContextId,
         session: action.session,
         isLoading: false,
         error: null,
@@ -376,7 +425,11 @@ function checkoutFlowReducer(
 /**
  * Hook for managing checkout flow state machine with real API calls
  */
-export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityLogger) {
+export function useCheckoutFlow(
+  logger?: ACPLogger,
+  agentLogger?: AgentActivityLogger,
+  protocol: CheckoutProtocol = "acp"
+) {
   const [context, dispatch] = useReducer(checkoutFlowReducer, initialContext);
 
   // Use refs for loggers to avoid recreating callbacks when context changes
@@ -388,76 +441,90 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
   /**
    * Select a product and create a checkout session
    */
-  const selectProduct = useCallback(async (product: Product) => {
-    dispatch({ type: "SELECT_PRODUCT", product });
+  const selectProduct = useCallback(
+    async (product: Product) => {
+      dispatch({ type: "SELECT_PRODUCT", product });
 
-    const eventId = loggerRef.current?.logEvent(
-      "session_create",
-      "POST",
-      "/checkout_sessions",
-      `Create session for ${product.name}`
-    );
+      const eventId = loggerRef.current?.logEvent(
+        "session_create",
+        "POST",
+        protocol === "ucp" ? getUCPLogEndpoint("create_checkout") : "/checkout_sessions",
+        protocol === "ucp"
+          ? `message/send:create_checkout (${product.name})`
+          : `Create session for ${product.name}`
+      );
 
-    try {
-      const session = await createCheckoutSession({
-        items: [{ id: product.id, quantity: 1 }],
-        buyer: DEFAULT_BUYER,
-        fulfillment_address: DEFAULT_FULFILLMENT_ADDRESS,
-      });
+      try {
+        const session = await createCheckoutSessionByProtocol(protocol, {
+          items: [{ id: product.id, quantity: 1 }],
+          buyer: DEFAULT_BUYER,
+          fulfillment_address: DEFAULT_FULFILLMENT_ADDRESS,
+        });
 
-      if (eventId) {
-        loggerRef.current?.completeEvent(
-          eventId,
-          "success",
-          `Session ${session.id.slice(0, 8)}... created`,
-          201
-        );
-      }
-
-      // Log promotion agent activity from line items
-      logPromotionAgentActivity(session.line_items, product, agentLoggerRef.current);
-
-      dispatch({ type: "SESSION_CREATED", session });
-
-      // Auto-select first shipping option if available
-      const firstOption = session.fulfillment_options[0];
-      if (firstOption) {
-        const updateEventId = loggerRef.current?.logEvent(
-          "session_update",
-          "POST",
-          `/checkout_sessions/${truncateId(session.id)}`,
-          `Select shipping: ${firstOption.title}`
-        );
-
-        try {
-          const updatedSession = await updateCheckoutSession(session.id, {
-            fulfillment_option_id: firstOption.id,
-          });
-
-          if (updateEventId) {
-            loggerRef.current?.completeEvent(
-              updateEventId,
-              "success",
-              `Status: ${updatedSession.status}`,
-              200
-            );
-          }
-
-          dispatch({ type: "SESSION_UPDATED", session: updatedSession });
-        } catch (error) {
-          if (updateEventId) {
-            loggerRef.current?.completeEvent(updateEventId, "error", "Update failed", 400);
-          }
-          dispatch({ type: "SET_ERROR", error: createAPIError(error) });
+        if (eventId) {
+          loggerRef.current?.completeEvent(
+            eventId,
+            "success",
+            formatUCPStatusSummary(session, `Session ${session.id.slice(0, 8)}... created`),
+            201
+          );
         }
+
+        // Log promotion agent activity from line items
+        logPromotionAgentActivity(session.line_items, product, agentLoggerRef.current);
+
+        dispatch({ type: "SESSION_CREATED", session });
+
+        // Auto-select first shipping option for ACP.
+        // For UCP we still trigger one update call to advance status transitions.
+        const firstOption = session.fulfillment_options[0];
+        if (protocol === "ucp" || firstOption) {
+          const updateEventId = loggerRef.current?.logEvent(
+            "session_update",
+            "POST",
+            protocol === "ucp"
+              ? getUCPLogEndpoint("update_checkout")
+              : `/checkout_sessions/${truncateId(session.id)}`,
+            protocol === "ucp"
+              ? "message/send:update_checkout"
+              : `Select shipping: ${firstOption?.title ?? "default"}`
+          );
+
+          try {
+            const updatedSession = await updateCheckoutSessionByProtocol(
+              protocol,
+              buildProtocolSessionRef(session.id, session.ucpContextId),
+              firstOption ? { fulfillment_option_id: firstOption.id } : {}
+            );
+
+            if (updateEventId) {
+              loggerRef.current?.completeEvent(
+                updateEventId,
+                "success",
+                protocol === "ucp"
+                  ? formatUCPStatusSummary(updatedSession)
+                  : `Status: ${updatedSession.status}`,
+                200
+              );
+            }
+
+            dispatch({ type: "SESSION_UPDATED", session: updatedSession });
+          } catch (error) {
+            if (updateEventId) {
+              loggerRef.current?.completeEvent(updateEventId, "error", "Update failed", 400);
+            }
+            dispatch({ type: "SET_ERROR", error: createAPIError(error) });
+          }
+        }
+      } catch (error) {
+        if (eventId) {
+          loggerRef.current?.completeEvent(eventId, "error", "Session creation failed", 400);
+        }
+        dispatch({ type: "SET_ERROR", error: createAPIError(error) });
       }
-    } catch (error) {
-      if (eventId) {
-        loggerRef.current?.completeEvent(eventId, "error", "Session creation failed", 400);
-      }
-      dispatch({ type: "SET_ERROR", error: createAPIError(error) });
-    }
-  }, []);
+    },
+    [protocol]
+  );
 
   /**
    * Update quantity and refresh session
@@ -475,8 +542,10 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
       const eventId = loggerRef.current?.logEvent(
         "session_update",
         "POST",
-        `/checkout_sessions/${truncateId(context.sessionId)}`,
-        `Update quantity: ${quantity}`
+        protocol === "ucp"
+          ? getUCPLogEndpoint("update_checkout")
+          : `/checkout_sessions/${truncateId(context.sessionId)}`,
+        protocol === "ucp" ? "message/send:update_checkout" : `Update quantity: ${quantity}`
       );
 
       try {
@@ -484,14 +553,20 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
           items: [{ id: context.selectedProduct.id, quantity }],
         };
 
-        const session = await updateCheckoutSession(context.sessionId, request);
+        const session = await updateCheckoutSessionByProtocol(
+          protocol,
+          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          request
+        );
 
         if (eventId) {
           const total = session.totals.find((t) => t.type === "total")?.amount ?? 0;
           loggerRef.current?.completeEvent(
             eventId,
             "success",
-            `Total: $${(total / 100).toFixed(2)}`,
+            protocol === "ucp"
+              ? formatUCPStatusSummary(session, `Total: $${(total / 100).toFixed(2)}`)
+              : `Total: $${(total / 100).toFixed(2)}`,
             200
           );
         }
@@ -504,7 +579,7 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
         dispatch({ type: "SET_ERROR", error: createAPIError(error) });
       }
     },
-    [context.sessionId, context.selectedProduct]
+    [context.sessionId, context.selectedProduct, context.ucpContextId, protocol]
   );
 
   /**
@@ -527,21 +602,29 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
       const eventId = loggerRef.current?.logEvent(
         "session_update",
         "POST",
-        `/checkout_sessions/${truncateId(context.sessionId)}`,
-        `Select: ${shippingName}`
+        protocol === "ucp"
+          ? getUCPLogEndpoint("update_checkout")
+          : `/checkout_sessions/${truncateId(context.sessionId)}`,
+        protocol === "ucp" ? "message/send:update_checkout" : `Select: ${shippingName}`
       );
 
       try {
-        const session = await updateCheckoutSession(context.sessionId, {
-          fulfillment_option_id: shippingId,
-        });
+        const session = await updateCheckoutSessionByProtocol(
+          protocol,
+          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          {
+            fulfillment_option_id: shippingId,
+          }
+        );
 
         if (eventId) {
           const total = session.totals.find((t) => t.type === "total")?.amount ?? 0;
           loggerRef.current?.completeEvent(
             eventId,
             "success",
-            `Total: $${(total / 100).toFixed(2)}`,
+            protocol === "ucp"
+              ? formatUCPStatusSummary(session, `Total: $${(total / 100).toFixed(2)}`)
+              : `Total: $${(total / 100).toFixed(2)}`,
             200
           );
         }
@@ -554,7 +637,7 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
         dispatch({ type: "SET_ERROR", error: createAPIError(error) });
       }
     },
-    [context.sessionId, context.selectedProduct, context.session]
+    [context.sessionId, context.selectedProduct, context.session, context.ucpContextId, protocol]
   );
 
   /**
@@ -572,23 +655,35 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
       const eventId = loggerRef.current?.logEvent(
         "session_update",
         "POST",
-        `/checkout_sessions/${truncateId(context.sessionId)}`,
-        normalized ? `Apply coupon: ${normalized}` : "Clear coupons"
+        protocol === "ucp"
+          ? getUCPLogEndpoint("update_checkout")
+          : `/checkout_sessions/${truncateId(context.sessionId)}`,
+        protocol === "ucp"
+          ? "message/send:update_checkout"
+          : normalized
+            ? `Apply coupon: ${normalized}`
+            : "Clear coupons"
       );
 
       try {
-        const session = await updateCheckoutSession(context.sessionId, {
-          discounts: {
-            codes: normalized ? [normalized] : [],
-          },
-        });
+        const session = await updateCheckoutSessionByProtocol(
+          protocol,
+          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          {
+            discounts: {
+              codes: normalized ? [normalized] : [],
+            },
+          }
+        );
 
         if (eventId) {
           const total = session.totals.find((t) => t.type === "total")?.amount ?? 0;
           loggerRef.current?.completeEvent(
             eventId,
             "success",
-            `Total: $${(total / 100).toFixed(2)}`,
+            protocol === "ucp"
+              ? formatUCPStatusSummary(session, `Total: $${(total / 100).toFixed(2)}`)
+              : `Total: $${(total / 100).toFixed(2)}`,
             200
           );
         }
@@ -601,7 +696,7 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
         dispatch({ type: "SET_ERROR", error: createAPIError(error) });
       }
     },
-    [context.sessionId]
+    [context.sessionId, context.ucpContextId, protocol]
   );
 
   /**
@@ -696,18 +791,24 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
         const completeEventId = loggerRef.current?.logEvent(
           "session_complete",
           "POST",
-          `/checkout_sessions/${truncateId(context.sessionId)}/complete`,
-          "Process payment"
+          protocol === "ucp"
+            ? getUCPLogEndpoint("complete_checkout")
+            : `/checkout_sessions/${truncateId(context.sessionId)}/complete`,
+          protocol === "ucp" ? "message/send:complete_checkout" : "Process payment"
         );
 
-        const completedSession = await completeCheckout(context.sessionId, {
-          payment_data: {
-            token: delegateResponse.id,
-            provider: "stripe",
-            billing_address: billingAddressData,
-          },
-          preferred_language: billingAddress.preferredLanguage,
-        });
+        const completedSession = await completeCheckoutByProtocol(
+          protocol,
+          buildProtocolSessionRef(context.sessionId, context.ucpContextId),
+          {
+            payment_data: {
+              token: delegateResponse.id,
+              provider: "stripe",
+              billing_address: billingAddressData,
+            },
+            preferred_language: billingAddress.preferredLanguage,
+          }
+        );
 
         // Check if 3DS is required
         if (completedSession.status === "authentication_required") {
@@ -721,26 +822,26 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
             const authEventId = loggerRef.current?.logEvent(
               "session_complete",
               "POST",
-              `/checkout_sessions/${truncateId(context.sessionId!)}/complete`,
-              "3DS authentication"
+              protocol === "ucp"
+                ? getUCPLogEndpoint("complete_checkout")
+                : `/checkout_sessions/${truncateId(context.sessionId!)}/complete`,
+              protocol === "ucp" ? "message/send:complete_checkout" : "3DS authentication"
             );
             try {
-              const finalSession = await completeCheckout(context.sessionId!, {
-                payment_data: {
-                  token: delegateResponse.id,
-                  provider: "stripe",
-                },
-                authentication_result: {
-                  outcome: "authenticated",
-                  outcome_details: {
-                    three_ds_cryptogram: "AAIBBYNoEQAAAAAAg4PyBhdAEQs=",
-                    electronic_commerce_indicator: "05",
-                    transaction_id: crypto.randomUUID(),
-                    version: "2.2.0",
+              const finalSession = await completeCheckoutByProtocol(
+                protocol,
+                buildProtocolSessionRef(context.sessionId!, context.ucpContextId),
+                {
+                  payment_data: {
+                    token: delegateResponse.id,
+                    provider: "stripe",
                   },
-                },
-                preferred_language: billingAddress.preferredLanguage,
-              });
+                  authentication_result: {
+                    outcome: "authenticated",
+                  },
+                  preferred_language: billingAddress.preferredLanguage,
+                }
+              );
               if (authEventId) {
                 loggerRef.current?.completeEvent(
                   authEventId,
@@ -790,10 +891,11 @@ export function useCheckoutFlow(logger?: ACPLogger, agentLogger?: AgentActivityL
     },
     [
       context.sessionId,
+      context.ucpContextId,
       context.session,
-      context.selectedProduct,
       context.paymentInfo,
       context.billingAddress,
+      protocol,
     ]
   );
 

--- a/src/ui/lib/api-client.test.ts
+++ b/src/ui/lib/api-client.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createCheckoutSessionByProtocol,
+  completeCheckoutByProtocol,
+  type ProtocolSessionRef,
+} from "./api-client";
+
+describe("api-client protocol routing", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("uses ACP endpoint when protocol is acp", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "cs_1",
+          status: "not_ready_for_payment",
+          currency: "usd",
+          payment_provider: {
+            provider: "stripe",
+            supported_payment_methods: [
+              { type: "card", supported_card_networks: ["visa", "mastercard"] },
+            ],
+          },
+          line_items: [],
+          fulfillment_options: [],
+          totals: [],
+          messages: [],
+          links: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    await createCheckoutSessionByProtocol("acp", {
+      items: [{ id: "prod_1", quantity: 1 }],
+    });
+
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    expect(url).toBe("/api/proxy/merchant/checkout_sessions");
+  });
+
+  it("uses A2A endpoint and normalizes UCP response", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req_1",
+          result: {
+            contextId: "ctx_123",
+            parts: [
+              {
+                data: {
+                  "a2a.ucp.checkout": {
+                    id: "cs_ucp_1",
+                    status: "ready_for_complete",
+                    currency: "USD",
+                    line_items: [
+                      {
+                        id: "li_1",
+                        item: { id: "prod_1", title: "Test Shirt", price: 2500 },
+                        quantity: 1,
+                        totals: [
+                          { type: "subtotal", label: "Subtotal", amount: 2500 },
+                          { type: "tax", label: "Tax", amount: 200 },
+                          { type: "total", label: "Total", amount: 2700 },
+                        ],
+                      },
+                    ],
+                    totals: [
+                      { type: "subtotal", label: "Subtotal", amount: 2500 },
+                      { type: "tax", label: "Tax", amount: 200 },
+                      { type: "total", label: "Total", amount: 2700 },
+                    ],
+                    messages: [],
+                  },
+                },
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const session = await createCheckoutSessionByProtocol("ucp", {
+      items: [{ id: "prod_1", quantity: 1 }],
+    });
+
+    expect(session.status).toBe("ready_for_payment");
+    expect(session.protocol).toBe("ucp");
+    expect(session.ucpContextId).toBe("ctx_123");
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["UCP-Agent"]).toContain("profile=");
+    expect(headers["X-A2A-Extensions"]).toBe("https://ucp.dev/2026-01-23/specification/reference/");
+  });
+
+  it("infers line-item discount from UCP subtotal", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req_discount",
+          result: {
+            contextId: "ctx_456",
+            parts: [
+              {
+                data: {
+                  "a2a.ucp.checkout": {
+                    id: "cs_ucp_2",
+                    status: "incomplete",
+                    currency: "USD",
+                    line_items: [
+                      {
+                        id: "li_2",
+                        item: { id: "prod_2", title: "Classic Tee", price: 7500 },
+                        quantity: 1,
+                        totals: [
+                          { type: "subtotal", label: "Subtotal", amount: 6750 },
+                          { type: "tax", label: "Tax", amount: 675 },
+                          { type: "total", label: "Total", amount: 7425 },
+                        ],
+                      },
+                    ],
+                    totals: [{ type: "total", label: "Total", amount: 7425 }],
+                    messages: [],
+                  },
+                },
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const session = await createCheckoutSessionByProtocol("ucp", {
+      items: [{ id: "prod_2", quantity: 1 }],
+    });
+
+    expect(session.line_items[0]?.base_amount).toBe(7500);
+    expect(session.line_items[0]?.discount).toBe(750);
+    expect(session.line_items[0]?.subtotal).toBe(6750);
+  });
+
+  it("sends tokenized payment instrument for UCP completion", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req_2",
+          result: {
+            contextId: "ctx_123",
+            parts: [
+              {
+                data: {
+                  "a2a.ucp.checkout": {
+                    id: "cs_ucp_1",
+                    status: "completed",
+                    currency: "USD",
+                    line_items: [],
+                    totals: [{ type: "total", label: "Total", amount: 2700 }],
+                    messages: [],
+                  },
+                },
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const sessionRef: ProtocolSessionRef = { sessionId: "cs_ucp_1", contextId: "ctx_123" };
+    await completeCheckoutByProtocol("ucp", sessionRef, {
+      payment_data: {
+        token: "vt_123",
+        provider: "stripe",
+      },
+    });
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
+    const body = JSON.parse(String(init.body)) as {
+      params: { message: { parts: Array<{ data?: Record<string, unknown> }> } };
+    };
+    const paymentPart = body.params.message.parts[1];
+    expect(paymentPart?.data?.["a2a.ucp.checkout.payment"]).toEqual({
+      instruments: [
+        {
+          type: "tokenized_card",
+          handler_id: "processor_tokenizer",
+          credential: { token: "vt_123" },
+        },
+      ],
+    });
+  });
+
+  it("throws APIError when A2A returns json-rpc error payload", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "req_3",
+          error: {
+            code: -32602,
+            message: "Invalid params",
+            data: { detail: "Missing required header: UCP-Agent" },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    await expect(
+      createCheckoutSessionByProtocol("ucp", {
+        items: [{ id: "prod_1", quantity: 1 }],
+      })
+    ).rejects.toMatchObject({
+      code: "jsonrpc_error",
+    });
+  });
+});

--- a/src/ui/lib/api-client.test.ts
+++ b/src/ui/lib/api-client.test.ts
@@ -57,6 +57,11 @@ describe("api-client protocol routing", () => {
                     id: "cs_ucp_1",
                     status: "ready_for_complete",
                     currency: "USD",
+                    ucp: {
+                      payment_handlers: {
+                        "com.example.processor_tokenizer": [{ id: "processor_tokenizer" }],
+                      },
+                    },
                     line_items: [
                       {
                         id: "li_1",
@@ -92,6 +97,7 @@ describe("api-client protocol routing", () => {
     expect(session.status).toBe("ready_for_payment");
     expect(session.protocol).toBe("ucp");
     expect(session.ucpContextId).toBe("ctx_123");
+    expect(session.ucpPaymentHandlerId).toBe("processor_tokenizer");
 
     const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] ?? [];
     const headers = init.headers as Record<string, string>;
@@ -162,6 +168,11 @@ describe("api-client protocol routing", () => {
                     id: "cs_ucp_1",
                     status: "completed",
                     currency: "USD",
+                    ucp: {
+                      payment_handlers: {
+                        "com.example.processor_tokenizer": [{ id: "processor_tokenizer" }],
+                      },
+                    },
                     line_items: [],
                     totals: [{ type: "total", label: "Total", amount: 2700 }],
                     messages: [],
@@ -175,7 +186,11 @@ describe("api-client protocol routing", () => {
       )
     );
 
-    const sessionRef: ProtocolSessionRef = { sessionId: "cs_ucp_1", contextId: "ctx_123" };
+    const sessionRef: ProtocolSessionRef = {
+      sessionId: "cs_ucp_1",
+      contextId: "ctx_123",
+      paymentHandlerId: "processor_tokenizer",
+    };
     await completeCheckoutByProtocol("ucp", sessionRef, {
       payment_data: {
         token: "vt_123",
@@ -191,11 +206,28 @@ describe("api-client protocol routing", () => {
     expect(paymentPart?.data?.["a2a.ucp.checkout.payment"]).toEqual({
       instruments: [
         {
+          id: "vt_123",
           type: "tokenized_card",
           handler_id: "processor_tokenizer",
           credential: { token: "vt_123" },
         },
       ],
+    });
+  });
+
+  it("throws when UCP complete is called without negotiated payment handler", async () => {
+    const sessionRef: ProtocolSessionRef = { sessionId: "cs_ucp_1", contextId: "ctx_123" };
+
+    await expect(
+      completeCheckoutByProtocol("ucp", sessionRef, {
+        payment_data: {
+          token: "vt_123",
+          provider: "stripe",
+        },
+      })
+    ).rejects.toMatchObject({
+      code: "missing",
+      message: "Missing negotiated UCP payment handler ID for checkout completion",
     });
   });
 

--- a/src/ui/lib/api-client.ts
+++ b/src/ui/lib/api-client.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  CheckoutProtocol,
   CheckoutSessionResponse,
   CreateCheckoutRequest,
   UpdateCheckoutRequest,
@@ -15,6 +16,11 @@ import type {
   APIError,
   TimeRange,
   MetricsDashboardAPIResponse,
+  Total,
+  Message,
+  LineItem,
+  PaymentProvider,
+  FulfillmentOption,
 } from "@/types";
 
 // =============================================================================
@@ -38,6 +44,83 @@ const MERCHANT_API_KEY = isServer ? process.env.MERCHANT_API_KEY || "" : "";
 const PSP_API_KEY = isServer ? process.env.PSP_API_KEY || "" : "";
 
 const API_VERSION = process.env.NEXT_PUBLIC_API_VERSION || "2026-01-16";
+const UCP_A2A_EXTENSION_URL = "https://ucp.dev/2026-01-23/specification/reference/";
+const UCP_CHECKOUT_KEY = "a2a.ucp.checkout";
+const UCP_PLATFORM_PROFILE_URL =
+  process.env.NEXT_PUBLIC_UCP_PLATFORM_PROFILE_URL || "https://platform.example/profile";
+
+export interface ProtocolSessionRef {
+  sessionId: string | null;
+  contextId?: string | null;
+}
+
+interface UCPA2ATotal {
+  type: string;
+  label: string;
+  amount: number;
+}
+
+interface UCPA2ALineItem {
+  id: string;
+  item: {
+    id: string;
+    title: string;
+    price: number;
+  };
+  quantity: number;
+  totals: UCPA2ATotal[];
+}
+
+interface UCPA2AMessage {
+  type: "info" | "warning" | "error";
+  code?: string;
+  path?: string;
+  content: string;
+}
+
+interface UCPA2ACheckout {
+  id: string;
+  status: string;
+  currency: string;
+  line_items: UCPA2ALineItem[];
+  totals: UCPA2ATotal[];
+  messages: UCPA2AMessage[];
+  continue_url?: string;
+  ucp?: {
+    capabilities?: Record<
+      string,
+      Array<{
+        version: string;
+        extends?: string | string[] | null;
+      }>
+    >;
+    payment_handlers?: Record<string, Array<{ id: string }>>;
+  };
+}
+
+interface A2AResultPart {
+  data?: Record<string, unknown>;
+}
+
+interface A2AResultMessage {
+  contextId: string;
+  parts: A2AResultPart[];
+}
+
+interface A2AJsonRpcError {
+  code: number;
+  message: string;
+  data?: {
+    detail?: string;
+  };
+}
+
+interface A2AJsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: A2AResultMessage;
+  error?: A2AJsonRpcError;
+}
 
 /**
  * Generate a unique idempotency key for payment requests
@@ -85,6 +168,13 @@ function getMerchantHeaders(idempotencyKey?: string): HeadersInit {
   return headers;
 }
 
+function getUCPHeaders(idempotencyKey: string): HeadersInit {
+  const headers = getMerchantHeaders(idempotencyKey) as Record<string, string>;
+  headers["UCP-Agent"] = `profile="${UCP_PLATFORM_PROFILE_URL}"`;
+  headers["X-A2A-Extensions"] = UCP_A2A_EXTENSION_URL;
+  return headers;
+}
+
 /**
  * Headers for PSP API requests
  * Authorization is only included server-side; client requests go through proxy
@@ -127,6 +217,231 @@ async function handleResponse<T>(response: Response): Promise<T> {
     throw error;
   }
   return response.json();
+}
+
+function mapUCPStatusToACP(status: string): CheckoutSessionResponse["status"] {
+  switch (status) {
+    case "ready_for_complete":
+      return "ready_for_payment";
+    case "complete_in_progress":
+      return "in_progress";
+    case "completed":
+      return "completed";
+    case "canceled":
+      return "canceled";
+    case "requires_escalation":
+    case "incomplete":
+    default:
+      return "not_ready_for_payment";
+  }
+}
+
+function mapUCPTotalType(type: string): Total["type"] {
+  switch (type) {
+    case "items_discount":
+      return "items_discount";
+    case "discount":
+      return "discount";
+    case "tax":
+      return "tax";
+    case "total":
+      return "total";
+    case "subtotal":
+    default:
+      return "subtotal";
+  }
+}
+
+function mapUCPMessages(messages: UCPA2AMessage[]): Message[] {
+  return messages.map((message) => {
+    if (message.type === "warning") {
+      return {
+        type: "warning",
+        code: message.code ?? "warning",
+        content_type: "plain",
+        content: message.content,
+        ...(message.path ? { param: message.path } : {}),
+      };
+    }
+    if (message.type === "error") {
+      return {
+        type: "error",
+        code: "invalid",
+        content_type: "plain",
+        content: message.content,
+        ...(message.path ? { param: message.path } : {}),
+      };
+    }
+    return {
+      type: "info",
+      content_type: "plain",
+      content: message.content,
+      ...(message.path ? { param: message.path } : {}),
+    };
+  });
+}
+
+function normalizeUCPCheckout(
+  checkout: UCPA2ACheckout,
+  contextId: string
+): CheckoutSessionResponse {
+  const lineItems: LineItem[] = checkout.line_items.map((item) => {
+    const subtotal = item.totals.find((total) => total.type === "subtotal")?.amount ?? 0;
+    const tax = item.totals.find((total) => total.type === "tax")?.amount ?? 0;
+    const total = item.totals.find((total) => total.type === "total")?.amount ?? subtotal + tax;
+    const baseAmount = item.item.price * item.quantity;
+    const inferredDiscount = Math.max(0, baseAmount - subtotal);
+    return {
+      id: item.id,
+      item: {
+        id: item.item.id,
+        quantity: item.quantity,
+      },
+      name: item.item.title,
+      base_amount: baseAmount,
+      // UCP line items do not currently include promotion metadata in this phase.
+      // Infer effective discount from base price vs subtotal so UI activity remains accurate.
+      discount: inferredDiscount,
+      subtotal,
+      tax,
+      total,
+    };
+  });
+
+  const totals: Total[] = checkout.totals.map((total) => ({
+    type: mapUCPTotalType(total.type),
+    display_text: total.label,
+    amount: total.amount,
+  }));
+
+  const paymentProvider: PaymentProvider = {
+    provider: "stripe",
+    supported_payment_methods: [
+      {
+        type: "card",
+        supported_card_networks: ["visa", "mastercard", "amex", "discover"],
+      },
+    ],
+  };
+
+  // Fulfillment extension is deferred in UCP responses for this phase.
+  // Keep the native checkout UI stable with synthetic options aligned to backend defaults.
+  const fulfillmentOptions: FulfillmentOption[] = [
+    {
+      type: "shipping",
+      id: "shipping_standard",
+      title: "Standard Shipping",
+      subtitle: "5-7 business days",
+      subtotal: 599,
+      tax: 0,
+      total: 599,
+    },
+    {
+      type: "shipping",
+      id: "shipping_express",
+      title: "Express Shipping",
+      subtitle: "2-3 business days",
+      subtotal: 1299,
+      tax: 0,
+      total: 1299,
+    },
+  ];
+
+  const response: CheckoutSessionResponse = {
+    id: checkout.id,
+    status: mapUCPStatusToACP(checkout.status),
+    currency: checkout.currency.toLowerCase(),
+    protocol: "ucp",
+    ucpContextId: contextId,
+    payment_provider: paymentProvider,
+    ...(checkout.ucp?.capabilities
+      ? {
+          capabilities: {
+            extensions: Object.keys(checkout.ucp.capabilities).map((name) => ({ name })),
+          },
+        }
+      : {}),
+    line_items: lineItems,
+    fulfillment_options: fulfillmentOptions,
+    totals,
+    messages: mapUCPMessages(checkout.messages),
+    links: [],
+    ...(checkout.continue_url ? { continue_url: checkout.continue_url } : {}),
+    ...(checkout.status === "completed"
+      ? {
+          order: {
+            id: `order_${checkout.id.slice(-8)}`,
+            checkout_session_id: checkout.id,
+            permalink_url: "#",
+          },
+        }
+      : {}),
+  };
+
+  return response;
+}
+
+function buildA2AMessage(
+  action: string,
+  data: Record<string, unknown>,
+  contextId?: string | null,
+  extraParts?: Array<Record<string, unknown>>
+): Record<string, unknown> {
+  const parts: Array<Record<string, unknown>> = [{ kind: "data", data: { action, ...data } }];
+  if (extraParts) {
+    parts.push(...extraParts);
+  }
+
+  const message: Record<string, unknown> = {
+    role: "user",
+    messageId: generateIdempotencyKey(),
+    kind: "message",
+    parts,
+  };
+  if (contextId) {
+    message.contextId = contextId;
+  }
+  return {
+    jsonrpc: "2.0",
+    id: generateRequestId(),
+    method: "message/send",
+    params: { message },
+  };
+}
+
+async function postA2AAction(
+  action: string,
+  data: Record<string, unknown>,
+  contextId?: string | null,
+  extraParts?: Array<Record<string, unknown>>
+): Promise<CheckoutSessionResponse> {
+  const response = await fetch(`${API_URL}/a2a`, {
+    method: "POST",
+    headers: getUCPHeaders(generateIdempotencyKey()),
+    body: JSON.stringify(buildA2AMessage(action, data, contextId, extraParts)),
+  });
+
+  const json = (await handleResponse<A2AJsonRpcResponse>(response)) as A2AJsonRpcResponse;
+
+  if (json.error) {
+    throw {
+      type: "invalid_request",
+      code: "jsonrpc_error",
+      message: json.error.data?.detail ?? json.error.message,
+    } satisfies APIError;
+  }
+
+  const result = json.result;
+  const checkoutData = result?.parts?.[0]?.data?.[UCP_CHECKOUT_KEY];
+  if (!result || !checkoutData || typeof checkoutData !== "object") {
+    throw {
+      type: "unknown_error",
+      code: "parse_error",
+      message: "Invalid A2A response: missing checkout payload",
+    } satisfies APIError;
+  }
+
+  return normalizeUCPCheckout(checkoutData as UCPA2ACheckout, result.contextId);
 }
 
 // =============================================================================
@@ -203,6 +518,137 @@ export async function cancelCheckout(sessionId: string): Promise<CheckoutSession
   });
 
   return handleResponse<CheckoutSessionResponse>(response);
+}
+
+/**
+ * Create checkout session using protocol-specific transport.
+ */
+export async function createCheckoutSessionByProtocol(
+  protocol: CheckoutProtocol,
+  request: CreateCheckoutRequest
+): Promise<CheckoutSessionResponse> {
+  if (protocol === "acp") {
+    return createCheckoutSession(request);
+  }
+
+  const firstItem = request.items[0];
+  if (!firstItem) {
+    throw {
+      type: "invalid_request",
+      code: "missing",
+      message: "At least one item is required to create a checkout session",
+    } satisfies APIError;
+  }
+
+  return postA2AAction("create_checkout", {
+    product_id: firstItem.id,
+    quantity: firstItem.quantity,
+    line_items: request.items.map((item) => ({ id: item.id, quantity: item.quantity })),
+    buyer: request.buyer,
+    fulfillment_address: request.fulfillment_address,
+    discounts: request.discounts,
+    coupons: request.coupons,
+  });
+}
+
+/**
+ * Update checkout session using protocol-specific transport.
+ */
+export async function updateCheckoutSessionByProtocol(
+  protocol: CheckoutProtocol,
+  sessionRef: ProtocolSessionRef,
+  request: UpdateCheckoutRequest
+): Promise<CheckoutSessionResponse> {
+  if (!sessionRef.sessionId) {
+    throw {
+      type: "invalid_request",
+      code: "session_not_found",
+      message: "Missing checkout session ID",
+    } satisfies APIError;
+  }
+
+  if (protocol === "acp") {
+    return updateCheckoutSession(sessionRef.sessionId, request);
+  }
+
+  if (!sessionRef.contextId) {
+    throw {
+      type: "invalid_request",
+      code: "session_not_found",
+      message: "Missing UCP context ID for checkout update",
+    } satisfies APIError;
+  }
+
+  const payload: Record<string, unknown> = {};
+  if (request.items !== undefined) {
+    payload.items = request.items;
+    payload.line_items = request.items.map((item) => ({ id: item.id, quantity: item.quantity }));
+  }
+  if (request.buyer !== undefined) {
+    payload.buyer = request.buyer;
+  }
+  if (request.fulfillment_address !== undefined) {
+    payload.fulfillment_address = request.fulfillment_address;
+  }
+  if (request.fulfillment_option_id !== undefined) {
+    payload.fulfillment_option_id = request.fulfillment_option_id;
+  }
+  if (request.discounts !== undefined) {
+    payload.discounts = request.discounts;
+  }
+  if (request.coupons !== undefined) {
+    payload.coupons = request.coupons;
+  }
+
+  return postA2AAction("update_checkout", payload, sessionRef.contextId);
+}
+
+/**
+ * Complete checkout session using protocol-specific transport.
+ */
+export async function completeCheckoutByProtocol(
+  protocol: CheckoutProtocol,
+  sessionRef: ProtocolSessionRef,
+  request: CompleteCheckoutRequest
+): Promise<CheckoutSessionResponse> {
+  if (!sessionRef.sessionId) {
+    throw {
+      type: "invalid_request",
+      code: "session_not_found",
+      message: "Missing checkout session ID",
+    } satisfies APIError;
+  }
+
+  if (protocol === "acp") {
+    return completeCheckout(sessionRef.sessionId, request);
+  }
+
+  if (!sessionRef.contextId) {
+    throw {
+      type: "invalid_request",
+      code: "session_not_found",
+      message: "Missing UCP context ID for checkout completion",
+    } satisfies APIError;
+  }
+
+  return postA2AAction("complete_checkout", {}, sessionRef.contextId, [
+    {
+      kind: "data",
+      data: {
+        "a2a.ucp.checkout.payment": {
+          instruments: [
+            {
+              type: "tokenized_card",
+              handler_id: "processor_tokenizer",
+              credential: {
+                token: request.payment_data.token,
+              },
+            },
+          ],
+        },
+      },
+    },
+  ]);
 }
 
 /**
@@ -315,7 +761,7 @@ export async function generatePostPurchaseMessage(
 }
 
 /**
- * Webhook payload for shipping updates (matches ACP spec)
+ * Webhook payload for shipping updates (shared ACP/UCP UI shape)
  */
 export interface WebhookShippingPayload {
   type: "shipping_update";
@@ -344,9 +790,11 @@ export interface WebhookResponse {
  * This simulates the merchant sending a notification to the client agent
  */
 export async function postWebhookShippingUpdate(
-  payload: WebhookShippingPayload
+  payload: WebhookShippingPayload,
+  protocol: CheckoutProtocol = "acp"
 ): Promise<WebhookResponse> {
-  const response = await fetch("/api/webhooks/acp", {
+  const webhookEndpoint = protocol === "ucp" ? "/api/webhooks/ucp" : "/api/webhooks/acp";
+  const response = await fetch(webhookEndpoint, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -374,9 +822,12 @@ export async function postWebhookShippingUpdate(
 export const apiClient = {
   // Merchant endpoints
   createCheckoutSession,
+  createCheckoutSessionByProtocol,
   getCheckoutSession,
   updateCheckoutSession,
+  updateCheckoutSessionByProtocol,
   completeCheckout,
+  completeCheckoutByProtocol,
   cancelCheckout,
 
   // PSP endpoints

--- a/src/ui/lib/api-client.ts
+++ b/src/ui/lib/api-client.ts
@@ -52,6 +52,7 @@ const UCP_PLATFORM_PROFILE_URL =
 export interface ProtocolSessionRef {
   sessionId: string | null;
   contextId?: string | null;
+  paymentHandlerId?: string | null;
 }
 
 interface UCPA2ATotal {
@@ -285,6 +286,10 @@ function normalizeUCPCheckout(
   checkout: UCPA2ACheckout,
   contextId: string
 ): CheckoutSessionResponse {
+  const negotiatedHandlerId = Object.values(checkout.ucp?.payment_handlers ?? {}).find(
+    (handlers) => handlers.length > 0 && handlers[0]?.id
+  )?.[0]?.id;
+
   const lineItems: LineItem[] = checkout.line_items.map((item) => {
     const subtotal = item.totals.find((total) => total.type === "subtotal")?.amount ?? 0;
     const tax = item.totals.find((total) => total.type === "tax")?.amount ?? 0;
@@ -353,6 +358,7 @@ function normalizeUCPCheckout(
     currency: checkout.currency.toLowerCase(),
     protocol: "ucp",
     ucpContextId: contextId,
+    ...(negotiatedHandlerId ? { ucpPaymentHandlerId: negotiatedHandlerId } : {}),
     payment_provider: paymentProvider,
     ...(checkout.ucp?.capabilities
       ? {
@@ -631,6 +637,15 @@ export async function completeCheckoutByProtocol(
     } satisfies APIError;
   }
 
+  const handlerId = sessionRef.paymentHandlerId?.trim();
+  if (!handlerId) {
+    throw {
+      type: "invalid_request",
+      code: "missing",
+      message: "Missing negotiated UCP payment handler ID for checkout completion",
+    } satisfies APIError;
+  }
+
   return postA2AAction("complete_checkout", {}, sessionRef.contextId, [
     {
       kind: "data",
@@ -638,8 +653,9 @@ export async function completeCheckoutByProtocol(
         "a2a.ucp.checkout.payment": {
           instruments: [
             {
+              id: request.payment_data.token,
               type: "tokenized_card",
-              handler_id: "processor_tokenizer",
+              handler_id: handlerId,
               credential: {
                 token: request.payment_data.token,
               },

--- a/src/ui/lib/webhook-emitter.ts
+++ b/src/ui/lib/webhook-emitter.ts
@@ -17,6 +17,7 @@ export interface WebhookEvent {
   id: string;
   type: "order_created" | "order_updated" | "shipping_update";
   receivedAt: string;
+  protocol?: "acp" | "ucp";
   data: OrderEventData | ShippingUpdateData;
 }
 

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -484,6 +484,11 @@ export type CheckoutStatus =
   | "completed"
   | "canceled";
 
+/**
+ * Active checkout protocol
+ */
+export type CheckoutProtocol = "acp" | "ucp";
+
 // =============================================================================
 // Checkout Session Response
 // =============================================================================
@@ -495,6 +500,9 @@ export interface CheckoutSessionResponse {
   id: string;
   status: CheckoutStatus;
   currency: string;
+  protocol?: CheckoutProtocol;
+  ucpContextId?: string;
+  continue_url?: string;
   buyer?: Buyer;
   capabilities?: CheckoutCapabilities;
   payment_provider: PaymentProvider;
@@ -901,6 +909,7 @@ export interface CheckoutFlowContext {
   selectedShippingId: string;
   orderId: string | null;
   sessionId: string | null;
+  ucpContextId: string | null;
   session: CheckoutSessionResponse | null;
   vaultToken: string | null;
   isLoading: boolean;

--- a/src/ui/types/index.ts
+++ b/src/ui/types/index.ts
@@ -502,6 +502,7 @@ export interface CheckoutSessionResponse {
   currency: string;
   protocol?: CheckoutProtocol;
   ucpContextId?: string;
+  ucpPaymentHandlerId?: string;
   continue_url?: string;
   buyer?: Buyer;
   capabilities?: CheckoutCapabilities;

--- a/tests/merchant/api/test_ucp_a2a.py
+++ b/tests/merchant/api/test_ucp_a2a.py
@@ -525,6 +525,40 @@ class TestApplicationErrors:
         response = auth_client.post("/a2a", json=request, headers=a2a_headers)
         assert response.json()["error"]["code"] == -32602
 
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_complete_checkout_with_unadvertised_handler_returns_invalid_params(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        create_req = _make_request("create_checkout", {"product_id": "prod_1"})
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        complete_req = _make_request(
+            "complete_checkout",
+            context_id=ctx,
+            extra_parts=[
+                {
+                    "type": "data",
+                    "data": {
+                        "a2a.ucp.checkout.payment": {
+                            "instruments": [
+                                {
+                                    "id": "pm_bad",
+                                    "type": "tokenized_card",
+                                    "handler_id": "unknown_handler",
+                                    "credential": {"token": "vt_test_bad"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        )
+        response = auth_client.post("/a2a", json=complete_req, headers=a2a_headers)
+        body = response.json()
+        assert body["error"]["code"] == -32602
+        assert body["error"]["message"] == "Unsupported payment handler_id: unknown_handler"
+
 
 # ===========================================================================
 # 5. Context / Session Persistence

--- a/tests/merchant/api/test_ucp_a2a.py
+++ b/tests/merchant/api/test_ucp_a2a.py
@@ -557,7 +557,10 @@ class TestApplicationErrors:
         response = auth_client.post("/a2a", json=complete_req, headers=a2a_headers)
         body = response.json()
         assert body["error"]["code"] == -32602
-        assert body["error"]["message"] == "Unsupported payment handler_id: unknown_handler"
+        assert (
+            body["error"]["message"]
+            == "Unsupported payment handler_id: unknown_handler"
+        )
 
 
 # ===========================================================================

--- a/tests/merchant/api/test_ucp_a2a.py
+++ b/tests/merchant/api/test_ucp_a2a.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -225,6 +226,38 @@ class TestCheckoutActions:
         assert "com.example.processor_tokenizer" in checkout["ucp"]["payment_handlers"]
 
     @pytest.mark.usefixtures("mock_platform_profile")
+    def test_create_checkout_with_buyer_starts_incomplete(
+        self, auth_client: TestClient, a2a_headers: dict[str, str]
+    ) -> None:
+        request = _make_request(
+            "create_checkout",
+            {
+                "product_id": "prod_1",
+                "buyer": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "email": "john@example.com",
+                },
+                "fulfillment_address": {
+                    "name": "John Doe",
+                    "line_one": "123 Main St",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "country": "US",
+                    "postal_code": "94102",
+                },
+            },
+        )
+        response = auth_client.post("/a2a", json=request, headers=a2a_headers)
+
+        body = response.json()
+        assert "error" not in body
+        checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
+        # A newly created checkout remains incomplete until fulfillment option
+        # selection/update advances readiness for completion.
+        assert checkout["status"] == "incomplete"
+
+    @pytest.mark.usefixtures("mock_platform_profile")
     def test_get_checkout(
         self, auth_client: TestClient, a2a_headers: dict[str, str]
     ) -> None:
@@ -279,6 +312,175 @@ class TestCheckoutActions:
         assert "error" not in body
         checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
         assert checkout["status"] == "canceled"
+
+    def test_complete_checkout_uses_negotiated_ucp_order_webhook_url(
+        self, auth_client: TestClient, a2a_headers: dict[str, str], monkeypatch
+    ) -> None:
+        async def _mock_fetch(_url: str) -> dict[str, Any]:
+            return {
+                "ucp": {
+                    "version": get_settings().ucp_version,
+                    "capabilities": {
+                        "dev.ucp.shopping.checkout": [
+                            {"version": get_settings().ucp_version}
+                        ],
+                        "dev.ucp.shopping.order": [
+                            {
+                                "version": get_settings().ucp_version,
+                                "config": {
+                                    "webhook_url": "http://platform.example/webhooks/ucp-order"
+                                },
+                            }
+                        ],
+                    },
+                }
+            }
+
+        monkeypatch.setattr(
+            "src.merchant.services.a2a.fetch_platform_profile", _mock_fetch
+        )
+        post_purchase_mock = AsyncMock()
+        monkeypatch.setattr(
+            "src.merchant.services.a2a.trigger_post_purchase_flow_ucp",
+            post_purchase_mock,
+        )
+
+        create_req = _make_request(
+            "create_checkout",
+            {
+                "product_id": "prod_1",
+                "buyer": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "email": "john@example.com",
+                },
+                "fulfillment_address": {
+                    "name": "John Doe",
+                    "line_one": "123 Main St",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "country": "US",
+                    "postal_code": "94102",
+                },
+            },
+        )
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        complete_req = _make_request(
+            "complete_checkout",
+            context_id=ctx,
+            extra_parts=[
+                {
+                    "type": "data",
+                    "data": {
+                        "a2a.ucp.checkout.payment": {
+                            "instruments": [
+                                {
+                                    "type": "tokenized_card",
+                                    "handler_id": "processor_tokenizer",
+                                    "credential": {"token": "vt_test_123"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        )
+        complete_resp = auth_client.post("/a2a", json=complete_req, headers=a2a_headers)
+
+        body = complete_resp.json()
+        assert "error" not in body
+        checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
+        assert checkout["status"] == "completed"
+        assert post_purchase_mock.await_count == 1
+        assert (
+            post_purchase_mock.await_args.kwargs["webhook_url"]
+            == "http://platform.example/webhooks/ucp-order"
+        )
+
+    def test_complete_checkout_uses_fallback_ucp_order_webhook_url(
+        self, auth_client: TestClient, a2a_headers: dict[str, str], monkeypatch
+    ) -> None:
+        monkeypatch.setenv(
+            "UCP_ORDER_WEBHOOK_URL", "http://fallback.example/webhooks/ucp-order"
+        )
+        get_settings.cache_clear()
+
+        async def _mock_fetch(_url: str) -> dict[str, Any]:
+            return {
+                "ucp": {
+                    "version": get_settings().ucp_version,
+                    "capabilities": {
+                        "dev.ucp.shopping.checkout": [
+                            {"version": get_settings().ucp_version}
+                        ]
+                    },
+                }
+            }
+
+        monkeypatch.setattr(
+            "src.merchant.services.a2a.fetch_platform_profile", _mock_fetch
+        )
+        post_purchase_mock = AsyncMock()
+        monkeypatch.setattr(
+            "src.merchant.services.a2a.trigger_post_purchase_flow_ucp",
+            post_purchase_mock,
+        )
+
+        create_req = _make_request(
+            "create_checkout",
+            {
+                "product_id": "prod_1",
+                "buyer": {
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "email": "john@example.com",
+                },
+                "fulfillment_address": {
+                    "name": "John Doe",
+                    "line_one": "123 Main St",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "country": "US",
+                    "postal_code": "94102",
+                },
+            },
+        )
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        complete_req = _make_request(
+            "complete_checkout",
+            context_id=ctx,
+            extra_parts=[
+                {
+                    "type": "data",
+                    "data": {
+                        "a2a.ucp.checkout.payment": {
+                            "instruments": [
+                                {
+                                    "type": "tokenized_card",
+                                    "handler_id": "processor_tokenizer",
+                                    "credential": {"token": "vt_test_456"},
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        )
+        complete_resp = auth_client.post("/a2a", json=complete_req, headers=a2a_headers)
+
+        body = complete_resp.json()
+        assert "error" not in body
+        checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
+        assert checkout["status"] == "completed"
+        assert post_purchase_mock.await_count == 1
+        assert (
+            post_purchase_mock.await_args.kwargs["webhook_url"]
+            == "http://fallback.example/webhooks/ucp-order"
+        )
 
 
 # ===========================================================================

--- a/tests/merchant/api/test_ucp_discovery.py
+++ b/tests/merchant/api/test_ucp_discovery.py
@@ -51,6 +51,13 @@ class TestUCPDiscovery:
         capabilities = data["ucp"]["capabilities"]
         assert "dev.ucp.shopping.discount" in capabilities
 
+    def test_profile_includes_order_capability(self, client: TestClient) -> None:
+        """Profile includes dev.ucp.shopping.order capability."""
+        response = client.get("/.well-known/ucp")
+        data = response.json()
+        capabilities = data["ucp"]["capabilities"]
+        assert "dev.ucp.shopping.order" in capabilities
+
     def test_profile_has_signing_keys_field(self, client: TestClient) -> None:
         """Profile includes top-level signing_keys field (may be null)."""
         response = client.get("/.well-known/ucp")

--- a/tests/merchant/api/test_ucp_schema_bridge.py
+++ b/tests/merchant/api/test_ucp_schema_bridge.py
@@ -20,6 +20,7 @@ from src.merchant.api.ucp_schemas import (
     to_sdk_checkout_response,
     to_sdk_discovery_profile,
 )
+from src.merchant.config import get_settings
 from src.merchant.services.ucp import build_business_profile
 
 
@@ -117,5 +118,5 @@ def test_to_sdk_checkout_response_supports_current_wire_shape() -> None:
 
 def test_build_business_profile_remains_sdk_validated() -> None:
     profile = build_business_profile(request_base_url="http://localhost:8000")
-    assert profile.ucp.version == "2026-01-11"
+    assert profile.ucp.version == get_settings().ucp_version
     assert "dev.ucp.shopping.checkout" in profile.ucp.capabilities


### PR DESCRIPTION
## Summary
- complete UCP Phase 5B end-to-end for post-purchase flow: order capability negotiation, UCP webhook dispatch, and UI webhook receiver and bridge
- fix protocol confusion in Merchant Activity by making webhook log endpoint protocol-aware (/api/webhooks/acp vs /api/webhooks/ucp)
- align docs and diagrams (Feature 17 + README Mermaid and UCP examples) with current A2A-only UCP implementation and webhook architecture

## Test plan
- uv run pytest tests/merchant/api/test_ucp_a2a.py tests/merchant/api/test_ucp_discovery.py -q
- uv run pytest tests/merchant/api/test_ucp_a2a.py -k complete_checkout_uses -q
- uv run ruff check tests/merchant/api/test_ucp_a2a.py src/merchant/services/post_purchase_webhook.py
- cd src/ui && pnpm test:run components/WebhookToAgentActivityBridge.test.tsx lib/api-client.test.ts
- cd src/ui && pnpm lint
- cd src/ui && pnpm format:check
- cd src/ui && pnpm typecheck

## Related
- docs/features/feature-17-ucp-integration.md