### PR TITLE
[agents] Align rag_retriever top_k with product_retriever (10)

### DIFF
--- a/src/agents/configs/recommendation.yml
+++ b/src/agents/configs/recommendation.yml
@@ -83,7 +83,7 @@ functions:
   rag_retriever:
     _type: rag_retriever
     retrieval_tool_name: product_search
-    top_k: 6
+    top_k: 10
 
   # -- Step 2a: NLI Agent (LLM) ------------------------------------------------
   nli_agent:
@@ -106,9 +106,9 @@ functions:
       - Weak fit: 0.0-0.3
 
       RULES:
-      - Evaluate only the first 6 candidates by input order.
+      - Evaluate only the first 10 candidates by input order.
       - Keep exact product_id and product_name.
-      - Return at most 6 objects in scored_candidates.
+      - Return at most 10 objects in scored_candidates.
       - Preserve original candidate order in scored_candidates.
       - Include only keys requested below.
       - Use compact JSON formatting (no extra whitespace/newlines).

--- a/tests/agents/test_recommendation_workflow_contract.py
+++ b/tests/agents/test_recommendation_workflow_contract.py
@@ -14,8 +14,8 @@ def test_recommendation_workflow_uses_llm_first_parallel_arag() -> None:
     )
     assert "tool_list: [user_understanding_agent, nli_agent]" in config_text
     assert "_type: output_contract_guard" in config_text
-    assert "top_k: 6" in config_text
-    assert "Evaluate only the first 6 candidates by input order." in config_text
+    assert "top_k: 10" in config_text
+    assert "Evaluate only the first 10 candidates by input order." in config_text
 
     for legacy_component in (
         "_type: nli_scorer",


### PR DESCRIPTION
## Summary
- Align `rag_retriever.top_k` from 6 to 10 in `recommendation.yml` to match `product_retriever.top_k` and the Python default in `RAGRetrieverConfig`
- NAT config loading was not applying the YAML `top_k: 6` override, so the Python default of 10 was used at runtime — making the YAML value misleading
- All 10 Milvus candidates now intentionally flow into the NLI and UUA agents, with filtering handled downstream by the Context Summary Agent (alignment > 0.7) and Item Ranker (top 3)

## Test plan
- [x] Run recommendation agent and verify 10 candidates appear in RAG Retriever logs
- [x] Verify NLI and UUA agents receive all 10 candidates
- [x] Confirm Context Summary Agent filters correctly (alignment > 0.7, up to 4)
- [x] Confirm Item Ranker outputs top 3 recommendations
- [x] Check Phoenix traces for consistent candidate counts across pipeline stages

Made with [Cursor](https://cursor.com)