### PR TITLE
[apps-sdk] Widget direct MCP callTool, ACP session tools, and local dev automation

### DIFF
--- a/.cursor/skills/setup/SKILL.md
+++ b/.cursor/skills/setup/SKILL.md
@@ -143,153 +143,58 @@ Setup complete (Docker). All services are running.
 
 ## Mode B: Local Development
 
-### Prerequisites
+### Quick Start
 
-- Docker 24+ and Docker Compose v2 (for infrastructure only)
-- Python 3.12+ with `uv` installed
-- Node.js 18+ with `pnpm` installed
-
-Verify:
+Run the automated setup script from the project root:
 
 ```bash
-docker --version
-docker compose version
-docker info > /dev/null 2>&1
-uv --version
-python3 --version
-node --version
-pnpm --version
+./install.sh
 ```
 
-If any check fails, stop and inform the user what to install.
-
-### 1. Start Infrastructure in Docker
+To stop all services:
 
 ```bash
-docker network create acp-infra-network || true
-docker compose -f docker-compose.infra.yml up -d
+./stop.sh
 ```
 
-### 2. Install and Run Backend Services
+### What the Script Does
 
-From the project root, set up the Python environment and start each service in a separate terminal:
+1. **Validates prerequisites** — Python 3.12+, `uv`, Node.js 18+, `pnpm`
+2. **Configures environment** — Creates `.env` from `env.example` if missing, validates `NVIDIA_API_KEY`
+3. **Installs dependencies** — Root venv (`uv sync`), agents venv (`uv pip install`), UI (`pnpm install`), Apps SDK widget
+4. **Starts 8 services** in background with PID tracking
+5. **Runs health checks** and prints a status table
 
-```bash
-# Setup (once)
-uv venv
-source .venv/bin/activate
-uv sync
-```
+### Services Started
 
-```bash
-# Terminal 1 — Merchant API (port 8000)
-source .venv/bin/activate
-uvicorn src.merchant.main:app --reload
-```
-
-```bash
-# Terminal 2 — PSP (port 8001)
-source .venv/bin/activate
-uvicorn src.payment.main:app --reload --port 8001
-```
-
-```bash
-# Terminal 3 — Apps SDK MCP (port 2091)
-source .venv/bin/activate
-uvicorn src.apps_sdk.main:app --reload --port 2091
-```
-
-### 3. Install and Run NAT Agents
-
-Agents have their own environment under `src/agents` and need NIM environment variables loaded:
-
-```bash
-# Setup (once)
-cd src/agents
-uv venv
-source .venv/bin/activate
-uv pip install -e ".[dev]"
-```
-
-Each agent terminal must have the NIM env vars loaded from the project root `.env`. Source them before starting:
-
-```bash
-# Terminal 4 — Promotion Agent (port 8002)
-cd src/agents
-source .venv/bin/activate
-source <(grep -E '^(NVIDIA_API_KEY|NIM_LLM_BASE_URL|NIM_LLM_MODEL_NAME|NIM_EMBED_BASE_URL|NIM_EMBED_MODEL_NAME|MILVUS_URI|PHOENIX_ENDPOINT)=' ../../.env | sed 's/^/export /')
-nat serve --config_file configs/promotion.yml --port 8002
-```
-
-```bash
-# Terminal 5 — Post-Purchase Agent (port 8003)
-cd src/agents
-source .venv/bin/activate
-source <(grep -E '^(NVIDIA_API_KEY|NIM_LLM_BASE_URL|NIM_LLM_MODEL_NAME|NIM_EMBED_BASE_URL|NIM_EMBED_MODEL_NAME|MILVUS_URI|PHOENIX_ENDPOINT)=' ../../.env | sed 's/^/export /')
-nat serve --config_file configs/post-purchase.yml --port 8003
-```
-
-```bash
-# Terminal 6 — Recommendation Agent (port 8004)
-cd src/agents
-source .venv/bin/activate
-source <(grep -E '^(NVIDIA_API_KEY|NIM_LLM_BASE_URL|NIM_LLM_MODEL_NAME|NIM_EMBED_BASE_URL|NIM_EMBED_MODEL_NAME|MILVUS_URI|PHOENIX_ENDPOINT)=' ../../.env | sed 's/^/export /')
-nat serve --config_file configs/recommendation.yml --port 8004
-```
-
-```bash
-# Terminal 7 — Search Agent (port 8005)
-cd src/agents
-source .venv/bin/activate
-source <(grep -E '^(NVIDIA_API_KEY|NIM_LLM_BASE_URL|NIM_LLM_MODEL_NAME|NIM_EMBED_BASE_URL|NIM_EMBED_MODEL_NAME|MILVUS_URI|PHOENIX_ENDPOINT)=' ../../.env | sed 's/^/export /')
-nat serve --config_file configs/search.yml --port 8005
-```
-
-### 4. Run UIs
-
-```bash
-# Terminal 8 — Demo UI (port 3000)
-cd src/ui
-cp env.example .env.local  # only needed on first setup
-pnpm install
-pnpm dev
-```
-
-```bash
-# Terminal 9 — Apps SDK Widget dev server (port 3001)
-cd src/apps_sdk/web
-pnpm install
-pnpm dev
-```
-
-### Health Verification
-
-```bash
-# Core services
-curl -s http://localhost:8000/health
-curl -s http://localhost:8001/health
-curl -s http://localhost:2091/health
-
-# NAT agents
-curl -s http://localhost:8002/health
-curl -s http://localhost:8003/health
-curl -s http://localhost:8004/health
-curl -s http://localhost:8005/health
-```
+| Service              | Port | Log File                          |
+|----------------------|------|-----------------------------------|
+| Merchant API         | 8000 | `logs/merchant.log`               |
+| PSP                  | 8001 | `logs/psp.log`                    |
+| Apps SDK MCP         | 2091 | `logs/apps-sdk.log`               |
+| Promotion Agent      | 8002 | `logs/promotion-agent.log`        |
+| Post-Purchase Agent  | 8003 | `logs/post-purchase-agent.log`    |
+| Recommendation Agent | 8004 | `logs/recommendation-agent.log`   |
+| Search Agent         | 8005 | `logs/search-agent.log`           |
+| Demo UI              | 3000 | `logs/ui.log`                     |
 
 ### Post-Setup Summary
 
 ```
-Setup complete (Local). All services are running.
-
-  Demo UI:        http://localhost:3000
-  Merchant API:   http://localhost:8000/docs
-  PSP:            http://localhost:8001/docs
-  Apps SDK MCP:   http://localhost:2091/docs
-  Apps SDK Widget: http://localhost:3001
-  Phoenix Traces: http://localhost:6006
-  MinIO Console:  http://localhost:9001
+  Demo UI:         http://localhost:3000
+  Merchant API:    http://localhost:8000/docs
+  PSP:             http://localhost:8001/docs
+  Apps SDK MCP:    http://localhost:2091/docs
+  Phoenix Traces:  http://localhost:6006  (requires Docker infra)
+  MinIO Console:   http://localhost:9001  (requires Docker infra)
 ```
+
+### Troubleshooting
+
+- **View logs**: `tail -f logs/<service>.log`
+- **Port conflicts**: `lsof -i :<port>` — stop the conflicting process or change the port
+- **Re-run setup**: `./install.sh` stops existing services first (idempotent)
+- **Docker infrastructure** (Milvus, Phoenix, MinIO): Optional. Start with `docker compose -f docker-compose.infra.yml up -d`
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ ipython_config.py
 *.log
 logs/
 
+# Local dev PID tracking
+.local-dev.pids
+
 # Frontend / UI (Node.js, Next.js, React)
 node_modules/
 .next/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ This project implements ACP/UCP flows with strict architecture contracts. Do not
 | Agent integration details | `src/agents/README.md` |
 | System architecture and data flow | `docs/architecture.md` |
 | Feature-specific behavior | `docs/features/index.md` and `docs/features/feature-XX-*.md` |
+| Docker deployment, common operations | `deploy/docker-deployment.md` |
+| Local development, `install.sh`/`stop.sh` | `deploy/local-development.md` |
 
 ### Specification Source of Truth
 

--- a/README.md
+++ b/README.md
@@ -127,14 +127,16 @@ flowchart TB
     SEARCH --> MILVUS
 ```
 
-## Quick Start
+## Quick Start (Cursor, Codex, Claude Code)
 
 This is the recommended path. It does not require local NIM containers.
 
 ### Prerequisites
 
-- Docker 24+
-- Docker Compose v2
+- Python 3.12+
+- [uv](https://astral.sh/uv) package manager
+- Node.js 18+ and [pnpm](https://pnpm.io/)
+- Docker 24+ and Docker Compose v2
 - NVIDIA API key ([create one](https://build.nvidia.com/settings/api-keys))
 
 ### 1. Clone and Configure
@@ -153,182 +155,19 @@ NVIDIA_API_KEY=nvapi-xxx
 
 On Cursor, Codex or Claude Code simply run: `setup`
 
-## Manual Docker Deployment
+## Manual Deployment Options
 
-### 1. Create Shared Docker Network (one-time)
+| Mode | Description | Guide |
+|------|-------------|-------|
+| **Docker** (recommended) | Full stack in containers via Docker Compose | [Docker Deployment](deploy/docker-deployment.md) |
+| **Local Development** | Services on host, automated via `install.sh` | [Local Development](deploy/local-development.md) |
 
-```bash
-docker network create acp-infra-network || true
-```
-
-### 2. Start Infrastructure + App Stack
-
-```bash
-docker compose -f docker-compose.infra.yml -f docker-compose.yml up --build -d
-```
-
-### 3. Verify Health
+Quick local start:
 
 ```bash
-curl http://localhost/api/health
-curl http://localhost/psp/health
-curl http://localhost/apps-sdk/health
+./install.sh   # install deps + start all 8 services
+./stop.sh      # stop everything
 ```
-
-Agent services also expose `/health`, but in full Docker deployment they are internal-only (not published on `localhost`).
-
-### 4. Open the Application
-
-- Demo UI: http://localhost
-- Phoenix traces: http://localhost:6006
-- MinIO console: http://localhost:9001
-
-## Service Routes
-
-| Route | Service | Purpose |
-|---|---|---|
-| `/` | UI | Demo frontend |
-| `/api/*` | Merchant API | ACP/UCP, products, checkout, orders |
-| `/psp/*` | PSP | Delegated payment endpoints |
-| `/apps-sdk/*` | Apps SDK MCP | MCP server + widget assets |
-
-## Common Operations
-
-### Logs and Status
-
-```bash
-docker compose -f docker-compose.infra.yml -f docker-compose.yml ps
-docker compose -f docker-compose.infra.yml -f docker-compose.yml logs -f merchant
-docker compose -f docker-compose.infra.yml -f docker-compose.yml logs -f nginx
-```
-
-### Agent Health (Troubleshooting)
-
-Docker deployment (check from inside the merchant container):
-
-```bash
-docker compose -f docker-compose.infra.yml -f docker-compose.yml exec merchant \
-  python -c "import urllib.request as u; print('promotion', u.urlopen('http://promotion-agent:8002/health', timeout=5).status); print('post-purchase', u.urlopen('http://post-purchase-agent:8003/health', timeout=5).status); print('recommendation', u.urlopen('http://recommendation-agent:8004/health', timeout=5).status); print('search', u.urlopen('http://search-agent:8005/health', timeout=5).status)"
-```
-
-Local development (agents started on host ports):
-
-```bash
-curl http://localhost:8002/health
-curl http://localhost:8003/health
-curl http://localhost:8004/health
-curl http://localhost:8005/health
-```
-
-### Stop Services
-
-```bash
-# Stop app + infra containers
-docker compose -f docker-compose.infra.yml -f docker-compose.yml down
-
-# Stop and remove volumes (full reset)
-docker compose -f docker-compose.infra.yml -f docker-compose.yml down -v
-```
-
-### Rebuild
-
-```bash
-docker compose -f docker-compose.infra.yml -f docker-compose.yml build
-docker compose -f docker-compose.infra.yml -f docker-compose.yml up -d
-```
-
-## Local Development (Optional)
-
-Use this when you want faster iteration outside full Docker runtime.
-
-### 1. Start Infra in Docker
-
-```bash
-docker network create acp-infra-network || true
-docker compose -f docker-compose.infra.yml up -d
-```
-
-### 2. Run Backend Services
-
-Run each service in a separate terminal:
-
-```bash
-# Terminal 1
-uv venv
-source .venv/bin/activate
-uv sync
-uvicorn src.merchant.main:app --reload
-```
-
-```bash
-# Terminal 2
-source .venv/bin/activate
-uvicorn src.payment.main:app --reload --port 8001
-```
-
-```bash
-# Terminal 3
-source .venv/bin/activate
-uvicorn src.apps_sdk.main:app --reload --port 2091
-```
-
-### 3. Run NAT Agents
-
-Run each agent in a separate terminal:
-
-```bash
-# Setup once
-cd src/agents
-uv venv
-source .venv/bin/activate
-uv pip install -e ".[dev]"
-```
-
-```bash
-# Terminal 4
-cd src/agents
-source .venv/bin/activate
-nat serve --config_file configs/promotion.yml --port 8002
-```
-
-```bash
-# Terminal 5
-cd src/agents
-source .venv/bin/activate
-nat serve --config_file configs/post-purchase.yml --port 8003
-```
-
-```bash
-# Terminal 6
-cd src/agents
-source .venv/bin/activate
-nat serve --config_file configs/recommendation.yml --port 8004
-```
-
-```bash
-# Terminal 7
-cd src/agents
-source .venv/bin/activate
-nat serve --config_file configs/search.yml --port 8005
-```
-
-### 4. Run UI
-
-```bash
-cd src/ui
-cp env.example .env.local
-pnpm install
-pnpm dev
-```
-
-Optional Apps SDK widget dev server:
-
-```bash
-cd src/apps_sdk/web
-pnpm install
-pnpm dev
-```
-
 ## Hardware Requirements (Local NIM Deployment)
 
 Local NIM deployment requires NVIDIA GPUs to host the inference models. The following table summarizes the models and their GPU requirements:
@@ -346,43 +185,7 @@ Local NIM deployment requires NVIDIA GPUs to host the inference models. The foll
 
 Only needed for self-hosted local inference. The default deployment already works with public endpoints.
 
-### 1. Start Local NIMs
-
-```bash
-docker compose -f docker-compose-nim.yml up -d
-```
-
-### 2. Point Agents to Local NIM in `.env`
-
-```env
-NIM_LLM_BASE_URL=http://nemotron-nano:8000/v1
-NIM_LLM_MODEL_NAME=nvidia/nemotron-3-nano
-NIM_EMBED_BASE_URL=http://embedqa:8000/v1
-NIM_EMBED_MODEL_NAME=nvidia/nv-embedqa-e5-v5
-```
-
-### 3. Start Full Stack with NIM + Infra + App
-
-```bash
-docker compose -f docker-compose.infra.yml -f docker-compose-nim.yml -f docker-compose.yml up --build -d
-```
-
-## API Docs
-
-Docker (via nginx):
-
-- Merchant API health: http://localhost/api/health
-- PSP health: http://localhost/psp/health
-- Apps SDK MCP health: http://localhost/apps-sdk/health
-- Merchant OpenAPI: http://localhost/api/openapi.json
-- PSP OpenAPI: http://localhost/psp/openapi.json
-- Apps SDK OpenAPI: http://localhost/apps-sdk/openapi.json
-
-Local development (direct ports):
-
-- Merchant API: http://localhost:8000/docs
-- PSP: http://localhost:8001/docs
-- Apps SDK MCP: http://localhost:2091/docs
+For step-by-step instructions (prerequisites, GPU setup, NIM containers, validation), see the **[Local NIM Deployment Notebook](deploy/1_Deploy_Agentic_Commerce.ipynb)**.
 
 ## Project Structure
 
@@ -394,6 +197,11 @@ src/
 ├── agents/        # NAT agents and configs
 └── ui/            # Next.js demo UI
 
+deploy/
+├── docker-deployment.md
+├── local-development.md
+└── 1_Deploy_Agentic_Commerce.ipynb
+
 docs/
 ├── architecture.md
 ├── features/
@@ -402,17 +210,14 @@ docs/
 
 ## Documentation
 
+- [Docker Deployment](deploy/docker-deployment.md)
+- [Local Development](deploy/local-development.md)
 - [Architecture](docs/architecture.md)
 - [Feature Breakdown](docs/features/index.md)
 - [ACP Spec](docs/specs/acp-spec.md)
 - [UCP Spec](docs/specs/ucp-spec.md)
 - [Apps SDK Spec](docs/specs/apps-sdk-spec.md)
 - [Agent Integration](src/agents/README.md)
-
-## Getting Help
-
-- Issues: https://github.com/NVIDIA/Retail-Agentic-Commerce/issues
-- Security: [SECURITY.md](SECURITY.md)
 
 ## License
 

--- a/deploy/docker-deployment.md
+++ b/deploy/docker-deployment.md
@@ -1,0 +1,73 @@
+# Docker Deployment
+
+Full-stack deployment using Docker Compose. This is the recommended approach.
+
+## Prerequisites
+
+- Docker 24+
+- Docker Compose v2
+- NVIDIA API key ([create one](https://build.nvidia.com/settings/api-keys))
+
+## 1. Create Shared Docker Network (one-time)
+
+```bash
+docker network create acp-infra-network || true
+```
+
+## 2. Start Infrastructure + App Stack
+
+```bash
+docker compose -f docker-compose.infra.yml -f docker-compose.yml up --build -d
+```
+
+## 3. Verify Health
+
+```bash
+curl http://localhost/api/health
+curl http://localhost/psp/health
+curl http://localhost/apps-sdk/health
+```
+
+Agent services also expose `/health`, but in full Docker deployment they are internal-only (not published on `localhost`).
+
+## 4. Open the Application
+
+- Demo UI: http://localhost
+- Phoenix traces: http://localhost:6006
+- MinIO console: http://localhost:9001
+
+## Common Operations
+
+### Logs and Status
+
+```bash
+docker compose -f docker-compose.infra.yml -f docker-compose.yml ps
+docker compose -f docker-compose.infra.yml -f docker-compose.yml logs -f merchant
+docker compose -f docker-compose.infra.yml -f docker-compose.yml logs -f nginx
+```
+
+### Agent Health (Troubleshooting)
+
+Check from inside the merchant container:
+
+```bash
+docker compose -f docker-compose.infra.yml -f docker-compose.yml exec merchant \
+  python -c "import urllib.request as u; print('promotion', u.urlopen('http://promotion-agent:8002/health', timeout=5).status); print('post-purchase', u.urlopen('http://post-purchase-agent:8003/health', timeout=5).status); print('recommendation', u.urlopen('http://recommendation-agent:8004/health', timeout=5).status); print('search', u.urlopen('http://search-agent:8005/health', timeout=5).status)"
+```
+
+### Stop Services
+
+```bash
+# Stop app + infra containers
+docker compose -f docker-compose.infra.yml -f docker-compose.yml down
+
+# Stop and remove volumes (full reset)
+docker compose -f docker-compose.infra.yml -f docker-compose.yml down -v
+```
+
+### Rebuild
+
+```bash
+docker compose -f docker-compose.infra.yml -f docker-compose.yml build
+docker compose -f docker-compose.infra.yml -f docker-compose.yml up -d
+```

--- a/deploy/local-development.md
+++ b/deploy/local-development.md
@@ -1,0 +1,148 @@
+# Local Development
+
+Use this when you want faster iteration outside the full Docker runtime. Services run on your host while infrastructure (Milvus, MinIO, Phoenix) stays in Docker.
+
+## Quick Start
+
+The fastest way to get running locally:
+
+```bash
+./install.sh   # install deps + start all 8 services
+./stop.sh      # stop everything
+```
+
+`install.sh` handles prerequisite checks, dependency installation, environment setup, and launches all services in the background with health checks. Logs are written to `logs/<service>.log`.
+
+## Prerequisites
+
+- Python 3.12+
+- [uv](https://astral.sh/uv) package manager
+- Node.js 18+ and pnpm
+- Docker (for infrastructure services)
+- NVIDIA API key configured in `.env`
+
+## Infrastructure
+
+Local development still requires the infrastructure stack running in Docker:
+
+```bash
+docker network create acp-infra-network || true
+docker compose -f docker-compose.infra.yml up -d
+```
+
+## Agent Health
+
+When running locally, agents are accessible on host ports:
+
+```bash
+curl http://localhost:8002/health   # promotion
+curl http://localhost:8003/health   # post-purchase
+curl http://localhost:8004/health   # recommendation
+curl http://localhost:8005/health   # search
+```
+
+## Access URLs
+
+| Service | URL |
+|---------|-----|
+| Demo UI | http://localhost:3000 |
+| Merchant API | http://localhost:8000/docs |
+| PSP | http://localhost:8001/docs |
+| Apps SDK MCP | http://localhost:2091/docs |
+| Phoenix Traces | http://localhost:6006 (requires Docker infra) |
+| MinIO Console | http://localhost:9001 (requires Docker infra) |
+
+## Manual Setup
+
+<details>
+<summary>Step-by-step manual setup (without install.sh)</summary>
+
+### 1. Start Infra in Docker
+
+```bash
+docker network create acp-infra-network || true
+docker compose -f docker-compose.infra.yml up -d
+```
+
+### 2. Run Backend Services
+
+Run each service in a separate terminal:
+
+```bash
+# Terminal 1
+uv venv
+source .venv/bin/activate
+uv sync
+uvicorn src.merchant.main:app --reload
+```
+
+```bash
+# Terminal 2
+source .venv/bin/activate
+uvicorn src.payment.main:app --reload --port 8001
+```
+
+```bash
+# Terminal 3
+source .venv/bin/activate
+uvicorn src.apps_sdk.main:app --reload --port 2091
+```
+
+### 3. Run NAT Agents
+
+Run each agent in a separate terminal:
+
+```bash
+# Setup once
+cd src/agents
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+```bash
+# Terminal 4
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/promotion.yml --port 8002
+```
+
+```bash
+# Terminal 5
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/post-purchase.yml --port 8003
+```
+
+```bash
+# Terminal 6
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/recommendation.yml --port 8004
+```
+
+```bash
+# Terminal 7
+cd src/agents
+source .venv/bin/activate
+nat serve --config_file configs/search.yml --port 8005
+```
+
+### 4. Run UI
+
+```bash
+cd src/ui
+cp env.example .env.local
+pnpm install
+pnpm dev
+```
+
+Optional Apps SDK widget dev server:
+
+```bash
+cd src/apps_sdk/web
+pnpm install
+pnpm dev
+```
+
+</details>

--- a/install.sh
+++ b/install.sh
@@ -269,8 +269,8 @@ ok "All services launched"
 # =============================================================================
 # 6. Health checks
 # =============================================================================
-info "Waiting for services to start (10s)..."
-sleep 10
+info "Waiting for services to start (15s)..."
+sleep 15
 
 printf "\n${BOLD}%-25s %-6s %-8s %s${NC}\n" "SERVICE" "PORT" "STATUS" "PID"
 printf "%-25s %-6s %-8s %s\n"  "-------" "----" "------" "---"
@@ -295,14 +295,14 @@ for i in "${!HEALTH_ENDPOINTS_NAMES[@]}"; do
         fi
     done
 
-    # Check health with retries
+    # Check health with retries (up to ~25s per service for slow agent startups)
     status="${RED}FAIL${NC}"
-    for attempt in 1 2 3; do
-        if curl -sf "http://localhost:$port$path" -o /dev/null --max-time 3 2>/dev/null; then
+    for attempt in 1 2 3 4 5; do
+        if curl -sf "http://localhost:$port$path" -o /dev/null --max-time 5 2>/dev/null; then
             status="${GREEN}OK${NC}"
             break
         fi
-        sleep 2
+        sleep 5
     done
 
     if [[ "$status" == *"FAIL"* ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# install.sh — Local development setup for Retail Agentic Commerce
+#
+# Installs dependencies, starts all 8 services in background, verifies health.
+# Usage: ./install.sh
+# Stop:  ./stop.sh
+# =============================================================================
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PID_FILE="$ROOT_DIR/.local-dev.pids"
+LOG_DIR="$ROOT_DIR/logs"
+ENV_FILE="$ROOT_DIR/.env"
+ROOT_VENV="$ROOT_DIR/.venv"
+AGENTS_DIR="$ROOT_DIR/src/agents"
+AGENTS_VENV="$AGENTS_DIR/.venv"
+UI_DIR="$ROOT_DIR/src/ui"
+WIDGET_DIR="$ROOT_DIR/src/apps_sdk/web"
+
+# --- Colors ----------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+info()  { printf "${CYAN}[INFO]${NC}  %s\n" "$1"; }
+ok()    { printf "${GREEN}[OK]${NC}    %s\n" "$1"; }
+warn()  { printf "${YELLOW}[WARN]${NC}  %s\n" "$1"; }
+err()   { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
+
+# =============================================================================
+# 1. Idempotency — stop existing services if running
+# =============================================================================
+if [ -f "$PID_FILE" ]; then
+    warn "Existing services detected (.local-dev.pids found). Stopping them first..."
+    if [ -x "$ROOT_DIR/stop.sh" ]; then
+        "$ROOT_DIR/stop.sh"
+    else
+        # Inline fallback if stop.sh isn't executable yet
+        while IFS=: read -r pid name; do
+            kill "$pid" 2>/dev/null || true
+        done < "$PID_FILE"
+        sleep 2
+        while IFS=: read -r pid name; do
+            kill -9 "$pid" 2>/dev/null || true
+        done < "$PID_FILE"
+        rm -f "$PID_FILE"
+    fi
+fi
+
+# =============================================================================
+# 2. Validate prerequisites
+# =============================================================================
+info "Checking prerequisites..."
+PREREQ_FAIL=0
+
+check_cmd() {
+    if ! command -v "$1" &>/dev/null; then
+        err "$1 is not installed. $2"
+        PREREQ_FAIL=1
+    fi
+}
+
+check_cmd "python3" "Install Python 3.12+: https://www.python.org/downloads/"
+check_cmd "uv"      "Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh"
+check_cmd "node"    "Install Node.js 18+: https://nodejs.org/"
+check_cmd "pnpm"    "Install pnpm: npm install -g pnpm"
+
+# Check Python version (need 3.12+)
+if command -v python3 &>/dev/null; then
+    PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+    PY_MAJOR=$(echo "$PY_VER" | cut -d. -f1)
+    PY_MINOR=$(echo "$PY_VER" | cut -d. -f2)
+    if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -lt 12 ]; }; then
+        err "Python 3.12+ required, found $PY_VER"
+        PREREQ_FAIL=1
+    else
+        ok "Python $PY_VER"
+    fi
+fi
+
+# Check Node version (need 18+)
+if command -v node &>/dev/null; then
+    NODE_VER=$(node -v | sed 's/^v//')
+    NODE_MAJOR=$(echo "$NODE_VER" | cut -d. -f1)
+    if [ "$NODE_MAJOR" -lt 18 ]; then
+        err "Node.js 18+ required, found $NODE_VER"
+        PREREQ_FAIL=1
+    else
+        ok "Node.js $NODE_VER"
+    fi
+fi
+
+if [ "$PREREQ_FAIL" -ne 0 ]; then
+    err "Prerequisites not met. Install the missing tools above and re-run."
+    exit 1
+fi
+ok "All prerequisites met"
+
+# =============================================================================
+# 3. Environment setup
+# =============================================================================
+info "Configuring environment..."
+
+if [ ! -f "$ENV_FILE" ]; then
+    cp "$ROOT_DIR/env.example" "$ENV_FILE"
+    ok "Created .env from env.example"
+else
+    ok ".env already exists"
+fi
+
+# Source env vars we need
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+# Validate NVIDIA_API_KEY
+if [ -z "${NVIDIA_API_KEY:-}" ] || [ "$NVIDIA_API_KEY" = "nvapi-xxx" ]; then
+    err "NVIDIA_API_KEY is not configured."
+    echo ""
+    echo "  Get a free API key at: https://build.nvidia.com/settings/api-keys"
+    echo "  Then set it in your .env file:  NVIDIA_API_KEY=nvapi-..."
+    echo ""
+    exit 1
+fi
+ok "NVIDIA_API_KEY is set"
+
+# Warn on non-default NIM endpoints
+if [ "${NIM_LLM_BASE_URL:-}" != "https://integrate.api.nvidia.com/v1" ] || \
+   [ "${NIM_EMBED_BASE_URL:-}" != "https://integrate.api.nvidia.com/v1" ]; then
+    warn "NIM endpoints are not using public defaults — using custom endpoints"
+fi
+
+# =============================================================================
+# 4. Install dependencies
+# =============================================================================
+info "Installing dependencies..."
+
+# Root venv
+info "Setting up root Python environment..."
+cd "$ROOT_DIR"
+uv venv --quiet 2>/dev/null || uv venv
+uv sync --quiet 2>/dev/null || uv sync
+ok "Root venv ready ($ROOT_VENV)"
+
+# Agents venv
+info "Setting up agents Python environment..."
+cd "$AGENTS_DIR"
+uv venv --quiet 2>/dev/null || uv venv
+"$AGENTS_VENV/bin/pip" install -q -e ".[dev]" 2>/dev/null || uv pip install -e ".[dev]" --python "$AGENTS_VENV/bin/python"
+ok "Agents venv ready ($AGENTS_VENV)"
+
+# UI
+info "Installing UI dependencies..."
+cd "$UI_DIR"
+if [ ! -f ".env.local" ]; then
+    cp env.example .env.local
+    ok "Created src/ui/.env.local from env.example"
+fi
+pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+ok "UI dependencies installed"
+
+# Apps SDK Widget (non-blocking)
+info "Installing Apps SDK widget dependencies..."
+cd "$WIDGET_DIR"
+if pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null; then
+    ok "Apps SDK widget dependencies installed"
+else
+    warn "Apps SDK widget install failed (non-blocking, widget dev server may not work)"
+fi
+
+cd "$ROOT_DIR"
+
+# =============================================================================
+# 5. Start services
+# =============================================================================
+info "Starting services..."
+mkdir -p "$LOG_DIR"
+
+# Parallel arrays for Bash 3.2 compatibility (no declare -A)
+SVC_NAMES=()
+SVC_PORTS=()
+SVC_PIDS=()
+
+start_service() {
+    local name="$1" port="$2" logfile="$LOG_DIR/$1.log"
+    shift 2
+
+    # Run the command in background, redirect output to log
+    "$@" > "$logfile" 2>&1 &
+    local pid=$!
+    echo "$pid:$name" >> "$PID_FILE"
+    SVC_NAMES+=("$name")
+    SVC_PORTS+=("$port")
+    SVC_PIDS+=("$pid")
+    info "  Started $name (PID $pid, port $port) → logs/$name.log"
+}
+
+# --- Backend services (using root venv uvicorn) ---
+start_service "merchant" 8000 \
+    "$ROOT_VENV/bin/uvicorn" src.merchant.main:app --host 0.0.0.0 --port 8000
+
+start_service "psp" 8001 \
+    "$ROOT_VENV/bin/uvicorn" src.payment.main:app --host 0.0.0.0 --port 8001
+
+start_service "apps-sdk" 2091 \
+    "$ROOT_VENV/bin/uvicorn" src.apps_sdk.main:app --host 0.0.0.0 --port 2091
+
+# --- NAT Agents (using agents venv, need env vars) ---
+# Env vars are already exported from the source above (set -a / set +a block)
+NAT_ENV_VARS=(
+    NVIDIA_API_KEY
+    NIM_LLM_BASE_URL
+    NIM_LLM_MODEL_NAME
+    NIM_EMBED_BASE_URL
+    NIM_EMBED_MODEL_NAME
+    MILVUS_URI
+    PHOENIX_ENDPOINT
+)
+
+# Build env prefix for agent commands
+AGENT_ENV=""
+for var in "${NAT_ENV_VARS[@]}"; do
+    val="${!var:-}"
+    if [ -n "$val" ]; then
+        AGENT_ENV="$AGENT_ENV $var=$val"
+    fi
+done
+
+start_agent() {
+    local name="$1"
+    local port="$2"
+    local config="$3"
+    local logfile="$LOG_DIR/$name.log"
+    cd "$AGENTS_DIR"
+    env $AGENT_ENV "$AGENTS_VENV/bin/nat" serve --config_file "configs/$config" --port "$port" > "$logfile" 2>&1 &
+    local pid=$!
+    echo "$pid:$name" >> "$PID_FILE"
+    SVC_NAMES+=("$name")
+    SVC_PORTS+=("$port")
+    SVC_PIDS+=("$pid")
+    info "  Started $name (PID $pid, port $port) → logs/$name.log"
+    cd "$ROOT_DIR"
+}
+
+start_agent "promotion-agent"      8002 "promotion.yml"
+start_agent "post-purchase-agent"  8003 "post-purchase.yml"
+start_agent "recommendation-agent" 8004 "recommendation.yml"
+start_agent "search-agent"         8005 "search.yml"
+
+# --- UI (Next.js dev server) ---
+cd "$UI_DIR"
+pnpm dev > "$LOG_DIR/ui.log" 2>&1 &
+UI_PID=$!
+echo "$UI_PID:ui" >> "$PID_FILE"
+SVC_NAMES+=("ui")
+SVC_PORTS+=("3000")
+SVC_PIDS+=("$UI_PID")
+info "  Started ui (PID $UI_PID, port 3000) → logs/ui.log"
+cd "$ROOT_DIR"
+
+ok "All services launched"
+
+# =============================================================================
+# 6. Health checks
+# =============================================================================
+info "Waiting for services to start (10s)..."
+sleep 10
+
+printf "\n${BOLD}%-25s %-6s %-8s %s${NC}\n" "SERVICE" "PORT" "STATUS" "PID"
+printf "%-25s %-6s %-8s %s\n"  "-------" "----" "------" "---"
+
+HEALTH_ENDPOINTS_NAMES=( "merchant" "psp" "apps-sdk" "promotion-agent" "post-purchase-agent" "recommendation-agent" "search-agent" "ui" )
+HEALTH_ENDPOINTS_PORTS=( 8000       8001  2091       8002              8003                  8004                   8005           3000 )
+HEALTH_ENDPOINTS_PATHS=( "/health"  "/health" "/health" "/health"      "/health"             "/health"              "/health"      "/" )
+
+ALL_HEALTHY=true
+
+for i in "${!HEALTH_ENDPOINTS_NAMES[@]}"; do
+    name="${HEALTH_ENDPOINTS_NAMES[$i]}"
+    port="${HEALTH_ENDPOINTS_PORTS[$i]}"
+    path="${HEALTH_ENDPOINTS_PATHS[$i]}"
+
+    # Find the PID for this service
+    pid="?"
+    for j in "${!SVC_NAMES[@]}"; do
+        if [ "${SVC_NAMES[$j]}" = "$name" ]; then
+            pid="${SVC_PIDS[$j]}"
+            break
+        fi
+    done
+
+    # Check health with retries
+    status="${RED}FAIL${NC}"
+    for attempt in 1 2 3; do
+        if curl -sf "http://localhost:$port$path" -o /dev/null --max-time 3 2>/dev/null; then
+            status="${GREEN}OK${NC}"
+            break
+        fi
+        sleep 2
+    done
+
+    if [[ "$status" == *"FAIL"* ]]; then
+        ALL_HEALTHY=false
+    fi
+
+    printf "%-25s %-6s %-8b %s\n" "$name" "$port" "$status" "$pid"
+done
+
+# =============================================================================
+# 7. Summary
+# =============================================================================
+printf "\n"
+if $ALL_HEALTHY; then
+    printf "${GREEN}${BOLD}All services are running!${NC}\n"
+else
+    printf "${YELLOW}${BOLD}Some services failed health checks. Check logs for details.${NC}\n"
+fi
+
+printf "\n${BOLD}Access URLs:${NC}\n"
+echo "  Demo UI:         http://localhost:3000"
+echo "  Merchant API:    http://localhost:8000/docs"
+echo "  PSP:             http://localhost:8001/docs"
+echo "  Apps SDK MCP:    http://localhost:2091/docs"
+echo "  Phoenix Traces:  http://localhost:6006  (requires Docker infra)"
+echo "  MinIO Console:   http://localhost:9001  (requires Docker infra)"
+printf "\n${BOLD}Logs:${NC}            $LOG_DIR/<service>.log\n"
+printf "${BOLD}Stop services:${NC}   ./stop.sh\n\n"

--- a/src/apps_sdk/events.py
+++ b/src/apps_sdk/events.py
@@ -62,7 +62,7 @@ def emit_agent_activity_event(
     stock_count: int = 0,
     base_price: int = 0,
 ) -> None:
-    """Emit an agent activity event to all SSE subscribers."""
+    """Emit a promotion agent activity event to all SSE subscribers."""
     event = {
         "id": f"agent_{datetime.now().timestamp()}",
         "agentType": agent_type,
@@ -78,6 +78,73 @@ def emit_agent_activity_event(
     }
     checkout_events.append(event)
 
+    for queue in event_subscribers:
+        with contextlib.suppress(asyncio.QueueFull):
+            queue.put_nowait(event)
+
+
+def emit_recommendation_pending_event(
+    *,
+    event_id: str,
+    product_id: str,
+    product_name: str,
+    cart_items: list[dict[str, Any]],
+) -> None:
+    """Emit a *pending* recommendation event so the Agent Activity Panel
+    immediately shows a "Generating" card while the ARAG agent works.
+    """
+    event: dict[str, Any] = {
+        "id": event_id,
+        "agentType": "recommendation",
+        "status": "pending",
+        "productId": product_id,
+        "productName": product_name,
+        "cartItems": cart_items,
+        "timestamp": datetime.now().isoformat(),
+    }
+    checkout_events.append(event)
+    for queue in event_subscribers:
+        with contextlib.suppress(asyncio.QueueFull):
+            queue.put_nowait(event)
+
+
+def emit_recommendation_complete_event(
+    *,
+    event_id: str,
+    product_id: str,
+    product_name: str,
+    cart_items: list[dict[str, Any]],
+    recommendations: list[dict[str, Any]],
+    user_intent: str | None = None,
+    pipeline_trace: dict[str, Any] | None = None,
+    recommendation_request_id: str | None = None,
+    latency_ms: int = 0,
+    error: str | None = None,
+) -> None:
+    """Emit a *completed* recommendation event that updates the pending card
+    with the final results (or error).
+    """
+    status = "error" if error else "success"
+    event: dict[str, Any] = {
+        "id": event_id,
+        "agentType": "recommendation",
+        "status": status,
+        "productId": product_id,
+        "productName": product_name,
+        "cartItems": cart_items,
+        "recommendations": recommendations,
+        "recommendationRequestId": recommendation_request_id,
+        "latencyMs": latency_ms,
+        "timestamp": datetime.now().isoformat(),
+    }
+    if user_intent is not None:
+        event["userIntent"] = user_intent
+    if pipeline_trace is not None:
+        event["pipelineTrace"] = pipeline_trace
+    if error is not None:
+        event["error"] = error
+
+    checkout_events.append(event)
     for queue in event_subscribers:
         with contextlib.suppress(asyncio.QueueFull):
             queue.put_nowait(event)

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -324,7 +324,8 @@ async def _handle_search_products(args: dict[str, Any]) -> types.ServerResult:
         str(result.get("error")) if result.get("error") is not None else None
     )
     status, error_code = _classify_outcome_status(
-        agent_type="search", error_message=error_message,
+        agent_type="search",
+        error_message=error_message,
     )
     await _record_apps_sdk_outcome(
         agent_type="search",
@@ -365,7 +366,9 @@ async def _handle_remove_from_cart(args: dict[str, Any]) -> types.ServerResult:
 async def _handle_update_cart_quantity(args: dict[str, Any]) -> types.ServerResult:
     payload = UpdateCartQuantityInput.model_validate(args)
     result = await update_cart_quantity(
-        payload.product_id, payload.quantity, payload.cart_id,
+        payload.product_id,
+        payload.quantity,
+        payload.cart_id,
     )
     return _ok(
         f"Cart quantity updated to {payload.quantity}",
@@ -438,13 +441,16 @@ async def _handle_get_recommendations(args: dict[str, Any]) -> types.ServerResul
 
     started = time.perf_counter()
     result = await call_recommendation_agent(
-        payload.product_id, payload.product_name, payload.cart_items,
+        payload.product_id,
+        payload.product_name,
+        payload.cart_items,
     )
     error_message = (
         str(result.get("error")) if result.get("error") is not None else None
     )
     status, error_code = _classify_outcome_status(
-        agent_type="recommendation", error_message=error_message,
+        agent_type="recommendation",
+        error_message=error_message,
     )
     await _record_apps_sdk_outcome(
         agent_type="recommendation",
@@ -455,7 +461,9 @@ async def _handle_get_recommendations(args: dict[str, Any]) -> types.ServerResul
 
     raw_recommendations = _extract_raw_recommendations(result)
     await _record_recommendation_impressions(
-        raw_recommendations, payload.session_id, recommendation_request_id,
+        raw_recommendations,
+        payload.session_id,
+        recommendation_request_id,
     )
 
     result["recommendationRequestId"] = recommendation_request_id
@@ -512,9 +520,7 @@ async def _record_recommendation_impressions(
         if not isinstance(product_id, str) or not product_id:
             continue
         position_value = rec.get("rank")
-        position = (
-            int(position_value) if isinstance(position_value, int) else index + 1
-        )
+        position = int(position_value) if isinstance(position_value, int) else index + 1
         await _record_recommendation_attribution_event(
             event_type="impression",
             product_id=product_id,
@@ -555,7 +561,9 @@ async def _handle_update_checkout_session(args: dict[str, Any]) -> types.ServerR
         return _err(str(e))
 
 
-async def _handle_track_recommendation_click(args: dict[str, Any]) -> types.ServerResult:
+async def _handle_track_recommendation_click(
+    args: dict[str, Any],
+) -> types.ServerResult:
     payload = TrackRecommendationClickInput.model_validate(args)
     await _record_recommendation_attribution_event(
         event_type="click",

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -31,7 +31,6 @@ from src.apps_sdk.events import (
 )
 from src.apps_sdk.recommendation_helpers import (
     call_recommendation_agent,
-    record_purchase_attribution as _record_purchase_attribution,
 )
 from src.apps_sdk.recommendation_helpers import (
     cart_meta as _cart_meta,
@@ -47,6 +46,9 @@ from src.apps_sdk.recommendation_helpers import (
 )
 from src.apps_sdk.recommendation_helpers import (
     record_apps_sdk_outcome as _record_apps_sdk_outcome,
+)
+from src.apps_sdk.recommendation_helpers import (
+    record_purchase_attribution as _record_purchase_attribution,
 )
 from src.apps_sdk.recommendation_helpers import (
     record_recommendation_attribution_event as _record_recommendation_attribution_event,

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -287,358 +287,313 @@ async def list_mcp_resources() -> list[types.Resource]:
 # =============================================================================
 
 
+def _ok(text: str, result: dict[str, Any], **kwargs: Any) -> types.ServerResult:
+    """Build a successful ServerResult with text + structured content."""
+    return types.ServerResult(
+        types.CallToolResult(
+            content=[types.TextContent(type="text", text=text)],
+            structuredContent=result,
+            **kwargs,
+        )
+    )
+
+
+def _err(text: str, **kwargs: Any) -> types.ServerResult:
+    """Build an error ServerResult."""
+    return types.ServerResult(
+        types.CallToolResult(
+            content=[types.TextContent(type="text", text=text)],
+            isError=True,
+            **kwargs,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Individual tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_search_products(args: dict[str, Any]) -> types.ServerResult:
+    payload = SearchProductsInput.model_validate(args)
+    started = time.perf_counter()
+    result = await search_products(payload.query, payload.category, payload.limit)
+    error_message = (
+        str(result.get("error")) if result.get("error") is not None else None
+    )
+    status, error_code = _classify_outcome_status(
+        agent_type="search", error_message=error_message,
+    )
+    await _record_apps_sdk_outcome(
+        agent_type="search",
+        status=status,
+        latency_ms=int((time.perf_counter() - started) * 1000),
+        error_code=error_code,
+    )
+    meta = result.get("_meta", _search_meta())
+    if result.get("error"):
+        return _err(str(result.get("error")), structuredContent=result, _meta=meta)
+    return _ok(
+        f"Found {result.get('totalResults', 0)} products for '{payload.query}'",
+        result,
+        _meta=meta,
+    )
+
+
+async def _handle_add_to_cart(args: dict[str, Any]) -> types.ServerResult:
+    payload = AddToCartInput.model_validate(args)
+    result = await add_to_cart(payload.product_id, payload.quantity, payload.cart_id)
+    return _ok(
+        f"Added {payload.quantity} item(s) to cart",
+        result,
+        _meta=result.get("_meta", _cart_meta(result.get("cartId", ""))),
+    )
+
+
+async def _handle_remove_from_cart(args: dict[str, Any]) -> types.ServerResult:
+    payload = RemoveFromCartInput.model_validate(args)
+    result = await remove_from_cart(payload.product_id, payload.cart_id)
+    return _ok(
+        "Item removed from cart",
+        result,
+        _meta=result.get("_meta", _cart_meta(payload.cart_id)),
+    )
+
+
+async def _handle_update_cart_quantity(args: dict[str, Any]) -> types.ServerResult:
+    payload = UpdateCartQuantityInput.model_validate(args)
+    result = await update_cart_quantity(
+        payload.product_id, payload.quantity, payload.cart_id,
+    )
+    return _ok(
+        f"Cart quantity updated to {payload.quantity}",
+        result,
+        _meta=result.get("_meta", _cart_meta(payload.cart_id)),
+    )
+
+
+async def _handle_get_cart(args: dict[str, Any]) -> types.ServerResult:
+    payload = GetCartInput.model_validate(args)
+    result = await get_cart(payload.cart_id)
+    return _ok(
+        f"Cart has {result.get('itemCount', 0)} items",
+        result,
+        _meta=result.get("_meta", _cart_meta(payload.cart_id)),
+    )
+
+
+async def _handle_checkout(args: dict[str, Any]) -> types.ServerResult:
+    payload = CheckoutInput.model_validate(args)
+
+    if payload.cart_items:
+        from src.apps_sdk.tools.cart import carts
+
+        carts[payload.cart_id] = [
+            {
+                "id": item.get("id"),
+                "name": item.get("name"),
+                "basePrice": item.get("basePrice"),
+                "quantity": item.get("quantity"),
+                "variant": item.get("variant"),
+                "size": item.get("size"),
+            }
+            for item in payload.cart_items
+        ]
+
+    result = await checkout(payload.cart_id, customer_name=payload.customer_name)
+
+    if result.get("success") and payload.cart_items:
+        await _record_purchase_attribution(
+            cart_items=payload.cart_items,
+            session_id=payload.cart_id,
+            order_id=str(result.get("orderId") or ""),
+        )
+
+    success = result.get("success", False)
+    return _ok(
+        result.get("message", "Checkout failed"),
+        result,
+        _meta=result.get("_meta", _checkout_meta(success)),
+    )
+
+
+async def _handle_get_recommendations(args: dict[str, Any]) -> types.ServerResult:
+    payload = GetRecommendationsInput.model_validate(args)
+    recommendation_request_id = f"rec_{uuid4().hex[:12]}"
+
+    rec_event_id = f"agent_rec_{uuid4().hex[:12]}"
+    cart_items_for_sse = [
+        {"productId": ci.product_id, "name": ci.name, "price": ci.price}
+        for ci in payload.cart_items
+    ]
+
+    emit_recommendation_pending_event(
+        event_id=rec_event_id,
+        product_id=payload.product_id,
+        product_name=payload.product_name,
+        cart_items=cart_items_for_sse,
+    )
+
+    started = time.perf_counter()
+    result = await call_recommendation_agent(
+        payload.product_id, payload.product_name, payload.cart_items,
+    )
+    error_message = (
+        str(result.get("error")) if result.get("error") is not None else None
+    )
+    status, error_code = _classify_outcome_status(
+        agent_type="recommendation", error_message=error_message,
+    )
+    await _record_apps_sdk_outcome(
+        agent_type="recommendation",
+        status=status,
+        latency_ms=int((time.perf_counter() - started) * 1000),
+        error_code=error_code,
+    )
+
+    raw_recommendations = _extract_raw_recommendations(result)
+    await _record_recommendation_impressions(
+        raw_recommendations, payload.session_id, recommendation_request_id,
+    )
+
+    result["recommendationRequestId"] = recommendation_request_id
+    latency_ms = int((time.perf_counter() - started) * 1000)
+
+    emit_recommendation_complete_event(
+        event_id=rec_event_id,
+        product_id=payload.product_id,
+        product_name=payload.product_name,
+        cart_items=cart_items_for_sse,
+        recommendations=[
+            {
+                "productId": rec.get("product_id") or rec.get("productId") or "",
+                "productName": rec.get("product_name") or rec.get("productName") or "",
+                "rank": rec.get("rank", idx + 1),
+                "reasoning": rec.get("reasoning", ""),
+            }
+            for idx, rec in enumerate(raw_recommendations)
+        ],
+        user_intent=result.get("userIntent"),
+        pipeline_trace=result.get("pipelineTrace"),
+        recommendation_request_id=recommendation_request_id,
+        latency_ms=latency_ms,
+        error=error_message,
+    )
+
+    return _ok(
+        f"Found {len(raw_recommendations)} recommendations",
+        result,
+        _meta=_recommendations_meta(),
+    )
+
+
+def _extract_raw_recommendations(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract and normalise the recommendations list from the agent response."""
+    raw_value: Any = result.get("recommendations")
+    if not isinstance(raw_value, list):
+        return []
+    return [
+        cast(dict[str, Any], rec)
+        for rec in cast(list[Any], raw_value)
+        if isinstance(rec, dict)
+    ]
+
+
+async def _record_recommendation_impressions(
+    raw_recommendations: list[dict[str, Any]],
+    session_id: str | None,
+    recommendation_request_id: str,
+) -> None:
+    """Record an impression attribution event for each recommendation."""
+    for index, rec in enumerate(raw_recommendations):
+        product_id = rec.get("product_id") or rec.get("productId")
+        if not isinstance(product_id, str) or not product_id:
+            continue
+        position_value = rec.get("rank")
+        position = (
+            int(position_value) if isinstance(position_value, int) else index + 1
+        )
+        await _record_recommendation_attribution_event(
+            event_type="impression",
+            product_id=product_id,
+            session_id=session_id,
+            recommendation_request_id=recommendation_request_id,
+            position=position,
+        )
+
+
+async def _handle_create_checkout_session(args: dict[str, Any]) -> types.ServerResult:
+    payload = CreateCheckoutSessionInput.model_validate(args)
+    try:
+        result = await create_acp_session(
+            items=payload.items,
+            buyer=payload.buyer,
+            fulfillment_address=payload.fulfillment_address,
+            discounts=payload.discounts,
+        )
+        return _ok(f"Checkout session {result.get('id', '')} created", result)
+    except Exception as e:
+        logger.exception("create-checkout-session failed")
+        return _err(str(e))
+
+
+async def _handle_update_checkout_session(args: dict[str, Any]) -> types.ServerResult:
+    payload = UpdateCheckoutSessionInput.model_validate(args)
+    try:
+        result = await update_acp_session(
+            session_id=payload.session_id,
+            items=payload.items,
+            fulfillment_option_id=payload.fulfillment_option_id,
+            fulfillment_address=payload.fulfillment_address,
+            discounts=payload.discounts,
+        )
+        return _ok(f"Session {payload.session_id} updated", result)
+    except Exception as e:
+        logger.exception("update-checkout-session failed for %s", payload.session_id)
+        return _err(str(e))
+
+
+async def _handle_track_recommendation_click(args: dict[str, Any]) -> types.ServerResult:
+    payload = TrackRecommendationClickInput.model_validate(args)
+    await _record_recommendation_attribution_event(
+        event_type="click",
+        product_id=payload.product_id,
+        session_id=payload.session_id,
+        recommendation_request_id=payload.recommendation_request_id,
+        position=payload.position,
+        source=payload.source,
+    )
+    return _ok("Click tracked", {"recorded": True})
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table — maps tool name to handler
+# ---------------------------------------------------------------------------
+
+_TOOL_HANDLERS: dict[
+    str,
+    Any,  # Callable[[dict[str, Any]], Awaitable[types.ServerResult]]
+] = {
+    "search-products": _handle_search_products,
+    "add-to-cart": _handle_add_to_cart,
+    "remove-from-cart": _handle_remove_from_cart,
+    "update-cart-quantity": _handle_update_cart_quantity,
+    "get-cart": _handle_get_cart,
+    "checkout": _handle_checkout,
+    "get-recommendations": _handle_get_recommendations,
+    "create-checkout-session": _handle_create_checkout_session,
+    "update-checkout-session": _handle_update_checkout_session,
+    "track-recommendation-click": _handle_track_recommendation_click,
+}
+
+
 async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
     """Route and handle all tool calls."""
     tool_name = req.params.name
-    args = req.params.arguments or {}
-
-    if tool_name == "search-products":
-        payload = SearchProductsInput.model_validate(args)
-        started = time.perf_counter()
-        result = await search_products(payload.query, payload.category, payload.limit)
-        error_message = (
-            str(result.get("error")) if result.get("error") is not None else None
-        )
-        status, error_code = _classify_outcome_status(
-            agent_type="search",
-            error_message=error_message,
-        )
-        await _record_apps_sdk_outcome(
-            agent_type="search",
-            status=status,
-            latency_ms=int((time.perf_counter() - started) * 1000),
-            error_code=error_code,
-        )
-        if result.get("error"):
-            return types.ServerResult(
-                types.CallToolResult(
-                    content=[
-                        types.TextContent(
-                            type="text",
-                            text=str(result.get("error")),
-                        )
-                    ],
-                    structuredContent=result,
-                    _meta=result.get("_meta", _search_meta()),
-                    isError=True,
-                )
-            )
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(
-                        type="text",
-                        text=f"Found {result.get('totalResults', 0)} products for '{payload.query}'",
-                    )
-                ],
-                structuredContent=result,
-                _meta=result.get("_meta", _search_meta()),
-            )
-        )
-
-    if tool_name == "add-to-cart":
-        payload = AddToCartInput.model_validate(args)
-        result = await add_to_cart(
-            payload.product_id, payload.quantity, payload.cart_id
-        )
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(
-                        type="text",
-                        text=f"Added {payload.quantity} item(s) to cart",
-                    )
-                ],
-                structuredContent=result,
-                _meta=result.get("_meta", _cart_meta(result.get("cartId", ""))),
-            )
-        )
-
-    if tool_name == "remove-from-cart":
-        payload = RemoveFromCartInput.model_validate(args)
-        result = await remove_from_cart(payload.product_id, payload.cart_id)
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(
-                        type="text",
-                        text="Item removed from cart",
-                    )
-                ],
-                structuredContent=result,
-                _meta=result.get("_meta", _cart_meta(payload.cart_id)),
-            )
-        )
-
-    if tool_name == "update-cart-quantity":
-        payload = UpdateCartQuantityInput.model_validate(args)
-        result = await update_cart_quantity(
-            payload.product_id, payload.quantity, payload.cart_id
-        )
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(
-                        type="text",
-                        text=f"Cart quantity updated to {payload.quantity}",
-                    )
-                ],
-                structuredContent=result,
-                _meta=result.get("_meta", _cart_meta(payload.cart_id)),
-            )
-        )
-
-    if tool_name == "get-cart":
-        payload = GetCartInput.model_validate(args)
-        result = await get_cart(payload.cart_id)
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(
-                        type="text",
-                        text=f"Cart has {result.get('itemCount', 0)} items",
-                    )
-                ],
-                structuredContent=result,
-                _meta=result.get("_meta", _cart_meta(payload.cart_id)),
-            )
-        )
-
-    if tool_name == "checkout":
-        payload = CheckoutInput.model_validate(args)
-
-        # If widget sent cart items, sync them into the server-side cart first
-        if payload.cart_items:
-            from src.apps_sdk.tools.cart import carts
-
-            carts[payload.cart_id] = [
-                {
-                    "id": item.get("id"),
-                    "name": item.get("name"),
-                    "basePrice": item.get("basePrice"),
-                    "quantity": item.get("quantity"),
-                    "variant": item.get("variant"),
-                    "size": item.get("size"),
-                }
-                for item in payload.cart_items
-            ]
-
-        result = await checkout(payload.cart_id, customer_name=payload.customer_name)
-
-        # Record purchase attribution for items that came from recommendations
-        if result.get("success") and payload.cart_items:
-            await _record_purchase_attribution(
-                cart_items=payload.cart_items,
-                session_id=payload.cart_id,
-                order_id=str(result.get("orderId") or ""),
-            )
-
-        success = result.get("success", False)
-        message = result.get("message", "Checkout failed")
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(
-                        type="text",
-                        text=message,
-                    )
-                ],
-                structuredContent=result,
-                _meta=result.get("_meta", _checkout_meta(success)),
-            )
-        )
-
-    if tool_name == "get-recommendations":
-        payload = GetRecommendationsInput.model_validate(args)
-        recommendation_request_id = f"rec_{uuid4().hex[:12]}"
-
-        # Stable event ID shared between pending and complete SSE events
-        rec_event_id = f"agent_rec_{uuid4().hex[:12]}"
-        cart_items_for_sse = [
-            {"productId": ci.product_id, "name": ci.name, "price": ci.price}
-            for ci in payload.cart_items
-        ]
-
-        # Emit pending immediately so the Agent Activity Panel shows "Generating"
-        emit_recommendation_pending_event(
-            event_id=rec_event_id,
-            product_id=payload.product_id,
-            product_name=payload.product_name,
-            cart_items=cart_items_for_sse,
-        )
-
-        started = time.perf_counter()
-        result = await call_recommendation_agent(
-            payload.product_id,
-            payload.product_name,
-            payload.cart_items,
-        )
-        error_message = (
-            str(result.get("error")) if result.get("error") is not None else None
-        )
-        status, error_code = _classify_outcome_status(
-            agent_type="recommendation",
-            error_message=error_message,
-        )
-        await _record_apps_sdk_outcome(
-            agent_type="recommendation",
-            status=status,
-            latency_ms=int((time.perf_counter() - started) * 1000),
-            error_code=error_code,
-        )
-        raw_recommendations_value: Any = result.get("recommendations")
-        raw_recommendations: list[dict[str, Any]] = (
-            [
-                cast(dict[str, Any], rec)
-                for rec in cast(list[Any], raw_recommendations_value)
-                if isinstance(rec, dict)
-            ]
-            if isinstance(raw_recommendations_value, list)
-            else []
-        )
-        for index, rec in enumerate(raw_recommendations):
-            product_id = rec.get("product_id") or rec.get("productId")
-            if not isinstance(product_id, str) or not product_id:
-                continue
-            position_value = rec.get("rank")
-            position = (
-                int(position_value) if isinstance(position_value, int) else index + 1
-            )
-            await _record_recommendation_attribution_event(
-                event_type="impression",
-                product_id=product_id,
-                session_id=payload.session_id,
-                recommendation_request_id=recommendation_request_id,
-                position=position,
-            )
-        result["recommendationRequestId"] = recommendation_request_id
-        rec_count = len(result.get("recommendations", []))
-        latency_ms = int((time.perf_counter() - started) * 1000)
-
-        # Emit complete event — updates the pending card with results
-        emit_recommendation_complete_event(
-            event_id=rec_event_id,
-            product_id=payload.product_id,
-            product_name=payload.product_name,
-            cart_items=cart_items_for_sse,
-            recommendations=[
-                {
-                    "productId": rec.get("product_id") or rec.get("productId") or "",
-                    "productName": rec.get("product_name") or rec.get("productName") or "",
-                    "rank": rec.get("rank", idx + 1),
-                    "reasoning": rec.get("reasoning", ""),
-                }
-                for idx, rec in enumerate(raw_recommendations)
-            ],
-            user_intent=result.get("userIntent"),
-            pipeline_trace=result.get("pipelineTrace"),
-            recommendation_request_id=recommendation_request_id,
-            latency_ms=latency_ms,
-            error=error_message,
-        )
-
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(
-                        type="text",
-                        text=f"Found {rec_count} recommendations",
-                    )
-                ],
-                structuredContent=result,
-                _meta=_recommendations_meta(),
-            )
-        )
-
-    if tool_name == "create-checkout-session":
-        payload = CreateCheckoutSessionInput.model_validate(args)
-        try:
-            result = await create_acp_session(
-                items=payload.items,
-                buyer=payload.buyer,
-                fulfillment_address=payload.fulfillment_address,
-                discounts=payload.discounts,
-            )
-            session_id = result.get("id", "")
-            return types.ServerResult(
-                types.CallToolResult(
-                    content=[
-                        types.TextContent(
-                            type="text",
-                            text=f"Checkout session {session_id} created",
-                        )
-                    ],
-                    structuredContent=result,
-                )
-            )
-        except Exception as e:
-            logger.exception("create-checkout-session failed")
-            return types.ServerResult(
-                types.CallToolResult(
-                    content=[
-                        types.TextContent(type="text", text=str(e))
-                    ],
-                    isError=True,
-                )
-            )
-
-    if tool_name == "update-checkout-session":
-        payload = UpdateCheckoutSessionInput.model_validate(args)
-        try:
-            result = await update_acp_session(
-                session_id=payload.session_id,
-                items=payload.items,
-                fulfillment_option_id=payload.fulfillment_option_id,
-                fulfillment_address=payload.fulfillment_address,
-                discounts=payload.discounts,
-            )
-            return types.ServerResult(
-                types.CallToolResult(
-                    content=[
-                        types.TextContent(
-                            type="text",
-                            text=f"Session {payload.session_id} updated",
-                        )
-                    ],
-                    structuredContent=result,
-                )
-            )
-        except Exception as e:
-            logger.exception("update-checkout-session failed for %s", payload.session_id)
-            return types.ServerResult(
-                types.CallToolResult(
-                    content=[
-                        types.TextContent(type="text", text=str(e))
-                    ],
-                    isError=True,
-                )
-            )
-
-    if tool_name == "track-recommendation-click":
-        payload = TrackRecommendationClickInput.model_validate(args)
-        await _record_recommendation_attribution_event(
-            event_type="click",
-            product_id=payload.product_id,
-            session_id=payload.session_id,
-            recommendation_request_id=payload.recommendation_request_id,
-            position=payload.position,
-            source=payload.source,
-        )
-        return types.ServerResult(
-            types.CallToolResult(
-                content=[
-                    types.TextContent(type="text", text="Click tracked")
-                ],
-                structuredContent={"recorded": True},
-            )
-        )
-
-    return types.ServerResult(
-        types.CallToolResult(
-            content=[types.TextContent(type="text", text=f"Unknown tool: {tool_name}")],
-            isError=True,
-        )
-    )
+    handler = _TOOL_HANDLERS.get(tool_name)
+    if handler is None:
+        return _err(f"Unknown tool: {tool_name}")
+    return await handler(req.params.arguments or {})
 
 
 # Register the handler

--- a/src/apps_sdk/main.py
+++ b/src/apps_sdk/main.py
@@ -23,12 +23,15 @@ from src.apps_sdk.config import get_apps_sdk_settings
 from src.apps_sdk.events import (
     emit_agent_activity_event,
     emit_checkout_event,
+    emit_recommendation_complete_event,
+    emit_recommendation_pending_event,
 )
 from src.apps_sdk.events import (
     router as events_router,
 )
 from src.apps_sdk.recommendation_helpers import (
     call_recommendation_agent,
+    record_purchase_attribution as _record_purchase_attribution,
 )
 from src.apps_sdk.recommendation_helpers import (
     cart_meta as _cart_meta,
@@ -59,6 +62,7 @@ from src.apps_sdk.schemas import (
     CartOutput,
     CheckoutInput,
     CheckoutOutput,
+    CreateCheckoutSessionInput,
     GetCartInput,
     GetRecommendationsInput,
     GetRecommendationsOutput,
@@ -68,7 +72,9 @@ from src.apps_sdk.schemas import (
     RemoveFromCartInput,
     SearchProductsInput,
     SearchProductsOutput,
+    TrackRecommendationClickInput,
     UpdateCartQuantityInput,
+    UpdateCheckoutSessionInput,
     UserOutput,
 )
 from src.apps_sdk.tools import (
@@ -79,6 +85,7 @@ from src.apps_sdk.tools import (
     search_products,
     update_cart_quantity,
 )
+from src.apps_sdk.tools.acp_sessions import create_acp_session, update_acp_session
 from src.apps_sdk.widget_endpoints import (
     DIST_DIR,
     PUBLIC_DIR,
@@ -213,6 +220,39 @@ async def list_mcp_tools() -> list[types.Tool]:
                 destructiveHint=False,
                 openWorldHint=True,
                 readOnlyHint=True,
+            ),
+        ),
+        types.Tool(
+            name="create-checkout-session",
+            title="Create Checkout Session",
+            description="Create a new ACP checkout session with the Merchant API. Returns session with line items, promotions, and totals.",
+            inputSchema=CreateCheckoutSessionInput.model_json_schema(by_alias=True),
+            annotations=types.ToolAnnotations(
+                destructiveHint=False,
+                openWorldHint=True,
+                readOnlyHint=False,
+            ),
+        ),
+        types.Tool(
+            name="update-checkout-session",
+            title="Update Checkout Session",
+            description="Update an existing ACP checkout session (items, shipping, discounts). Returns updated session with recalculated totals.",
+            inputSchema=UpdateCheckoutSessionInput.model_json_schema(by_alias=True),
+            annotations=types.ToolAnnotations(
+                destructiveHint=False,
+                openWorldHint=True,
+                readOnlyHint=False,
+            ),
+        ),
+        types.Tool(
+            name="track-recommendation-click",
+            title="Track Recommendation Click",
+            description="Record a recommendation click event for attribution analytics.",
+            inputSchema=TrackRecommendationClickInput.model_json_schema(by_alias=True),
+            annotations=types.ToolAnnotations(
+                destructiveHint=False,
+                openWorldHint=True,
+                readOnlyHint=False,
             ),
         ),
     ]
@@ -366,7 +406,33 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
 
     if tool_name == "checkout":
         payload = CheckoutInput.model_validate(args)
-        result = await checkout(payload.cart_id)
+
+        # If widget sent cart items, sync them into the server-side cart first
+        if payload.cart_items:
+            from src.apps_sdk.tools.cart import carts
+
+            carts[payload.cart_id] = [
+                {
+                    "id": item.get("id"),
+                    "name": item.get("name"),
+                    "basePrice": item.get("basePrice"),
+                    "quantity": item.get("quantity"),
+                    "variant": item.get("variant"),
+                    "size": item.get("size"),
+                }
+                for item in payload.cart_items
+            ]
+
+        result = await checkout(payload.cart_id, customer_name=payload.customer_name)
+
+        # Record purchase attribution for items that came from recommendations
+        if result.get("success") and payload.cart_items:
+            await _record_purchase_attribution(
+                cart_items=payload.cart_items,
+                session_id=payload.cart_id,
+                order_id=str(result.get("orderId") or ""),
+            )
+
         success = result.get("success", False)
         message = result.get("message", "Checkout failed")
         return types.ServerResult(
@@ -385,6 +451,22 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
     if tool_name == "get-recommendations":
         payload = GetRecommendationsInput.model_validate(args)
         recommendation_request_id = f"rec_{uuid4().hex[:12]}"
+
+        # Stable event ID shared between pending and complete SSE events
+        rec_event_id = f"agent_rec_{uuid4().hex[:12]}"
+        cart_items_for_sse = [
+            {"productId": ci.product_id, "name": ci.name, "price": ci.price}
+            for ci in payload.cart_items
+        ]
+
+        # Emit pending immediately so the Agent Activity Panel shows "Generating"
+        emit_recommendation_pending_event(
+            event_id=rec_event_id,
+            product_id=payload.product_id,
+            product_name=payload.product_name,
+            cart_items=cart_items_for_sse,
+        )
+
         started = time.perf_counter()
         result = await call_recommendation_agent(
             payload.product_id,
@@ -431,6 +513,30 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
             )
         result["recommendationRequestId"] = recommendation_request_id
         rec_count = len(result.get("recommendations", []))
+        latency_ms = int((time.perf_counter() - started) * 1000)
+
+        # Emit complete event — updates the pending card with results
+        emit_recommendation_complete_event(
+            event_id=rec_event_id,
+            product_id=payload.product_id,
+            product_name=payload.product_name,
+            cart_items=cart_items_for_sse,
+            recommendations=[
+                {
+                    "productId": rec.get("product_id") or rec.get("productId") or "",
+                    "productName": rec.get("product_name") or rec.get("productName") or "",
+                    "rank": rec.get("rank", idx + 1),
+                    "reasoning": rec.get("reasoning", ""),
+                }
+                for idx, rec in enumerate(raw_recommendations)
+            ],
+            user_intent=result.get("userIntent"),
+            pipeline_trace=result.get("pipelineTrace"),
+            recommendation_request_id=recommendation_request_id,
+            latency_ms=latency_ms,
+            error=error_message,
+        )
+
         return types.ServerResult(
             types.CallToolResult(
                 content=[
@@ -441,6 +547,89 @@ async def _handle_call_tool(req: types.CallToolRequest) -> types.ServerResult:
                 ],
                 structuredContent=result,
                 _meta=_recommendations_meta(),
+            )
+        )
+
+    if tool_name == "create-checkout-session":
+        payload = CreateCheckoutSessionInput.model_validate(args)
+        try:
+            result = await create_acp_session(
+                items=payload.items,
+                buyer=payload.buyer,
+                fulfillment_address=payload.fulfillment_address,
+                discounts=payload.discounts,
+            )
+            session_id = result.get("id", "")
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[
+                        types.TextContent(
+                            type="text",
+                            text=f"Checkout session {session_id} created",
+                        )
+                    ],
+                    structuredContent=result,
+                )
+            )
+        except Exception as e:
+            logger.exception("create-checkout-session failed")
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[
+                        types.TextContent(type="text", text=str(e))
+                    ],
+                    isError=True,
+                )
+            )
+
+    if tool_name == "update-checkout-session":
+        payload = UpdateCheckoutSessionInput.model_validate(args)
+        try:
+            result = await update_acp_session(
+                session_id=payload.session_id,
+                items=payload.items,
+                fulfillment_option_id=payload.fulfillment_option_id,
+                fulfillment_address=payload.fulfillment_address,
+                discounts=payload.discounts,
+            )
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[
+                        types.TextContent(
+                            type="text",
+                            text=f"Session {payload.session_id} updated",
+                        )
+                    ],
+                    structuredContent=result,
+                )
+            )
+        except Exception as e:
+            logger.exception("update-checkout-session failed for %s", payload.session_id)
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[
+                        types.TextContent(type="text", text=str(e))
+                    ],
+                    isError=True,
+                )
+            )
+
+    if tool_name == "track-recommendation-click":
+        payload = TrackRecommendationClickInput.model_validate(args)
+        await _record_recommendation_attribution_event(
+            event_type="click",
+            product_id=payload.product_id,
+            session_id=payload.session_id,
+            recommendation_request_id=payload.recommendation_request_id,
+            position=payload.position,
+            source=payload.source,
+        )
+        return types.ServerResult(
+            types.CallToolResult(
+                content=[
+                    types.TextContent(type="text", text="Click tracked")
+                ],
+                structuredContent={"recorded": True},
             )
         )
 
@@ -527,4 +716,10 @@ __all__ = [
     "GetRecommendationsOutput",
     "ProductOutput",
     "UserOutput",
+    "CreateCheckoutSessionInput",
+    "UpdateCheckoutSessionInput",
+    "TrackRecommendationClickInput",
+    # Shared ACP session functions.
+    "create_acp_session",
+    "update_acp_session",
 ]

--- a/src/apps_sdk/recommendation_helpers.py
+++ b/src/apps_sdk/recommendation_helpers.py
@@ -165,6 +165,52 @@ async def record_recommendation_attribution_event(
         )
 
 
+async def record_purchase_attribution(
+    cart_items: list[dict[str, Any]],
+    session_id: str,
+    order_id: str,
+) -> None:
+    """Record purchase attribution for cart items that originated from recommendations.
+
+    Items without a ``recommendationRequestId`` are silently skipped (they
+    were not recommended, so no attribution is needed).
+    """
+    for item in cart_items:
+        recommendation_request_id = item.get(
+            "recommendationRequestId"
+        ) or item.get("recommendation_request_id")
+        product_id = item.get("id") or item.get("productId")
+
+        if not isinstance(recommendation_request_id, str) or not recommendation_request_id:
+            continue
+        if not isinstance(product_id, str) or not product_id:
+            logger.debug("Skipping purchase attribution — missing product_id: %s", item)
+            continue
+
+        quantity_raw = item.get("quantity")
+        price_raw = (
+            item.get("basePrice") if "basePrice" in item else item.get("base_price")
+        )
+        quantity = (
+            quantity_raw if isinstance(quantity_raw, int) and quantity_raw > 0 else 1
+        )
+        unit_price = price_raw if isinstance(price_raw, int) and price_raw >= 0 else 0
+        position_raw = item.get("recommendationPosition")
+        position = position_raw if isinstance(position_raw, int) else None
+
+        await record_recommendation_attribution_event(
+            event_type="purchase",
+            product_id=product_id,
+            session_id=session_id,
+            recommendation_request_id=recommendation_request_id,
+            position=position,
+            order_id=order_id or None,
+            quantity=quantity,
+            revenue_cents=unit_price * quantity,
+            source="apps_sdk_checkout",
+        )
+
+
 def _parse_agent_response(raw_result: Any) -> dict[str, Any]:
     """Parse the ARAG agent response into a typed dictionary."""
     parsed: dict[str, Any] = {}

--- a/src/apps_sdk/recommendation_helpers.py
+++ b/src/apps_sdk/recommendation_helpers.py
@@ -165,6 +165,35 @@ async def record_recommendation_attribution_event(
         )
 
 
+def _parse_attribution_fields(
+    item: dict[str, Any],
+) -> tuple[str, str, int, int, int | None] | None:
+    """Extract and validate attribution fields from a cart item.
+
+    Returns ``(recommendation_request_id, product_id, quantity, unit_price, position)``
+    or ``None`` if the item is not attributable.
+    """
+    recommendation_request_id = item.get(
+        "recommendationRequestId"
+    ) or item.get("recommendation_request_id")
+    product_id = item.get("id") or item.get("productId")
+
+    if not isinstance(recommendation_request_id, str) or not recommendation_request_id:
+        return None
+    if not isinstance(product_id, str) or not product_id:
+        logger.debug("Skipping purchase attribution — missing product_id: %s", item)
+        return None
+
+    quantity_raw = item.get("quantity")
+    price_raw = item.get("basePrice") if "basePrice" in item else item.get("base_price")
+    quantity = quantity_raw if isinstance(quantity_raw, int) and quantity_raw > 0 else 1
+    unit_price = price_raw if isinstance(price_raw, int) and price_raw >= 0 else 0
+    position_raw = item.get("recommendationPosition")
+    position = position_raw if isinstance(position_raw, int) else None
+
+    return recommendation_request_id, product_id, quantity, unit_price, position
+
+
 async def record_purchase_attribution(
     cart_items: list[dict[str, Any]],
     session_id: str,
@@ -176,33 +205,15 @@ async def record_purchase_attribution(
     were not recommended, so no attribution is needed).
     """
     for item in cart_items:
-        recommendation_request_id = item.get(
-            "recommendationRequestId"
-        ) or item.get("recommendation_request_id")
-        product_id = item.get("id") or item.get("productId")
-
-        if not isinstance(recommendation_request_id, str) or not recommendation_request_id:
+        fields = _parse_attribution_fields(item)
+        if fields is None:
             continue
-        if not isinstance(product_id, str) or not product_id:
-            logger.debug("Skipping purchase attribution — missing product_id: %s", item)
-            continue
-
-        quantity_raw = item.get("quantity")
-        price_raw = (
-            item.get("basePrice") if "basePrice" in item else item.get("base_price")
-        )
-        quantity = (
-            quantity_raw if isinstance(quantity_raw, int) and quantity_raw > 0 else 1
-        )
-        unit_price = price_raw if isinstance(price_raw, int) and price_raw >= 0 else 0
-        position_raw = item.get("recommendationPosition")
-        position = position_raw if isinstance(position_raw, int) else None
-
+        rec_id, product_id, quantity, unit_price, position = fields
         await record_recommendation_attribution_event(
             event_type="purchase",
             product_id=product_id,
             session_id=session_id,
-            recommendation_request_id=recommendation_request_id,
+            recommendation_request_id=rec_id,
             position=position,
             order_id=order_id or None,
             quantity=quantity,

--- a/src/apps_sdk/recommendation_helpers.py
+++ b/src/apps_sdk/recommendation_helpers.py
@@ -173,9 +173,9 @@ def _parse_attribution_fields(
     Returns ``(recommendation_request_id, product_id, quantity, unit_price, position)``
     or ``None`` if the item is not attributable.
     """
-    recommendation_request_id = item.get(
-        "recommendationRequestId"
-    ) or item.get("recommendation_request_id")
+    recommendation_request_id = item.get("recommendationRequestId") or item.get(
+        "recommendation_request_id"
+    )
     product_id = item.get("id") or item.get("productId")
 
     if not isinstance(recommendation_request_id, str) or not recommendation_request_id:

--- a/src/apps_sdk/rest_endpoints.py
+++ b/src/apps_sdk/rest_endpoints.py
@@ -9,14 +9,11 @@ from uuid import uuid4
 import httpx
 from fastapi import APIRouter, HTTPException
 
-from src.apps_sdk.config import get_apps_sdk_settings
 from src.apps_sdk.events import (
-    checkout_events,
-    emit_agent_activity_event,
     emit_checkout_event,
 )
 from src.apps_sdk.recommendation_helpers import (
-    record_recommendation_attribution_event,
+    record_purchase_attribution,
 )
 from src.apps_sdk.schemas import (
     ACPCreateSessionRequest,
@@ -28,6 +25,11 @@ from src.apps_sdk.schemas import (
     ShippingUpdateRequest,
 )
 from src.apps_sdk.tools import add_to_cart, checkout
+from src.apps_sdk.tools.acp_sessions import (
+    ACPSessionError,
+    create_acp_session,
+    update_acp_session,
+)
 
 router = APIRouter()
 
@@ -42,7 +44,11 @@ active_sessions: dict[str, str] = {}  # cart_id -> session_id
 async def api_recommendation_click(
     request: RecommendationClickRequest,
 ) -> dict[str, bool]:
-    """Track a recommendation click event for attribution analytics."""
+    """Track a recommendation click event for attribution analytics.
+
+    .. deprecated::
+        Prefer the ``track-recommendation-click`` MCP tool for new integrations.
+    """
     await record_recommendation_attribution_event(
         event_type="click",
         product_id=request.product_id,
@@ -178,80 +184,18 @@ async def api_update_shipping(request: ShippingUpdateRequest) -> dict[str, Any]:
 
 @router.post("/acp/sessions", tags=["acp"])
 async def acp_create_session(request: ACPCreateSessionRequest) -> dict[str, Any]:
-    """Create a checkout session on the Merchant API."""
-    checkout_events.clear()
+    """Create a checkout session on the Merchant API.
 
-    settings = get_apps_sdk_settings()
-    merchant_api_url = settings.merchant_api_url
-    merchant_api_key = settings.merchant_api_key
-
+    .. deprecated::
+        Prefer the ``create-checkout-session`` MCP tool for new integrations.
+    """
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            body: dict[str, Any] = {"items": request.items}
-            if request.buyer:
-                body["buyer"] = request.buyer
-            if request.fulfillment_address:
-                body["fulfillment_address"] = request.fulfillment_address
-            if request.discounts is not None:
-                body["discounts"] = request.discounts
-
-            response = await client.post(
-                f"{merchant_api_url}/checkout_sessions",
-                headers={
-                    "Authorization": f"Bearer {merchant_api_key}",
-                    "Content-Type": "application/json",
-                },
-                json=body,
-            )
-
-            if response.status_code == 201:
-                data = response.json()
-                session_id = data.get("id", "")
-
-                emit_checkout_event(
-                    event_type="session_create",
-                    endpoint="/checkout_sessions",
-                    method="POST",
-                    status="success",
-                    summary=f"Session {session_id[-12:]} created",
-                    status_code=201,
-                    session_id=session_id,
-                )
-
-                line_items = data.get("line_items", [])
-                for line_item in line_items:
-                    promotion = line_item.get("promotion")
-                    if promotion:
-                        item_info = line_item.get("item", {})
-                        product_id = item_info.get("id", "unknown")
-                        product_name = line_item.get("name") or product_id
-                        stock_count = promotion.get("stock_count", 0)
-
-                        emit_agent_activity_event(
-                            agent_type="promotion",
-                            product_id=product_id,
-                            product_name=product_name,
-                            action=promotion.get("action", "NO_PROMO"),
-                            discount_amount=line_item.get("discount", 0),
-                            reason_codes=promotion.get("reason_codes", []),
-                            reasoning=promotion.get("reasoning", ""),
-                            stock_count=stock_count,
-                            base_price=line_item.get("base_amount", 0),
-                        )
-
-                return data
-
-            error_text = response.text
-            emit_checkout_event(
-                event_type="session_create",
-                endpoint="/checkout_sessions",
-                method="POST",
-                status="error",
-                summary=f"Failed: {response.status_code}",
-                status_code=response.status_code,
-            )
-            raise HTTPException(status_code=response.status_code, detail=error_text)
-
+        return await create_acp_session(
+            items=request.items,
+            buyer=request.buyer,
+            fulfillment_address=request.fulfillment_address,
+            discounts=request.discounts,
+        )
     except httpx.ConnectError as e:
         emit_checkout_event(
             event_type="session_create",
@@ -262,76 +206,27 @@ async def acp_create_session(request: ACPCreateSessionRequest) -> dict[str, Any]
             status_code=503,
         )
         raise HTTPException(status_code=503, detail=str(e)) from e
+    except ACPSessionError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
 
 
 @router.post("/acp/sessions/{session_id}", tags=["acp"])
 async def acp_update_session(
     session_id: str, request: ACPUpdateSessionRequest
 ) -> dict[str, Any]:
-    """Update a checkout session on the Merchant API."""
-    settings = get_apps_sdk_settings()
-    merchant_api_url = settings.merchant_api_url
-    merchant_api_key = settings.merchant_api_key
+    """Update a checkout session on the Merchant API.
 
-    update_parts: list[str] = []
-    if request.items:
-        update_parts.append(f"{len(request.items)} items")
-    if request.fulfillment_option_id:
-        update_parts.append("shipping")
-    if request.fulfillment_address:
-        update_parts.append("address")
-    if request.discounts is not None:
-        update_parts.append("discounts")
-    update_summary = ", ".join(update_parts) or "session"
-
+    .. deprecated::
+        Prefer the ``update-checkout-session`` MCP tool for new integrations.
+    """
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            body: dict[str, Any] = {}
-            if request.items is not None:
-                body["items"] = request.items
-            if request.fulfillment_option_id is not None:
-                body["fulfillment_option_id"] = request.fulfillment_option_id
-            if request.fulfillment_address is not None:
-                body["fulfillment_address"] = request.fulfillment_address
-            if request.discounts is not None:
-                body["discounts"] = request.discounts
-
-            response = await client.post(
-                f"{merchant_api_url}/checkout_sessions/{session_id}",
-                headers={
-                    "Authorization": f"Bearer {merchant_api_key}",
-                    "Content-Type": "application/json",
-                },
-                json=body,
-            )
-
-            if response.status_code == 200:
-                data = response.json()
-
-                emit_checkout_event(
-                    event_type="session_update",
-                    endpoint=f"/checkout_sessions/{session_id[-12:]}",
-                    method="POST",
-                    status="success",
-                    summary=f"Updated {update_summary}",
-                    status_code=200,
-                    session_id=session_id,
-                )
-
-                return data
-
-            error_text = response.text
-            emit_checkout_event(
-                event_type="session_update",
-                endpoint=f"/checkout_sessions/{session_id[-12:]}",
-                method="POST",
-                status="error",
-                summary=f"Failed: {response.status_code}",
-                status_code=response.status_code,
-                session_id=session_id,
-            )
-            raise HTTPException(status_code=response.status_code, detail=error_text)
-
+        return await update_acp_session(
+            session_id=session_id,
+            items=request.items,
+            fulfillment_option_id=request.fulfillment_option_id,
+            fulfillment_address=request.fulfillment_address,
+            discounts=request.discounts,
+        )
     except httpx.ConnectError as e:
         emit_checkout_event(
             event_type="session_update",
@@ -343,6 +238,8 @@ async def acp_update_session(
             session_id=session_id,
         )
         raise HTTPException(status_code=503, detail=str(e)) from e
+    except ACPSessionError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
 
 
 @router.post("/cart/sync", tags=["cart"])
@@ -377,7 +274,11 @@ async def api_sync_cart(request: CartCheckoutRequest) -> dict[str, Any]:
 
 @router.post("/cart/checkout", tags=["cart"])
 async def api_checkout(request: CartCheckoutRequest) -> dict[str, Any]:
-    """Process checkout after syncing cart state."""
+    """Process checkout after syncing cart state.
+
+    .. deprecated::
+        Prefer the ``checkout`` MCP tool (with cartItems/customerName) for new integrations.
+    """
     from src.apps_sdk.tools.cart import carts
 
     cart_id = request.cart_id or f"cart_{uuid4().hex[:12]}"
@@ -400,44 +301,10 @@ async def api_checkout(request: CartCheckoutRequest) -> dict[str, Any]:
 
     result = await checkout(cart_id, customer_name=request.customer_name)
 
-    if result.get("success") is True:
-        order_id = str(result.get("orderId") or "")
-        for item in request.cart_items:
-            recommendation_request_id = item.get("recommendationRequestId") or item.get(
-                "recommendation_request_id"
-            )
-            product_id = item.get("id") or item.get("productId")
-            if (
-                not isinstance(recommendation_request_id, str)
-                or not recommendation_request_id
-            ):
-                continue
-            if not isinstance(product_id, str) or not product_id:
-                continue
-            quantity_raw = item.get("quantity")
-            price_raw = (
-                item.get("basePrice") if "basePrice" in item else item.get("base_price")
-            )
-            quantity = (
-                quantity_raw
-                if isinstance(quantity_raw, int) and quantity_raw > 0
-                else 1
-            )
-            unit_price = (
-                price_raw if isinstance(price_raw, int) and price_raw >= 0 else 0
-            )
-            position_raw = item.get("recommendationPosition")
-            position = position_raw if isinstance(position_raw, int) else None
-
-            await record_recommendation_attribution_event(
-                event_type="purchase",
-                product_id=product_id,
-                session_id=request.cart_id,
-                recommendation_request_id=recommendation_request_id,
-                position=position,
-                order_id=order_id or None,
-                quantity=quantity,
-                revenue_cents=unit_price * quantity,
-                source="apps_sdk_checkout",
-            )
+    if result.get("success"):
+        await record_purchase_attribution(
+            cart_items=request.cart_items,
+            session_id=request.cart_id,
+            order_id=str(result.get("orderId") or ""),
+        )
     return result

--- a/src/apps_sdk/rest_endpoints.py
+++ b/src/apps_sdk/rest_endpoints.py
@@ -228,10 +228,12 @@ async def acp_update_session(
             fulfillment_address=request.fulfillment_address,
             discounts=request.discounts,
         )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except httpx.ConnectError as e:
         emit_checkout_event(
             event_type="session_update",
-            endpoint=f"/checkout_sessions/{session_id[-12:]}",
+            endpoint="/checkout_sessions/<session>",
             method="POST",
             status="error",
             summary="Connection failed",

--- a/src/apps_sdk/rest_endpoints.py
+++ b/src/apps_sdk/rest_endpoints.py
@@ -14,6 +14,7 @@ from src.apps_sdk.events import (
 )
 from src.apps_sdk.recommendation_helpers import (
     record_purchase_attribution,
+    record_recommendation_attribution_event,
 )
 from src.apps_sdk.schemas import (
     ACPCreateSessionRequest,

--- a/src/apps_sdk/schemas.py
+++ b/src/apps_sdk/schemas.py
@@ -50,6 +50,16 @@ class CheckoutInput(BaseModel):
     """Schema for checkout tool."""
 
     cart_id: str = Field(..., alias="cartId", description="Cart ID to checkout")
+    cart_items: list[dict[str, Any]] | None = Field(
+        None,
+        alias="cartItems",
+        description="Optional cart items to sync before checkout (widget use case)",
+    )
+    customer_name: str | None = Field(
+        None,
+        alias="customerName",
+        description="Optional customer name for personalized messages",
+    )
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -322,3 +332,51 @@ class ACPUpdateSessionRequest(BaseModel):
     discounts: dict[str, list[str]] | None = Field(None)
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+# =============================================================================
+# MCP Tool Input Schemas (used by callTool from widget)
+# =============================================================================
+
+
+class CreateCheckoutSessionInput(BaseModel):
+    """Schema for create-checkout-session MCP tool."""
+
+    items: list[dict[str, Any]] = Field(..., description="Items with id and quantity")
+    buyer: dict[str, str] | None = Field(None, description="Buyer info (first_name, last_name, email)")
+    fulfillment_address: dict[str, str] | None = Field(
+        None, alias="fulfillmentAddress", description="Shipping address"
+    )
+    discounts: dict[str, list[str]] | None = Field(None, description="Discount codes")
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class UpdateCheckoutSessionInput(BaseModel):
+    """Schema for update-checkout-session MCP tool."""
+
+    session_id: str = Field(..., alias="sessionId", description="Session ID to update")
+    items: list[dict[str, Any]] | None = Field(None, description="Updated items")
+    fulfillment_option_id: str | None = Field(
+        None, alias="fulfillmentOptionId", description="Selected fulfillment option"
+    )
+    fulfillment_address: dict[str, str] | None = Field(
+        None, alias="fulfillmentAddress", description="Updated shipping address"
+    )
+    discounts: dict[str, list[str]] | None = Field(None, description="Discount codes")
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class TrackRecommendationClickInput(BaseModel):
+    """Schema for track-recommendation-click MCP tool."""
+
+    product_id: str = Field(..., alias="productId", description="Clicked product ID")
+    recommendation_request_id: str = Field(
+        ..., alias="recommendationRequestId", description="Recommendation request ID for attribution"
+    )
+    session_id: str | None = Field(None, alias="sessionId", description="Cart/session ID")
+    position: int | None = Field(None, description="Position in recommendation list")
+    source: str = Field(default="apps_sdk_widget", description="Click source identifier")
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")

--- a/src/apps_sdk/schemas.py
+++ b/src/apps_sdk/schemas.py
@@ -343,7 +343,9 @@ class CreateCheckoutSessionInput(BaseModel):
     """Schema for create-checkout-session MCP tool."""
 
     items: list[dict[str, Any]] = Field(..., description="Items with id and quantity")
-    buyer: dict[str, str] | None = Field(None, description="Buyer info (first_name, last_name, email)")
+    buyer: dict[str, str] | None = Field(
+        None, description="Buyer info (first_name, last_name, email)"
+    )
     fulfillment_address: dict[str, str] | None = Field(
         None, alias="fulfillmentAddress", description="Shipping address"
     )
@@ -373,10 +375,16 @@ class TrackRecommendationClickInput(BaseModel):
 
     product_id: str = Field(..., alias="productId", description="Clicked product ID")
     recommendation_request_id: str = Field(
-        ..., alias="recommendationRequestId", description="Recommendation request ID for attribution"
+        ...,
+        alias="recommendationRequestId",
+        description="Recommendation request ID for attribution",
     )
-    session_id: str | None = Field(None, alias="sessionId", description="Cart/session ID")
+    session_id: str | None = Field(
+        None, alias="sessionId", description="Cart/session ID"
+    )
     position: int | None = Field(None, description="Position in recommendation list")
-    source: str = Field(default="apps_sdk_widget", description="Click source identifier")
+    source: str = Field(
+        default="apps_sdk_widget", description="Click source identifier"
+    )
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")

--- a/src/apps_sdk/tools/__init__.py
+++ b/src/apps_sdk/tools/__init__.py
@@ -8,8 +8,14 @@ This module exports all available tools for the MCP server:
 - get_cart: Get cart contents
 - update_cart_quantity: Update item quantity in cart
 - checkout: Process checkout via ACP payment flow
+- create_acp_session / update_acp_session: ACP session management
 """
 
+from src.apps_sdk.tools.acp_sessions import (
+    ACPSessionError,
+    create_acp_session,
+    update_acp_session,
+)
 from src.apps_sdk.tools.cart import (
     add_to_cart,
     get_cart,
@@ -26,4 +32,7 @@ __all__ = [
     "get_cart",
     "update_cart_quantity",
     "checkout",
+    "ACPSessionError",
+    "create_acp_session",
+    "update_acp_session",
 ]

--- a/src/apps_sdk/tools/acp_sessions.py
+++ b/src/apps_sdk/tools/acp_sessions.py
@@ -7,6 +7,7 @@ on the Merchant API. Both MCP tool handlers and REST endpoints delegate here.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import httpx
@@ -18,6 +19,9 @@ from src.apps_sdk.events import (
 )
 
 logger = logging.getLogger("src.apps_sdk.main")
+
+#: Session IDs are UUIDs or short hex tokens — reject anything else.
+_SAFE_SESSION_ID = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class ACPSessionError(Exception):
@@ -152,7 +156,10 @@ async def update_acp_session(
     Raises:
         httpx.ConnectError: When the Merchant API is unreachable.
         ACPSessionError: For non-200 responses (carries the HTTP status code).
+        ValueError: If ``session_id`` contains unsafe characters.
     """
+    if not _SAFE_SESSION_ID.match(session_id):
+        raise ValueError(f"Invalid session_id: {session_id!r}")
     settings = get_apps_sdk_settings()
     merchant_api_url = settings.merchant_api_url
     merchant_api_key = settings.merchant_api_key

--- a/src/apps_sdk/tools/acp_sessions.py
+++ b/src/apps_sdk/tools/acp_sessions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any
+from urllib.parse import quote as url_quote
 
 import httpx
 
@@ -186,8 +187,9 @@ async def update_acp_session(
         if discounts is not None:
             body["discounts"] = discounts
 
+        safe_id = url_quote(session_id, safe="")
         response = await client.post(
-            f"{merchant_api_url}/checkout_sessions/{session_id}",
+            f"{merchant_api_url}/checkout_sessions/{safe_id}",
             headers={
                 "Authorization": f"Bearer {merchant_api_key}",
                 "Content-Type": "application/json",

--- a/src/apps_sdk/tools/acp_sessions.py
+++ b/src/apps_sdk/tools/acp_sessions.py
@@ -1,0 +1,219 @@
+"""Shared ACP session logic for both MCP tools and REST endpoints.
+
+Provides reusable functions for creating and updating checkout sessions
+on the Merchant API. Both MCP tool handlers and REST endpoints delegate here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from src.apps_sdk.config import get_apps_sdk_settings
+from src.apps_sdk.events import (
+    emit_agent_activity_event,
+    emit_checkout_event,
+)
+
+logger = logging.getLogger("src.apps_sdk.main")
+
+
+class ACPSessionError(Exception):
+    """Raised when a Merchant API checkout session request fails."""
+
+    def __init__(self, message: str, status_code: int) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+async def create_acp_session(
+    items: list[dict[str, Any]],
+    buyer: dict[str, str] | None = None,
+    fulfillment_address: dict[str, str] | None = None,
+    discounts: dict[str, list[str]] | None = None,
+) -> dict[str, Any]:
+    """Create a checkout session on the Merchant API.
+
+    Clears the checkout event history before creating a new session so
+    the Protocol Inspector shows a clean timeline per checkout flow.
+
+    Args:
+        items: Line items with ``id`` and ``quantity``.
+        buyer: Optional buyer information.
+        fulfillment_address: Optional shipping address.
+        discounts: Optional discount codes.
+
+    Returns:
+        The full session response from the Merchant API.
+
+    Raises:
+        httpx.ConnectError: When the Merchant API is unreachable.
+        ACPSessionError: For non-201 responses (carries the HTTP status code).
+    """
+    from src.apps_sdk.events import checkout_events
+
+    checkout_events.clear()
+
+    settings = get_apps_sdk_settings()
+    merchant_api_url = settings.merchant_api_url
+    merchant_api_key = settings.merchant_api_key
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        body: dict[str, Any] = {"items": items}
+        if buyer:
+            body["buyer"] = buyer
+        if fulfillment_address:
+            body["fulfillment_address"] = fulfillment_address
+        if discounts is not None:
+            body["discounts"] = discounts
+
+        response = await client.post(
+            f"{merchant_api_url}/checkout_sessions",
+            headers={
+                "Authorization": f"Bearer {merchant_api_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+        )
+
+        if response.status_code == 201:
+            data = response.json()
+            session_id = data.get("id", "")
+
+            emit_checkout_event(
+                event_type="session_create",
+                endpoint="/checkout_sessions",
+                method="POST",
+                status="success",
+                summary=f"Session {session_id[-12:]} created",
+                status_code=201,
+                session_id=session_id,
+            )
+
+            line_items = data.get("line_items", [])
+            for line_item in line_items:
+                promotion = line_item.get("promotion")
+                if promotion:
+                    item_info = line_item.get("item", {})
+                    product_id = item_info.get("id", "unknown")
+                    product_name = line_item.get("name") or product_id
+                    stock_count = promotion.get("stock_count", 0)
+
+                    emit_agent_activity_event(
+                        agent_type="promotion",
+                        product_id=product_id,
+                        product_name=product_name,
+                        action=promotion.get("action", "NO_PROMO"),
+                        discount_amount=line_item.get("discount", 0),
+                        reason_codes=promotion.get("reason_codes", []),
+                        reasoning=promotion.get("reasoning", ""),
+                        stock_count=stock_count,
+                        base_price=line_item.get("base_amount", 0),
+                    )
+
+            return data
+
+        error_text = response.text
+        emit_checkout_event(
+            event_type="session_create",
+            endpoint="/checkout_sessions",
+            method="POST",
+            status="error",
+            summary=f"Failed: {response.status_code}",
+            status_code=response.status_code,
+        )
+        raise ACPSessionError(
+            f"Failed to create checkout session: {response.status_code} {error_text}",
+            status_code=response.status_code,
+        )
+
+
+async def update_acp_session(
+    session_id: str,
+    items: list[dict[str, Any]] | None = None,
+    fulfillment_option_id: str | None = None,
+    fulfillment_address: dict[str, str] | None = None,
+    discounts: dict[str, list[str]] | None = None,
+) -> dict[str, Any]:
+    """Update a checkout session on the Merchant API.
+
+    Args:
+        session_id: The session to update.
+        items: Optional updated line items.
+        fulfillment_option_id: Optional selected shipping option.
+        fulfillment_address: Optional updated shipping address.
+        discounts: Optional discount codes.
+
+    Returns:
+        The updated session response from the Merchant API.
+
+    Raises:
+        httpx.ConnectError: When the Merchant API is unreachable.
+        ACPSessionError: For non-200 responses (carries the HTTP status code).
+    """
+    settings = get_apps_sdk_settings()
+    merchant_api_url = settings.merchant_api_url
+    merchant_api_key = settings.merchant_api_key
+
+    update_parts: list[str] = []
+    if items:
+        update_parts.append(f"{len(items)} items")
+    if fulfillment_option_id:
+        update_parts.append("shipping")
+    if fulfillment_address:
+        update_parts.append("address")
+    if discounts is not None:
+        update_parts.append("discounts")
+    update_summary = ", ".join(update_parts) or "session"
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        body: dict[str, Any] = {}
+        if items is not None:
+            body["items"] = items
+        if fulfillment_option_id is not None:
+            body["fulfillment_option_id"] = fulfillment_option_id
+        if fulfillment_address is not None:
+            body["fulfillment_address"] = fulfillment_address
+        if discounts is not None:
+            body["discounts"] = discounts
+
+        response = await client.post(
+            f"{merchant_api_url}/checkout_sessions/{session_id}",
+            headers={
+                "Authorization": f"Bearer {merchant_api_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+        )
+
+        if response.status_code == 200:
+            data = response.json()
+
+            emit_checkout_event(
+                event_type="session_update",
+                endpoint=f"/checkout_sessions/{session_id[-12:]}",
+                method="POST",
+                status="success",
+                summary=f"Updated {update_summary}",
+                status_code=200,
+                session_id=session_id,
+            )
+
+            return data
+
+        error_text = response.text
+        emit_checkout_event(
+            event_type="session_update",
+            endpoint=f"/checkout_sessions/{session_id[-12:]}",
+            method="POST",
+            status="error",
+            summary=f"Failed: {response.status_code}",
+            status_code=response.status_code,
+            session_id=session_id,
+        )
+        raise ACPSessionError(
+            f"Failed to update checkout session: {response.status_code} {error_text}",
+            status_code=response.status_code,
+        )

--- a/src/apps_sdk/web/src/App.tsx
+++ b/src/apps_sdk/web/src/App.tsx
@@ -5,7 +5,7 @@ import { RecommendationCarousel } from "@/components/RecommendationCarousel";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { ProductDetailPage } from "@/components/ProductDetailPage";
 import { CheckoutPage } from "@/components/CheckoutPage";
-import { useToolOutput } from "@/hooks";
+import { useToolOutput, useWidgetState } from "@/hooks";
 import type {
   Product,
   MerchantUser,
@@ -20,6 +20,25 @@ import { cartStateFromSession, EMPTY_CART_STATE } from "@/types";
  * Widget page state for navigation
  */
 type WidgetPage = "browse" | "product_detail" | "checkout";
+
+/**
+ * State that persists across widget remounts via useWidgetState.
+ * Only includes what needs to survive — transient UI state stays in useState.
+ */
+interface PersistedWidgetState {
+  cartItems: CartItem[];
+  sessionId: string | null;
+  currentPage: WidgetPage;
+  selectedProductId: string | null;
+  [key: string]: unknown;
+}
+
+const DEFAULT_PERSISTED_STATE: PersistedWidgetState = {
+  cartItems: [],
+  sessionId: null,
+  currentPage: "browse",
+  selectedProductId: null,
+};
 
 // Default mock data for standalone mode
 const DEFAULT_USER: MerchantUser = {
@@ -65,11 +84,76 @@ const DEFAULT_RECOMMENDATIONS: Product[] = [
   },
 ];
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Map raw recommendation agent output to Product[] for display.
+ * Shared by both product-detail and checkout recommendation flows.
+ */
+type EnrichedRec = {
+  productId?: string;
+  product_id?: string;
+  productName?: string;
+  product_name?: string;
+  price?: number;
+  sku?: string;
+  image_url?: string;
+  stock_count?: number;
+  rank: number;
+};
+
+function mapRecommendationsToProducts(
+  recommendations: EnrichedRec[],
+  recommendationRequestId: string | undefined,
+  source: string
+): Product[] {
+  if (!recommendations || recommendations.length === 0) return [];
+  return recommendations.map((rec, index) => ({
+    id: rec.productId ?? rec.product_id ?? `prod_${Date.now()}`,
+    sku: rec.sku ?? `SKU-${rec.productId ?? rec.product_id}`,
+    name: rec.productName ?? rec.product_name ?? "Product",
+    basePrice: rec.price ?? 2500,
+    stockCount: rec.stock_count ?? 100,
+    variant: "Default",
+    size: "One Size",
+    imageUrl: rec.image_url,
+    recommendationRequestId,
+    recommendationPosition: typeof rec.rank === "number" ? rec.rank : index + 1,
+    recommendationSource: source,
+  }));
+}
+
+/**
+ * Call window.openai.callTool and parse the JSON result.
+ * In production the real host provides this; in dev the simulated bridge
+ * routes to the MCP server via JSON-RPC (see main.tsx).
+ */
+async function callTool<T = Record<string, unknown>>(
+  name: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  if (!window.openai?.callTool) {
+    throw new Error("window.openai.callTool not available");
+  }
+  const response = await window.openai.callTool(name, args);
+  try {
+    return JSON.parse(response.result) as T;
+  } catch {
+    throw new Error(`Failed to parse ${name} response: ${response.result.slice(0, 200)}`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main App Component
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
  * Main App Component
  *
  * The merchant widget app that provides a full shopping experience.
- * Works in both standalone (simulated bridge) and production (real bridge) modes.
+ * All communication with the MCP server goes through window.openai.callTool().
  * Supports light/dark mode theming via @openai/apps-sdk-ui.
  */
 export function App() {
@@ -91,85 +175,98 @@ export function App() {
   const emptyStateMessage =
     toolError ?? "No products found. Try a different search or browse trending items.";
 
-  // Page navigation state
-  const [currentPage, setCurrentPage] = useState<WidgetPage>("browse");
+  // ── Persisted state (survives widget remount) ──────────────────────────
+  const [persisted, setPersisted] = useWidgetState<PersistedWidgetState>(DEFAULT_PERSISTED_STATE);
+
+  // Convenience updaters that merge into persisted state
+  const updateCartItems = useCallback(
+    (items: CartItem[]) => setPersisted((prev) => ({ ...prev, cartItems: items })),
+    [setPersisted]
+  );
+  const updateSessionId = useCallback(
+    (id: string | null) => setPersisted((prev) => ({ ...prev, sessionId: id })),
+    [setPersisted]
+  );
+  const updateCurrentPage = useCallback(
+    (page: WidgetPage, productId?: string | null) =>
+      setPersisted((prev) => ({
+        ...prev,
+        currentPage: page,
+        selectedProductId: productId !== undefined ? productId : prev.selectedProductId,
+      })),
+    [setPersisted]
+  );
+
+  // Derive frequently used values
+  const cartItems = persisted.cartItems;
+  const sessionId = persisted.sessionId;
+  const currentPage = persisted.currentPage;
+
+  // ── Transient state (OK to lose on remount) ────────────────────────────
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [productRecommendations, setProductRecommendations] = useState<Product[]>([]);
   const [isLoadingRecommendations, setIsLoadingRecommendations] = useState(false);
-  
-  // Checkout-specific recommendations
   const [checkoutRecommendations, setCheckoutRecommendations] = useState<Product[]>([]);
   const [isLoadingCheckoutRecommendations, setIsLoadingCheckoutRecommendations] = useState(false);
-
-  // Cart state - totals come from backend ACP session
-  const [cartItems, setCartItems] = useState<CartItem[]>([]);
   const [cartState, setCartState] = useState<CartState>(EMPTY_CART_STATE);
-  // Track pending backend updates to show loading state
   const [isPendingCartUpdate, setIsPendingCartUpdate] = useState(false);
-
-  // Checkout state
   const [isCheckingOut, setIsCheckingOut] = useState(false);
-  const [checkoutResult, setCheckoutResult] = useState<CheckoutResult | null>(
-    null
-  );
-
-  // ACP session state
-  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [checkoutResult, setCheckoutResult] = useState<CheckoutResult | null>(null);
   const [acpSession, setAcpSession] = useState<ACPSessionResponse | null>(null);
 
-  // API base URL - handles dev server, Docker (via nginx), and direct access
-  const getApiBaseUrl = useCallback(() => {
-    const isViteDevServer = window.location.port === "3001" || window.location.port === "3002";
-    const isAppsSdkPath = window.location.pathname.startsWith("/apps-sdk/");
-    
-    if (isViteDevServer) {
-      // Local dev with Vite - call Apps SDK directly
-      return "http://localhost:2091";
-    } else if (isAppsSdkPath) {
-      // Running via nginx proxy - use relative path to apps-sdk
-      return "/apps-sdk";
-    } else {
-      // Fallback - assume running directly on Apps SDK server
-      return "";
+  // ── Re-sync ACP session on mount if persisted cart is non-empty ─────────
+  useEffect(() => {
+    let mounted = true;
+    if (cartItems.length > 0 && !acpSession) {
+      void (async () => {
+        setIsPendingCartUpdate(true);
+        try {
+          const { sessionId: newSid, sessionData } = await syncCheckoutSession(
+            cartItems,
+            sessionId
+          );
+          if (!mounted) return;
+          if (newSid !== sessionId) updateSessionId(newSid);
+          if (sessionData) setAcpSession(sessionData);
+        } finally {
+          if (mounted) setIsPendingCartUpdate(false);
+        }
+      })();
     }
+    return () => { mounted = false; };
+    // Only run once on mount — intentionally omitting deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // ── Track recommendation click via callTool ─────────────────────────────
   const trackRecommendationClick = useCallback(
     async (product: Product) => {
-      if (!product.recommendationRequestId) {
-        return;
-      }
+      if (!product.recommendationRequestId) return;
       try {
-        const apiBaseUrl = getApiBaseUrl();
-        await fetch(`${apiBaseUrl}/recommendations/click`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            productId: product.id,
-            recommendationRequestId: product.recommendationRequestId,
-            sessionId: cartState.cartId || sessionId || undefined,
-            position: product.recommendationPosition,
-            source: product.recommendationSource ?? "apps_sdk_widget",
-          }),
+        await callTool("track-recommendation-click", {
+          productId: product.id,
+          recommendationRequestId: product.recommendationRequestId,
+          sessionId: cartState.cartId || sessionId || undefined,
+          position: product.recommendationPosition,
+          source: product.recommendationSource ?? "apps_sdk_widget",
         });
       } catch (error) {
         console.warn("[Widget] Failed to track recommendation click:", error);
       }
     },
-    [getApiBaseUrl, cartState.cartId, sessionId]
+    [cartState.cartId, sessionId]
   );
 
-  // Create or update ACP checkout session
+  // ── ACP session management via callTool ─────────────────────────────────
   const syncCheckoutSession = useCallback(
-    async (items: CartItem[], currentSessionId: string | null): Promise<{sessionId: string | null; sessionData: ACPSessionResponse | null}> => {
+    async (
+      items: CartItem[],
+      currentSessionId: string | null
+    ): Promise<{ sessionId: string | null; sessionData: ACPSessionResponse | null }> => {
       if (items.length === 0) {
-        // No items, no session needed
         return { sessionId: null, sessionData: null };
       }
 
-      const apiBaseUrl = getApiBaseUrl();
       const acpItems = items.map((item) => ({
         id: item.id,
         quantity: item.quantity,
@@ -177,74 +274,57 @@ export function App() {
 
       try {
         if (currentSessionId) {
-          // Update existing session
           console.log("[Widget] Updating ACP session:", currentSessionId);
-          const response = await fetch(`${apiBaseUrl}/acp/sessions/${currentSessionId}`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
+          try {
+            const data = await callTool<ACPSessionResponse>("update-checkout-session", {
               sessionId: currentSessionId,
               items: acpItems,
-            }),
-          });
-
-          if (response.ok) {
-            const data = await response.json() as ACPSessionResponse;
-            console.log("[Widget] ACP session updated with promotion data:", data.line_items?.map(li => li.promotion));
+            });
+            console.log("[Widget] ACP session updated with promotion data:", data.line_items?.map((li) => li.promotion));
             return { sessionId: data.id || currentSessionId, sessionData: data };
-          } else {
-            // Session might be invalid, create a new one
+          } catch {
             console.warn("[Widget] Session update failed, creating new session");
           }
         }
 
         // Create new session
         console.log("[Widget] Creating new ACP session");
-        const response = await fetch(`${apiBaseUrl}/acp/sessions`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            items: acpItems,
-            buyer: {
-              first_name: "John",
-              last_name: "Doe",
-              email: "john@example.com",
-            },
-            fulfillmentAddress: {
-              name: "John Doe",
-              line_one: "123 AI Boulevard",
-              city: "San Francisco",
-              state: "CA",
-              postal_code: "94102",
-              country: "US",
-            },
-          }),
+        const data = await callTool<ACPSessionResponse>("create-checkout-session", {
+          items: acpItems,
+          buyer: {
+            first_name: "John",
+            last_name: "Doe",
+            email: "john@example.com",
+          },
+          fulfillmentAddress: {
+            name: "John Doe",
+            line_one: "123 AI Boulevard",
+            city: "San Francisco",
+            state: "CA",
+            postal_code: "94102",
+            country: "US",
+          },
         });
-
-        if (response.ok) {
-          const data = await response.json() as ACPSessionResponse;
-          console.log("[Widget] ACP session created:", data.id);
-          console.log("[Widget] Promotion data:", data.line_items?.map(li => li.promotion));
-          return { sessionId: data.id, sessionData: data };
-        }
+        console.log("[Widget] ACP session created:", data.id);
+        console.log("[Widget] Promotion data:", data.line_items?.map((li) => li.promotion));
+        return { sessionId: data.id, sessionData: data };
       } catch (error) {
         console.warn("[Widget] Failed to sync ACP session:", error);
       }
 
       return { sessionId: currentSessionId, sessionData: null };
     },
-    [getApiBaseUrl]
+    []
   );
 
   // Notify server of cart updates via ACP
   const notifyCartUpdate = useCallback(
     async (items: CartItem[]) => {
-      // Mark as pending to show loading state while backend calculates
       setIsPendingCartUpdate(true);
       try {
         const { sessionId: newSessionId, sessionData } = await syncCheckoutSession(items, sessionId);
         if (newSessionId !== sessionId) {
-          setSessionId(newSessionId);
+          updateSessionId(newSessionId);
         }
         if (sessionData) {
           setAcpSession(sessionData);
@@ -253,409 +333,317 @@ export function App() {
         setIsPendingCartUpdate(false);
       }
     },
-    [sessionId, syncCheckoutSession]
+    [sessionId, syncCheckoutSession, updateSessionId]
   );
 
-  // Update shipping option via ACP - backend recalculates totals
+  // ── Shipping update via callTool ────────────────────────────────────────
   const handleShippingUpdate = useCallback(
     async (fulfillmentOptionId: string) => {
       if (!sessionId) {
         console.warn("[Widget] No session ID for shipping update");
         return;
       }
-
-      const apiBaseUrl = getApiBaseUrl();
       try {
         console.log("[Widget] Updating shipping to:", fulfillmentOptionId);
-        const response = await fetch(`${apiBaseUrl}/acp/sessions/${sessionId}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            sessionId,
-            fulfillmentOptionId,
-          }),
+        const data = await callTool<ACPSessionResponse>("update-checkout-session", {
+          sessionId,
+          fulfillmentOptionId,
         });
-
-        if (response.ok) {
-          const data = await response.json() as ACPSessionResponse;
-          console.log("[Widget] Shipping updated, new totals:", data.totals);
-          setAcpSession(data);
-        } else {
-          console.error("[Widget] Shipping update failed:", response.status);
-        }
+        console.log("[Widget] Shipping updated, new totals:", data.totals);
+        setAcpSession(data);
       } catch (error) {
         console.error("[Widget] Failed to update shipping:", error);
         throw error;
       }
     },
-    [sessionId, getApiBaseUrl]
+    [sessionId]
   );
 
-  // Apply coupon code via ACP session update
+  // ── Coupon via callTool ─────────────────────────────────────────────────
   const handleApplyCoupon = useCallback(
     async (couponCode: string) => {
       if (!sessionId) {
         console.warn("[Widget] No session ID for coupon update");
         return;
       }
-
-      const apiBaseUrl = getApiBaseUrl();
       const normalized = couponCode.trim().toUpperCase();
       try {
-        const response = await fetch(`${apiBaseUrl}/acp/sessions/${sessionId}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            sessionId,
-            discounts: {
-              codes: normalized ? [normalized] : [],
-            },
-          }),
+        const data = await callTool<ACPSessionResponse>("update-checkout-session", {
+          sessionId,
+          discounts: { codes: normalized ? [normalized] : [] },
         });
-
-        if (response.ok) {
-          const data = (await response.json()) as ACPSessionResponse;
-          setAcpSession(data);
-        } else {
-          console.error("[Widget] Coupon update failed:", response.status);
-        }
+        setAcpSession(data);
       } catch (error) {
         console.error("[Widget] Failed to update coupon:", error);
         throw error;
       }
     },
-    [sessionId, getApiBaseUrl]
+    [sessionId]
   );
 
-  // Update cart state when ACP session changes - totals come from backend
+  // ── Derive cart state from ACP session ──────────────────────────────────
   useEffect(() => {
     const newCartState = cartStateFromSession(acpSession, cartItems, sessionId || "");
-    // Override isCalculating if we're waiting for a backend update
     if (isPendingCartUpdate) {
       newCartState.isCalculating = true;
     }
     setCartState(newCartState);
   }, [acpSession, cartItems, sessionId, isPendingCartUpdate]);
 
-  // Add item to cart
+  // ── Cart operations ─────────────────────────────────────────────────────
   const handleAddToCart = useCallback(
     (product: Product) => {
       void trackRecommendationClick(product);
-      setCartItems((prev) => {
-        const existingItem = prev.find((item) => item.id === product.id);
-        let newItems: CartItem[];
-        if (existingItem) {
-          newItems = prev.map((item) =>
-            item.id === product.id
-              ? {
-                  ...item,
-                  quantity: item.quantity + 1,
-                  recommendationRequestId:
-                    item.recommendationRequestId ?? product.recommendationRequestId,
-                  recommendationPosition:
-                    item.recommendationPosition ?? product.recommendationPosition,
-                  recommendationSource:
-                    item.recommendationSource ?? product.recommendationSource,
-                }
-              : item
-          );
-        } else {
-          newItems = [
-            ...prev,
-            {
-              id: product.id,
-              name: product.name,
-              basePrice: product.basePrice,
-              quantity: 1,
-              variant: product.variant,
-              size: product.size,
-              recommendationRequestId: product.recommendationRequestId,
-              recommendationPosition: product.recommendationPosition,
-              recommendationSource: product.recommendationSource,
-            },
-          ];
-        }
-        // Notify server after state update
-        notifyCartUpdate(newItems);
-        return newItems;
-      });
+      const existingItem = cartItems.find((item) => item.id === product.id);
+      let newItems: CartItem[];
+      if (existingItem) {
+        newItems = cartItems.map((item) =>
+          item.id === product.id
+            ? {
+                ...item,
+                quantity: item.quantity + 1,
+                recommendationRequestId:
+                  item.recommendationRequestId ?? product.recommendationRequestId,
+                recommendationPosition:
+                  item.recommendationPosition ?? product.recommendationPosition,
+                recommendationSource:
+                  item.recommendationSource ?? product.recommendationSource,
+              }
+            : item
+        );
+      } else {
+        newItems = [
+          ...cartItems,
+          {
+            id: product.id,
+            name: product.name,
+            basePrice: product.basePrice,
+            quantity: 1,
+            variant: product.variant,
+            size: product.size,
+            recommendationRequestId: product.recommendationRequestId,
+            recommendationPosition: product.recommendationPosition,
+            recommendationSource: product.recommendationSource,
+          },
+        ];
+      }
+      updateCartItems(newItems);
+      notifyCartUpdate(newItems);
     },
-    [notifyCartUpdate, trackRecommendationClick]
+    [cartItems, notifyCartUpdate, trackRecommendationClick, updateCartItems]
   );
 
-  // Update item quantity
   const handleUpdateQuantity = useCallback(
     (productId: string, quantity: number) => {
-      setCartItems((prev) => {
-        let newItems: CartItem[];
-        if (quantity <= 0) {
-          newItems = prev.filter((item) => item.id !== productId);
-        } else {
-          newItems = prev.map((item) =>
-            item.id === productId ? { ...item, quantity } : item
-          );
-        }
-        // Notify server after state update
-        notifyCartUpdate(newItems);
-        return newItems;
-      });
+      let newItems: CartItem[];
+      if (quantity <= 0) {
+        newItems = cartItems.filter((item) => item.id !== productId);
+      } else {
+        newItems = cartItems.map((item) =>
+          item.id === productId ? { ...item, quantity } : item
+        );
+      }
+      updateCartItems(newItems);
+      notifyCartUpdate(newItems);
     },
-    [notifyCartUpdate]
+    [cartItems, notifyCartUpdate, updateCartItems]
   );
 
-  // Remove item from cart
-  const handleRemoveItem = useCallback((productId: string) => {
-    setCartItems((prev) => {
-      const newItems = prev.filter((item) => item.id !== productId);
+  const handleRemoveItem = useCallback(
+    (productId: string) => {
+      const newItems = cartItems.filter((item) => item.id !== productId);
+      updateCartItems(newItems);
       notifyCartUpdate(newItems);
-      return newItems;
-    });
-  }, [notifyCartUpdate]);
+    },
+    [cartItems, notifyCartUpdate, updateCartItems]
+  );
 
-  // Clear cart and result
   const handleClearCart = useCallback(() => {
-    setCartItems([]);
+    updateCartItems([]);
     setCheckoutResult(null);
     notifyCartUpdate([]);
-  }, [notifyCartUpdate]);
+  }, [notifyCartUpdate, updateCartItems]);
+
+  // ── Fetch recommendations via callTool ──────────────────────────────────
+  const fetchRecommendations = useCallback(
+    async (
+      productId: string,
+      productName: string,
+      source: string
+    ) => {
+      try {
+        const result = await callTool<{
+          recommendations?: EnrichedRec[];
+          recommendationRequestId?: string;
+        }>("get-recommendations", {
+          productId,
+          productName,
+          cartItems: cartItems.map((item) => ({
+            productId: item.id,
+            name: item.name,
+            price: item.basePrice,
+          })),
+          sessionId: cartState.cartId || sessionId || undefined,
+        });
+
+        const recRequestId =
+          typeof result.recommendationRequestId === "string"
+            ? result.recommendationRequestId
+            : undefined;
+        return mapRecommendationsToProducts(
+          result.recommendations ?? [],
+          recRequestId,
+          source
+        );
+      } catch (error) {
+        console.error("[Widget] Failed to get recommendations:", error);
+        return [];
+      }
+    },
+    [cartItems, cartState.cartId, sessionId]
+  );
 
   // Navigate to product detail page
   const handleProductClick = useCallback(
     async (product: Product) => {
       void trackRecommendationClick(product);
       setSelectedProduct(product);
-      setCurrentPage("product_detail");
+      updateCurrentPage("product_detail", product.id);
       setProductRecommendations([]);
       setIsLoadingRecommendations(true);
 
-      try {
-        // Request recommendations from parent via postMessage
-        const message = {
-          type: "GET_RECOMMENDATIONS",
-          source: "product_detail",
-          productId: product.id,
-          productName: product.name,
-          cartItems: cartItems.map((item) => ({
-            productId: item.id,
-            name: item.name,
-            price: item.basePrice,
-          })),
-          sessionId: cartState.cartId || sessionId || undefined,
-        };
-        window.parent.postMessage(message, "*");
-      } catch (error) {
-        console.error("[Widget] Failed to request recommendations:", error);
-        setIsLoadingRecommendations(false);
-      }
+      const products = await fetchRecommendations(product.id, product.name, "product_detail");
+      setProductRecommendations(products);
+      setIsLoadingRecommendations(false);
     },
-    [cartItems, cartState.cartId, sessionId, trackRecommendationClick]
+    [trackRecommendationClick, updateCurrentPage, fetchRecommendations]
   );
-
-  // Handle recommendations response from parent
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type === "RECOMMENDATIONS_RESULT") {
-        console.log("[Widget] Received RECOMMENDATIONS_RESULT:", event.data);
-        const source = event.data.source || "product_detail";
-        
-        // Convert recommendations from agent format to Product format
-        // Now uses enriched data from MCP server (real prices, images from merchant API)
-        type EnrichedRec = {
-          productId?: string;
-          product_id?: string;
-          productName?: string;
-          product_name?: string;
-          price?: number;
-          sku?: string;
-          image_url?: string;
-          stock_count?: number;
-          rank: number;
-        };
-        
-        const products: Product[] = event.data.recommendations?.length > 0
-          ? event.data.recommendations.map((rec: EnrichedRec, index: number) => ({
-              id: rec.productId ?? rec.product_id ?? `prod_${Date.now()}`,
-              sku: rec.sku ?? `SKU-${rec.productId ?? rec.product_id}`,
-              name: rec.productName ?? rec.product_name ?? "Product",
-              basePrice: rec.price ?? 2500,
-              stockCount: rec.stock_count ?? 100,
-              variant: "Default",
-              size: "One Size",
-              imageUrl: rec.image_url,
-              recommendationRequestId:
-                typeof event.data.recommendationRequestId === "string"
-                  ? (event.data.recommendationRequestId as string)
-                  : undefined,
-              recommendationPosition: typeof rec.rank === "number" ? rec.rank : index + 1,
-              recommendationSource: source,
-            }))
-          : [];
-        
-        console.log(`[Widget] Mapped ${products.length} products for ${source}`);
-        
-        // Route to appropriate state based on source
-        if (source === "checkout") {
-          setIsLoadingCheckoutRecommendations(false);
-          setCheckoutRecommendations(products);
-        } else {
-          setIsLoadingRecommendations(false);
-          setProductRecommendations(products);
-        }
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
 
   // Navigate back to browse
   const handleBackToBrowse = useCallback(() => {
-    setCurrentPage("browse");
+    updateCurrentPage("browse", null);
     setSelectedProduct(null);
     setProductRecommendations([]);
-  }, []);
+  }, [updateCurrentPage]);
 
   // Navigate to checkout page and request recommendations based on cart
   const handleCartClick = useCallback(() => {
-    setCurrentPage("checkout");
-    
-    // Request recommendations based on cart items
+    updateCurrentPage("checkout");
+
     if (cartItems.length > 0) {
       setCheckoutRecommendations([]);
       setIsLoadingCheckoutRecommendations(true);
-      
-      try {
-        // Use first cart item as the "current product" context for recommendations
-        const primaryItem = cartItems[0];
-        const message = {
-          type: "GET_RECOMMENDATIONS",
-          source: "checkout",
-          productId: primaryItem.id,
-          productName: primaryItem.name,
-          cartItems: cartItems.map((item) => ({
-            productId: item.id,
-            name: item.name,
-            price: item.basePrice,
-          })),
-          sessionId: cartState.cartId || sessionId || undefined,
-        };
-        console.log("[Widget] Requesting checkout recommendations:", message);
-        window.parent.postMessage(message, "*");
-      } catch (error) {
-        console.error("[Widget] Failed to request checkout recommendations:", error);
+
+      const primaryItem = cartItems[0];
+      console.log("[Widget] Requesting checkout recommendations for:", primaryItem.name);
+
+      void (async () => {
+        const products = await fetchRecommendations(primaryItem.id, primaryItem.name, "checkout");
+        setCheckoutRecommendations(products);
         setIsLoadingCheckoutRecommendations(false);
-      }
+      })();
     }
-  }, [cartItems, cartState.cartId, sessionId]);
+  }, [cartItems, updateCurrentPage, fetchRecommendations]);
 
   // Add to cart with quantity (for product detail page)
   const handleAddToCartWithQuantity = useCallback(
     (product: Product, quantity: number) => {
       void trackRecommendationClick(product);
-      setCartItems((prev) => {
-        const existingItem = prev.find((item) => item.id === product.id);
-        let newItems: CartItem[];
-        if (existingItem) {
-          newItems = prev.map((item) =>
-            item.id === product.id
-              ? {
-                  ...item,
-                  quantity: item.quantity + quantity,
-                  recommendationRequestId:
-                    item.recommendationRequestId ?? product.recommendationRequestId,
-                  recommendationPosition:
-                    item.recommendationPosition ?? product.recommendationPosition,
-                  recommendationSource:
-                    item.recommendationSource ?? product.recommendationSource,
-                }
-              : item
-          );
-        } else {
-          newItems = [
-            ...prev,
-            {
-              id: product.id,
-              name: product.name,
-              basePrice: product.basePrice,
-              quantity,
-              variant: product.variant,
-              size: product.size,
-              recommendationRequestId: product.recommendationRequestId,
-              recommendationPosition: product.recommendationPosition,
-              recommendationSource: product.recommendationSource,
-            },
-          ];
-        }
-        // Notify server after state update
-        notifyCartUpdate(newItems);
-        return newItems;
-      });
+      const existingItem = cartItems.find((item) => item.id === product.id);
+      let newItems: CartItem[];
+      if (existingItem) {
+        newItems = cartItems.map((item) =>
+          item.id === product.id
+            ? {
+                ...item,
+                quantity: item.quantity + quantity,
+                recommendationRequestId:
+                  item.recommendationRequestId ?? product.recommendationRequestId,
+                recommendationPosition:
+                  item.recommendationPosition ?? product.recommendationPosition,
+                recommendationSource:
+                  item.recommendationSource ?? product.recommendationSource,
+              }
+            : item
+        );
+      } else {
+        newItems = [
+          ...cartItems,
+          {
+            id: product.id,
+            name: product.name,
+            basePrice: product.basePrice,
+            quantity,
+            variant: product.variant,
+            size: product.size,
+            recommendationRequestId: product.recommendationRequestId,
+            recommendationPosition: product.recommendationPosition,
+            recommendationSource: product.recommendationSource,
+          },
+        ];
+      }
+      updateCartItems(newItems);
+      notifyCartUpdate(newItems);
     },
-    [notifyCartUpdate, trackRecommendationClick]
+    [cartItems, notifyCartUpdate, trackRecommendationClick, updateCartItems]
   );
 
-  // Handle checkout - makes real API calls to the MCP server
-  // Widget is fully isolated - no postMessage communication with parent
-  const handleCheckout = useCallback(async (paymentFormData?: { fullName: string; address: string; city: string; zipCode: string }) => {
-    if (cartItems.length === 0) return;
+  // ── Checkout via callTool ───────────────────────────────────────────────
+  const handleCheckout = useCallback(
+    async (paymentFormData?: {
+      fullName: string;
+      address: string;
+      city: string;
+      zipCode: string;
+    }) => {
+      if (cartItems.length === 0) return;
 
-    setIsCheckingOut(true);
-    setCheckoutResult(null);
+      setIsCheckingOut(true);
+      setCheckoutResult(null);
 
-    // Use the same API base URL logic as session management
-    const apiBaseUrl = getApiBaseUrl();
-    const cartId = cartState.cartId || `cart_${Date.now().toString(36)}`;
+      const cartId = cartState.cartId || `cart_${Date.now().toString(36)}`;
+      const customerName = paymentFormData?.fullName || "Customer";
 
-    // Extract customer name from form data for personalized post-purchase messages
-    const customerName = paymentFormData?.fullName || "Customer";
+      try {
+        console.log("[Checkout] Calling checkout via callTool...", {
+          cartId,
+          itemCount: cartItems.length,
+          customerName,
+        });
 
-    try {
-      // Make real HTTP call to the MCP server's REST API
-      // The MCP server handles the full ACP flow and emits SSE events
-      // that the Protocol Inspector can subscribe to independently
-      console.log("[Checkout] Calling checkout REST API...", { cartId, itemCount: cartItems.length, customerName });
-      
-      const response = await fetch(`${apiBaseUrl}/cart/checkout`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+        const result = await callTool<CheckoutResult>("checkout", {
           cartId,
           cartItems: cartItems,
-          customerName: customerName,
-        }),
-      });
+          customerName,
+        });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("[Checkout] API error:", response.status, errorText);
-        throw new Error(`Checkout failed: ${response.status}`);
+        console.log("[Checkout] callTool response:", result);
+        setCheckoutResult(result);
+
+        if (result.success) {
+          updateCartItems([]);
+          updateSessionId(null);
+          setAcpSession(null);
+        }
+      } catch (error) {
+        console.error("[Checkout] Error:", error);
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : "Checkout failed - is the MCP server running?";
+        setCheckoutResult({
+          success: false,
+          status: "failed",
+          error: errorMessage,
+        });
+      } finally {
+        setIsCheckingOut(false);
       }
+    },
+    [cartItems, cartState, updateCartItems, updateSessionId]
+  );
 
-      const result = await response.json() as CheckoutResult;
-      console.log("[Checkout] API response:", result);
-      
-      setCheckoutResult(result);
-
-      if (result.success) {
-        // Clear cart and session state on successful checkout
-        setCartItems([]);
-        setSessionId(null);
-        setAcpSession(null);
-      }
-    } catch (error) {
-      console.error("[Checkout] Error:", error);
-      const errorMessage = error instanceof Error ? error.message : "Checkout failed - is the MCP server running?";
-      setCheckoutResult({
-        success: false,
-        status: "failed",
-        error: errorMessage,
-      });
-    } finally {
-      setIsCheckingOut(false);
-    }
-  }, [cartItems, cartState, getApiBaseUrl]);
+  // ── Render ──────────────────────────────────────────────────────────────
 
   // Render product detail page
   if (currentPage === "product_detail" && selectedProduct) {
@@ -678,11 +666,11 @@ export function App() {
 
   // Render checkout page
   if (currentPage === "checkout") {
-    // Use checkout recommendations if available, fall back to browse recommendations
-    const displayRecommendations = checkoutRecommendations.length > 0 
-      ? checkoutRecommendations 
-      : browseRecommendations;
-    
+    const displayRecommendations =
+      checkoutRecommendations.length > 0
+        ? checkoutRecommendations
+        : browseRecommendations;
+
     return (
       <div className="min-h-screen bg-surface transition-colors">
         <CheckoutPage

--- a/src/apps_sdk/web/src/main.tsx
+++ b/src/apps_sdk/web/src/main.tsx
@@ -37,6 +37,47 @@ function getMcpBaseUrl(): string {
   }
 }
 
+interface McpJsonRpcResponse {
+  result?: {
+    structuredContent?: Record<string, unknown>;
+    content?: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  };
+  error?: { code: number; message: string };
+}
+
+/**
+ * Parse the raw response text (SSE stream or plain JSON) into a JSON-RPC response.
+ */
+function parseMcpResponse(text: string): McpJsonRpcResponse | null {
+  // Try SSE stream first — look for "data: " lines containing a JSON-RPC result
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    try {
+      const data = JSON.parse(line.slice(6)) as McpJsonRpcResponse;
+      if (data.result || data.error) return data;
+    } catch {
+      // Continue parsing remaining lines
+    }
+  }
+  // Fallback to plain JSON
+  try {
+    return JSON.parse(text) as McpJsonRpcResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the tool result string from a parsed MCP JSON-RPC response.
+ */
+function extractToolResult(mcpResponse: McpJsonRpcResponse): string {
+  const structured = mcpResponse.result?.structuredContent;
+  if (structured) return JSON.stringify(structured);
+  const textContent = mcpResponse.result?.content?.[0]?.text;
+  return textContent ?? JSON.stringify({ success: false, error: "Empty response" });
+}
+
 /**
  * Call an MCP tool directly via JSON-RPC to the MCP server.
  * Parses the SSE response stream to extract the tool result.
@@ -67,58 +108,16 @@ async function callMcpTool(
   }
 
   const text = await response.text();
-
-  // Parse SSE stream to find the JSON-RPC result
-  interface McpJsonRpcResponse {
-    result?: {
-      structuredContent?: Record<string, unknown>;
-      content?: Array<{ type: string; text: string }>;
-      isError?: boolean;
-    };
-    error?: { code: number; message: string };
-  }
-
-  let mcpResponse: McpJsonRpcResponse | null = null;
-  const lines = text.split("\n");
-  for (const line of lines) {
-    if (line.startsWith("data: ")) {
-      try {
-        const data = JSON.parse(line.slice(6)) as McpJsonRpcResponse;
-        if (data.result || data.error) {
-          mcpResponse = data;
-        }
-      } catch {
-        // Continue parsing
-      }
-    }
-  }
-
-  // Try plain JSON if no SSE data found
-  if (!mcpResponse) {
-    try {
-      mcpResponse = JSON.parse(text) as McpJsonRpcResponse;
-    } catch {
-      // Not valid JSON
-    }
-  }
+  const mcpResponse = parseMcpResponse(text);
 
   if (!mcpResponse) {
     throw new Error("No valid response from MCP server");
   }
-
   if (mcpResponse.error) {
     throw new Error(`MCP error: ${mcpResponse.error.message}`);
   }
 
-  // Return structuredContent as stringified JSON (matching real CallToolResponse contract)
-  const structured = mcpResponse.result?.structuredContent;
-  if (structured) {
-    return { result: JSON.stringify(structured) };
-  }
-
-  // Fallback to text content
-  const textContent = mcpResponse.result?.content?.[0]?.text;
-  return { result: textContent ?? JSON.stringify({ success: false, error: "Empty response" }) };
+  return { result: extractToolResult(mcpResponse) };
 }
 
 /**

--- a/src/apps_sdk/web/src/main.tsx
+++ b/src/apps_sdk/web/src/main.tsx
@@ -14,9 +14,117 @@ applyDocumentTheme(savedTheme ?? (systemPrefersDark ? "dark" : "light"));
 // Store for simulated bridge data
 let simulatedToolOutput: ToolOutput | null = null;
 
+// Persisted widget state in simulated mode (stored in memory)
+let simulatedWidgetState: unknown = null;
+
+/**
+ * Determine the MCP server base URL for the simulated bridge.
+ * Uses the same 3-way detection as the rest of the widget:
+ * 1. Vite dev server → localhost:2091
+ * 2. Nginx proxy (/apps-sdk/) → /apps-sdk
+ * 3. Direct → ""
+ */
+function getMcpBaseUrl(): string {
+  const isViteDevServer = window.location.port === "3001" || window.location.port === "3002";
+  const isAppsSdkPath = window.location.pathname.startsWith("/apps-sdk/");
+
+  if (isViteDevServer) {
+    return "http://localhost:2091";
+  } else if (isAppsSdkPath) {
+    return "/apps-sdk";
+  } else {
+    return "";
+  }
+}
+
+/**
+ * Call an MCP tool directly via JSON-RPC to the MCP server.
+ * Parses the SSE response stream to extract the tool result.
+ * This is used by the simulated bridge in dev mode.
+ */
+async function callMcpTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<{ result: string }> {
+  const mcpBaseUrl = getMcpBaseUrl();
+  const response = await fetch(`${mcpBaseUrl}/api/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: Date.now(),
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+    signal: AbortSignal.timeout(65000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`MCP server returned ${response.status}: ${response.statusText || "Unknown error"}`);
+  }
+
+  const text = await response.text();
+
+  // Parse SSE stream to find the JSON-RPC result
+  interface McpJsonRpcResponse {
+    result?: {
+      structuredContent?: Record<string, unknown>;
+      content?: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    };
+    error?: { code: number; message: string };
+  }
+
+  let mcpResponse: McpJsonRpcResponse | null = null;
+  const lines = text.split("\n");
+  for (const line of lines) {
+    if (line.startsWith("data: ")) {
+      try {
+        const data = JSON.parse(line.slice(6)) as McpJsonRpcResponse;
+        if (data.result || data.error) {
+          mcpResponse = data;
+        }
+      } catch {
+        // Continue parsing
+      }
+    }
+  }
+
+  // Try plain JSON if no SSE data found
+  if (!mcpResponse) {
+    try {
+      mcpResponse = JSON.parse(text) as McpJsonRpcResponse;
+    } catch {
+      // Not valid JSON
+    }
+  }
+
+  if (!mcpResponse) {
+    throw new Error("No valid response from MCP server");
+  }
+
+  if (mcpResponse.error) {
+    throw new Error(`MCP error: ${mcpResponse.error.message}`);
+  }
+
+  // Return structuredContent as stringified JSON (matching real CallToolResponse contract)
+  const structured = mcpResponse.result?.structuredContent;
+  if (structured) {
+    return { result: JSON.stringify(structured) };
+  }
+
+  // Fallback to text content
+  const textContent = mcpResponse.result?.content?.[0]?.text;
+  return { result: textContent ?? JSON.stringify({ success: false, error: "Empty response" }) };
+}
+
 /**
  * Create a simulated window.openai object for standalone mode.
  * This mimics what the client agent injects in production.
+ * callTool sends JSON-RPC directly to the MCP server (like the real host does).
  */
 function createSimulatedOpenAi(globals?: Partial<OpenAiGlobals>): OpenAiGlobals {
   return {
@@ -26,35 +134,24 @@ function createSimulatedOpenAi(globals?: Partial<OpenAiGlobals>): OpenAiGlobals 
     displayMode: globals?.displayMode ?? "inline",
     toolInput: globals?.toolInput ?? {},
     toolOutput: globals?.toolOutput ?? simulatedToolOutput,
-    widgetState: globals?.widgetState ?? null,
+    widgetState: globals?.widgetState ?? (simulatedWidgetState as OpenAiGlobals["widgetState"]),
 
-    // Methods that communicate with parent
+    // Persist widget state in memory for simulated mode
     setWidgetState: async (state: unknown) => {
       console.log("[SimulatedBridge] setWidgetState:", state);
+      simulatedWidgetState = state;
     },
 
+    // Direct MCP JSON-RPC call (no postMessage relay)
     callTool: async (name: string, args: Record<string, unknown>) => {
       console.log("[SimulatedBridge] callTool:", name, args);
-      
-      // Send to parent for processing
-      window.parent.postMessage({ type: "CALL_TOOL", toolName: name, args }, "*");
-      
-      // Wait for response
-      return new Promise((resolve) => {
-        const handleResponse = (event: MessageEvent) => {
-          if (event.data?.type === "TOOL_RESULT" && event.data?.toolName === name) {
-            window.removeEventListener("message", handleResponse);
-            resolve({ result: event.data.result });
-          }
-        };
-        window.addEventListener("message", handleResponse);
-        
-        // Timeout after 30 seconds
-        setTimeout(() => {
-          window.removeEventListener("message", handleResponse);
-          resolve({ result: JSON.stringify({ success: false, error: "Timeout" }) });
-        }, 30000);
-      });
+      try {
+        return await callMcpTool(name, args);
+      } catch (error) {
+        console.error("[SimulatedBridge] callTool failed:", error);
+        const msg = error instanceof Error ? error.message : "callTool failed";
+        return { result: JSON.stringify({ success: false, error: msg }) };
+      }
     },
 
     sendFollowUpMessage: async (args: { prompt: string }) => {

--- a/src/ui/components/agent/MerchantIframeContainer.tsx
+++ b/src/ui/components/agent/MerchantIframeContainer.tsx
@@ -4,7 +4,6 @@ import { useRef, useEffect, useCallback, useState } from "react";
 import { useACPLog } from "@/hooks/useACPLog";
 import { useMCPClient } from "@/hooks/useMCPClient";
 import { useAgentActivityLog } from "@/hooks/useAgentActivityLog";
-import type { RecommendationInputSignals, RecommendationDecision } from "@/types";
 
 /**
  * Props for the MerchantIframeContainer component
@@ -36,12 +35,6 @@ const FALLBACK_WIDGET_URL =
  * Shows the skeleton loader for this duration before revealing the iframe.
  */
 const LOADING_DELAY_MS = 4000;
-
-/**
- * Minimum delay for recommendation requests in milliseconds.
- * Ensures the skeleton loader is visible for at least this duration.
- */
-const MIN_RECOMMENDATION_DELAY_MS = 1000;
 
 /**
  * Minimum delay for search refresh loading animation in milliseconds.
@@ -94,7 +87,7 @@ export function MerchantIframeContainer({
   const { logEvent, completeEvent } = useACPLog();
 
   // MCP client hook for URL discovery and tool calls
-  const { getWidgetUrl, callTool, callToolWithWidget } = useMCPClient();
+  const { getWidgetUrl, callToolWithWidget } = useMCPClient();
 
   // Agent activity logging for recommendation events
   const { logAgentCall, completeAgentCall } = useAgentActivityLog();
@@ -263,194 +256,15 @@ export function MerchantIframeContainer({
   }, [iframeSrc]);
 
   /**
-   * Handle GET_RECOMMENDATIONS request from iframe.
-   * Calls the MCP tool and logs to Agent Activity panel.
-   * Ensures a minimum delay for UX (skeleton visibility).
-   */
-  const handleRecommendationRequest = useCallback(
-    async (data: {
-      productId: string;
-      productName: string;
-      cartItems: Array<{ productId: string; name: string; price: number }>;
-      source?: string;
-      sessionId?: string;
-    }) => {
-      const source = data.source || "product_detail";
-      // Record start time for minimum delay calculation
-      const startTime = Date.now();
-
-      // Create input signals for agent activity logging
-      const inputSignals: RecommendationInputSignals = {
-        productId: data.productId,
-        productName: data.productName,
-        cartItems: data.cartItems,
-      };
-
-      // Log the start of the recommendation request
-      const agentEventId = logAgentCall("recommendation", inputSignals);
-
-      // Log to ACP protocol inspector
-      const contextLabel = source === "checkout" ? "cart checkout" : data.productName;
-      const acpEventId = logEvent(
-        "session_update",
-        "POST",
-        "/api/mcp (tools/call: get-recommendations)",
-        `Getting recommendations for ${contextLabel}...`
-      );
-
-      /**
-       * Helper to ensure minimum delay before sending result.
-       * This ensures the skeleton loader is visible for at least MIN_RECOMMENDATION_DELAY_MS.
-       */
-      const waitForMinDelay = async () => {
-        const elapsed = Date.now() - startTime;
-        const remaining = MIN_RECOMMENDATION_DELAY_MS - elapsed;
-        if (remaining > 0) {
-          await new Promise((resolve) => setTimeout(resolve, remaining));
-        }
-      };
-
-      try {
-        // Call the MCP tool
-        const result = await callTool("get-recommendations", {
-          productId: data.productId,
-          productName: data.productName,
-          cartItems: data.cartItems,
-          sessionId: data.sessionId,
-        });
-
-        // Parse the result - ensure recommendations is an array
-        const rawRecommendations = Array.isArray(result?.recommendations)
-          ? result.recommendations
-          : [];
-        const userIntent = typeof result?.userIntent === "string" ? result.userIntent : undefined;
-        const rawPipelineTrace = result?.pipelineTrace as
-          | {
-              candidatesFound?: number;
-              afterNliFilter?: number;
-              finalRanked?: number;
-            }
-          | undefined;
-
-        // Map recommendations to typed format
-        type RawRec = {
-          productId?: string;
-          product_id?: string;
-          productName?: string;
-          product_name?: string;
-          rank: number;
-          reasoning: string;
-        };
-        const mappedRecommendations = rawRecommendations.map((rec: RawRec) => ({
-          productId: rec.productId ?? rec.product_id ?? "",
-          productName: rec.productName ?? rec.product_name ?? "",
-          rank: rec.rank,
-          reasoning: rec.reasoning,
-        }));
-
-        // Create decision for agent activity log
-        const decision: RecommendationDecision = {
-          recommendations: mappedRecommendations,
-          ...(userIntent !== undefined && { userIntent }),
-          ...(rawPipelineTrace && {
-            pipelineTrace: {
-              candidatesFound: rawPipelineTrace.candidatesFound ?? 0,
-              afterNliFilter: rawPipelineTrace.afterNliFilter ?? 0,
-              finalRanked: rawPipelineTrace.finalRanked ?? 0,
-            },
-          }),
-        };
-
-        // Complete agent activity log
-        completeAgentCall(agentEventId, "success", decision);
-
-        // Complete ACP log
-        completeEvent(
-          acpEventId,
-          "success",
-          `Found ${rawRecommendations.length} recommendations`,
-          200
-        );
-
-        // Ensure minimum delay for UX before sending result
-        await waitForMinDelay();
-
-        // Send result back to iframe with source for routing
-        const messageToSend = {
-          type: "RECOMMENDATIONS_RESULT",
-          source,
-          recommendationRequestId:
-            typeof result?.recommendationRequestId === "string"
-              ? result.recommendationRequestId
-              : undefined,
-          recommendations: rawRecommendations,
-          userIntent,
-          pipelineTrace: rawPipelineTrace,
-        };
-        if (iframeRef.current?.contentWindow) {
-          iframeRef.current.contentWindow.postMessage(messageToSend, "*");
-        }
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : "Failed to get recommendations";
-
-        // Complete agent activity log with error
-        completeAgentCall(agentEventId, "error", undefined, errorMessage);
-
-        // Complete ACP log with error
-        completeEvent(acpEventId, "error", errorMessage, 500);
-
-        // Ensure minimum delay for UX before sending error
-        await waitForMinDelay();
-
-        // Send error back to iframe with source for routing
-        iframeRef.current?.contentWindow?.postMessage(
-          {
-            type: "RECOMMENDATIONS_RESULT",
-            source,
-            recommendations: [],
-            error: errorMessage,
-          },
-          "*"
-        );
-      }
-    },
-    [logAgentCall, completeAgentCall, logEvent, completeEvent, callTool]
-  );
-
-  /**
    * Handle messages from the iframe.
-   * Handles checkout completion and recommendation requests.
+   * The widget now calls MCP tools directly via callTool, so we only
+   * need to listen for checkout completion notifications.
    */
   const handleMessage = useCallback(
     (event: MessageEvent) => {
       const message = event.data;
 
       if (typeof message !== "object" || message === null) return;
-
-      // Handle recommendation request from widget
-      if (message.type === "GET_RECOMMENDATIONS") {
-        const requestData: {
-          productId: string;
-          productName: string;
-          cartItems: Array<{ productId: string; name: string; price: number }>;
-          source?: string;
-          sessionId?: string;
-        } = {
-          productId: message.productId as string,
-          productName: message.productName as string,
-          cartItems:
-            (message.cartItems as Array<{ productId: string; name: string; price: number }>) ?? [],
-        };
-        if (message.source) {
-          requestData.source = message.source as string;
-        }
-        if (message.sessionId) {
-          requestData.sessionId = message.sessionId as string;
-        }
-        handleRecommendationRequest(requestData);
-        return;
-      }
 
       // Listen for checkout completion notification from the widget (optional)
       // Note: The widget is isolated and doesn't send postMessage for checkout events.
@@ -461,7 +275,7 @@ export function MerchantIframeContainer({
         }
       }
     },
-    [onCheckoutComplete, handleRecommendationRequest]
+    [onCheckoutComplete]
   );
 
   /**
@@ -512,12 +326,8 @@ export function MerchantIframeContainer({
             toolOutput: toolOutput,
           };
           latestGlobalsRef.current = globals;
-          if (bridgeInitializedRef.current) {
-            postGlobalsToIframe(globals, "UPDATE_OPENAI_GLOBALS");
-          } else {
-            postGlobalsToIframe(globals, "UPDATE_OPENAI_GLOBALS");
-            bridgeInitializedRef.current = true;
-          }
+          postGlobalsToIframe(globals, "UPDATE_OPENAI_GLOBALS");
+          bridgeInitializedRef.current = true;
 
           if (toolError) {
             completeEvent(acpEventId, "error", toolError, 500);

--- a/src/ui/hooks/useCheckoutEvents.tsx
+++ b/src/ui/hooks/useCheckoutEvents.tsx
@@ -76,6 +76,56 @@ interface RecommendationActivitySSEEvent {
 
 type AgentActivitySSEEvent = PromotionActivitySSEEvent | RecommendationActivitySSEEvent;
 
+// ---------------------------------------------------------------------------
+// Pure helpers for agent activity event processing
+// ---------------------------------------------------------------------------
+
+function buildPromotionSignals(data: PromotionActivitySSEEvent): {
+  inputSignals: PromotionInputSignals;
+  decision: PromotionDecision;
+} {
+  return {
+    inputSignals: {
+      productId: data.productId,
+      productName: data.productName,
+      stockCount: data.stockCount,
+      basePrice: data.basePrice,
+      competitorPrice: null,
+      inventoryPressure: data.stockCount > 50 ? "high" : "low",
+      competitionPosition: inferCompetitionPosition(data.reasonCodes),
+    },
+    decision: {
+      action: data.action,
+      discountAmount: data.discountAmount,
+      reasonCodes: data.reasonCodes,
+      reasoning: data.reasoning,
+    },
+  };
+}
+
+function buildRecommendationDecision(data: RecommendationActivitySSEEvent): RecommendationDecision {
+  const recommendations: RecommendationItem[] = (data.recommendations ?? []).map((rec) => ({
+    productId: rec.productId ?? "",
+    productName: rec.productName ?? "",
+    rank: rec.rank,
+    reasoning: rec.reasoning,
+  }));
+
+  const pipelineTrace: RecommendationPipelineTrace | undefined = data.pipelineTrace
+    ? {
+        candidatesFound: data.pipelineTrace.candidatesFound ?? 0,
+        afterNliFilter: data.pipelineTrace.afterNliFilter ?? 0,
+        finalRanked: data.pipelineTrace.finalRanked ?? 0,
+      }
+    : undefined;
+
+  return {
+    recommendations,
+    ...(data.userIntent !== undefined && { userIntent: data.userIntent }),
+    ...(pipelineTrace !== undefined && { pipelineTrace }),
+  };
+}
+
 /**
  * Map SSE event type to ACP log event type
  */
@@ -170,76 +220,36 @@ export function useCheckoutEvents(mcpServerUrl = MCP_SERVER_URL) {
         const data = JSON.parse(event.data) as AgentActivitySSEEvent;
 
         if (data.agentType === "promotion") {
-          const promoData = data as PromotionActivitySSEEvent;
-          const inputSignals: PromotionInputSignals = {
-            productId: promoData.productId,
-            productName: promoData.productName,
-            stockCount: promoData.stockCount,
-            basePrice: promoData.basePrice,
-            competitorPrice: null,
-            inventoryPressure: promoData.stockCount > 50 ? "high" : "low",
-            competitionPosition: inferCompetitionPosition(promoData.reasonCodes),
-          };
-
-          const decision: PromotionDecision = {
-            action: promoData.action,
-            discountAmount: promoData.discountAmount,
-            reasonCodes: promoData.reasonCodes,
-            reasoning: promoData.reasoning,
-          };
-
+          const { inputSignals, decision } = buildPromotionSignals(data);
           addAgentEvent("promotion", inputSignals, decision, "success");
-        } else if (data.agentType === "recommendation") {
-          const recData = data as RecommendationActivitySSEEvent;
-          const inputSignals: RecommendationInputSignals = {
-            productId: recData.productId,
-            productName: recData.productName,
-            cartItems: recData.cartItems ?? [],
-          };
+          return;
+        }
 
-          if (recData.status === "pending") {
-            // Create a pending event — shows "Generating" in the panel
-            const localId = logAgentCall("recommendation", inputSignals);
-            // Track so we can complete it when the result arrives
-            pendingEventsRef.current.set(recData.id, localId);
-          } else {
-            // Build the decision from completed data
-            const recommendations: RecommendationItem[] = (recData.recommendations ?? []).map(
-              (rec) => ({
-                productId: rec.productId ?? "",
-                productName: rec.productName ?? "",
-                rank: rec.rank,
-                reasoning: rec.reasoning,
-              })
-            );
+        if (data.agentType !== "recommendation") return;
 
-            const pipelineTrace: RecommendationPipelineTrace | undefined = recData.pipelineTrace
-              ? {
-                  candidatesFound: recData.pipelineTrace.candidatesFound ?? 0,
-                  afterNliFilter: recData.pipelineTrace.afterNliFilter ?? 0,
-                  finalRanked: recData.pipelineTrace.finalRanked ?? 0,
-                }
-              : undefined;
+        const recData = data as RecommendationActivitySSEEvent;
+        const inputSignals: RecommendationInputSignals = {
+          productId: recData.productId,
+          productName: recData.productName,
+          cartItems: recData.cartItems ?? [],
+        };
 
-            const decision: RecommendationDecision = {
-              recommendations,
-              ...(recData.userIntent !== undefined && { userIntent: recData.userIntent }),
-              ...(pipelineTrace !== undefined && { pipelineTrace }),
-            };
+        if (recData.status === "pending") {
+          const localId = logAgentCall("recommendation", inputSignals);
+          pendingEventsRef.current.set(recData.id, localId);
+          return;
+        }
 
-            const status = recData.error ? "error" : "success";
+        const decision = buildRecommendationDecision(recData);
+        const status = recData.error ? "error" : "success";
+        const pendingLocalId = pendingEventsRef.current.get(recData.id);
 
-            // Find and complete the pending event
-            const pendingLocalId = pendingEventsRef.current.get(recData.id);
-            if (pendingLocalId) {
-              completeAgentCall(pendingLocalId, status, decision, recData.error);
-              pendingEventsRef.current.delete(recData.id);
-            } else {
-              // No pending event — create a completed event directly (race/reconnect)
-              const localId = logAgentCall("recommendation", inputSignals);
-              completeAgentCall(localId, status, decision, recData.error);
-            }
-          }
+        if (pendingLocalId) {
+          completeAgentCall(pendingLocalId, status, decision, recData.error);
+          pendingEventsRef.current.delete(recData.id);
+        } else {
+          const localId = logAgentCall("recommendation", inputSignals);
+          completeAgentCall(localId, status, decision, recData.error);
         }
       } catch (error) {
         console.error("[useCheckoutEvents] Failed to parse agent activity event:", error);

--- a/src/ui/hooks/useCheckoutEvents.tsx
+++ b/src/ui/hooks/useCheckoutEvents.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useCallback, useRef } from "react";
 import { useACPLog, type ACPEventType } from "./useACPLog";
 import { useAgentActivityLog } from "./useAgentActivityLog";
-import type { PromotionInputSignals, PromotionDecision } from "@/types";
+import type {
+  PromotionInputSignals,
+  PromotionDecision,
+  RecommendationInputSignals,
+  RecommendationDecision,
+  RecommendationItem,
+  RecommendationPipelineTrace,
+} from "@/types";
 
 /**
  * SSE event from the MCP server
@@ -22,11 +29,11 @@ interface CheckoutSSEEvent {
 }
 
 /**
- * Agent activity SSE event from the MCP server
+ * Agent activity SSE event from the MCP server (promotion)
  */
-interface AgentActivitySSEEvent {
+interface PromotionActivitySSEEvent {
   id: string;
-  agentType: string;
+  agentType: "promotion";
   productId: string;
   productName: string;
   action: string;
@@ -37,6 +44,37 @@ interface AgentActivitySSEEvent {
   basePrice: number;
   timestamp: string;
 }
+
+/**
+ * Agent activity SSE event from the MCP server (recommendation)
+ */
+interface RecommendationActivitySSEEvent {
+  id: string;
+  agentType: "recommendation";
+  status: "pending" | "success" | "error";
+  productId: string;
+  productName: string;
+  cartItems: Array<{ productId: string; name: string; price: number }>;
+  // Fields below are only present on complete (success/error) events
+  recommendations?: Array<{
+    productId: string;
+    productName: string;
+    rank: number;
+    reasoning: string;
+  }>;
+  userIntent?: string;
+  pipelineTrace?: {
+    candidatesFound?: number;
+    afterNliFilter?: number;
+    finalRanked?: number;
+  };
+  recommendationRequestId?: string;
+  latencyMs?: number;
+  error?: string;
+  timestamp: string;
+}
+
+type AgentActivitySSEEvent = PromotionActivitySSEEvent | RecommendationActivitySSEEvent;
 
 /**
  * Map SSE event type to ACP log event type
@@ -72,7 +110,7 @@ const MCP_SERVER_URL = process.env.NEXT_PUBLIC_MCP_SERVER_URL || "http://localho
  */
 export function useCheckoutEvents(mcpServerUrl = MCP_SERVER_URL) {
   const { logEvent, completeEvent } = useACPLog();
-  const { addAgentEvent } = useAgentActivityLog();
+  const { addAgentEvent, logAgentCall, completeAgentCall } = useAgentActivityLog();
   const eventSourceRef = useRef<EventSource | null>(null);
   const pendingEventsRef = useRef<Map<string, string>>(new Map());
 
@@ -131,35 +169,83 @@ export function useCheckoutEvents(mcpServerUrl = MCP_SERVER_URL) {
       try {
         const data = JSON.parse(event.data) as AgentActivitySSEEvent;
 
-        // Only handle promotion agent events for now
         if (data.agentType === "promotion") {
-          // Build input signals
+          const promoData = data as PromotionActivitySSEEvent;
           const inputSignals: PromotionInputSignals = {
-            productId: data.productId,
-            productName: data.productName,
-            stockCount: data.stockCount,
-            basePrice: data.basePrice,
+            productId: promoData.productId,
+            productName: promoData.productName,
+            stockCount: promoData.stockCount,
+            basePrice: promoData.basePrice,
             competitorPrice: null,
-            inventoryPressure: data.stockCount > 50 ? "high" : "low",
-            competitionPosition: inferCompetitionPosition(data.reasonCodes),
+            inventoryPressure: promoData.stockCount > 50 ? "high" : "low",
+            competitionPosition: inferCompetitionPosition(promoData.reasonCodes),
           };
 
-          // Build decision
           const decision: PromotionDecision = {
-            action: data.action,
-            discountAmount: data.discountAmount,
-            reasonCodes: data.reasonCodes,
-            reasoning: data.reasoning,
+            action: promoData.action,
+            discountAmount: promoData.discountAmount,
+            reasonCodes: promoData.reasonCodes,
+            reasoning: promoData.reasoning,
           };
 
-          // Add to agent activity log
           addAgentEvent("promotion", inputSignals, decision, "success");
+        } else if (data.agentType === "recommendation") {
+          const recData = data as RecommendationActivitySSEEvent;
+          const inputSignals: RecommendationInputSignals = {
+            productId: recData.productId,
+            productName: recData.productName,
+            cartItems: recData.cartItems ?? [],
+          };
+
+          if (recData.status === "pending") {
+            // Create a pending event — shows "Generating" in the panel
+            const localId = logAgentCall("recommendation", inputSignals);
+            // Track so we can complete it when the result arrives
+            pendingEventsRef.current.set(recData.id, localId);
+          } else {
+            // Build the decision from completed data
+            const recommendations: RecommendationItem[] = (recData.recommendations ?? []).map(
+              (rec) => ({
+                productId: rec.productId ?? "",
+                productName: rec.productName ?? "",
+                rank: rec.rank,
+                reasoning: rec.reasoning,
+              })
+            );
+
+            const pipelineTrace: RecommendationPipelineTrace | undefined = recData.pipelineTrace
+              ? {
+                  candidatesFound: recData.pipelineTrace.candidatesFound ?? 0,
+                  afterNliFilter: recData.pipelineTrace.afterNliFilter ?? 0,
+                  finalRanked: recData.pipelineTrace.finalRanked ?? 0,
+                }
+              : undefined;
+
+            const decision: RecommendationDecision = {
+              recommendations,
+              ...(recData.userIntent !== undefined && { userIntent: recData.userIntent }),
+              ...(pipelineTrace !== undefined && { pipelineTrace }),
+            };
+
+            const status = recData.error ? "error" : "success";
+
+            // Find and complete the pending event
+            const pendingLocalId = pendingEventsRef.current.get(recData.id);
+            if (pendingLocalId) {
+              completeAgentCall(pendingLocalId, status, decision, recData.error);
+              pendingEventsRef.current.delete(recData.id);
+            } else {
+              // No pending event — create a completed event directly (race/reconnect)
+              const localId = logAgentCall("recommendation", inputSignals);
+              completeAgentCall(localId, status, decision, recData.error);
+            }
+          }
         }
       } catch (error) {
         console.error("[useCheckoutEvents] Failed to parse agent activity event:", error);
       }
     },
-    [addAgentEvent]
+    [addAgentEvent, logAgentCall, completeAgentCall]
   );
 
   useEffect(() => {

--- a/src/ui/hooks/useCheckoutEvents.tsx
+++ b/src/ui/hooks/useCheckoutEvents.tsx
@@ -227,7 +227,7 @@ export function useCheckoutEvents(mcpServerUrl = MCP_SERVER_URL) {
 
         if (data.agentType !== "recommendation") return;
 
-        const recData = data as RecommendationActivitySSEEvent;
+        const recData = data;
         const inputSignals: RecommendationInputSignals = {
           productId: recData.productId,
           productName: recData.productName,

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# stop.sh — Stop all local development services
+#
+# Reads .local-dev.pids, sends SIGTERM, waits for graceful shutdown,
+# then SIGKILL any remaining processes. Removes PID file when done.
+# =============================================================================
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PID_FILE="$ROOT_DIR/.local-dev.pids"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info() { printf "${CYAN}[INFO]${NC}  %s\n" "$1"; }
+ok()   { printf "${GREEN}[OK]${NC}    %s\n" "$1"; }
+warn() { printf "${YELLOW}[WARN]${NC}  %s\n" "$1"; }
+
+if [ ! -f "$PID_FILE" ]; then
+    warn "No .local-dev.pids file found. Nothing to stop."
+    exit 0
+fi
+
+info "Stopping services..."
+
+# Send SIGTERM to all
+while IFS=: read -r pid name; do
+    if kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null || true
+        info "  Sent SIGTERM to $name (PID $pid)"
+    else
+        warn "  $name (PID $pid) already stopped"
+    fi
+done < "$PID_FILE"
+
+# Wait up to 5 seconds for graceful shutdown
+info "Waiting up to 5s for graceful shutdown..."
+for i in 1 2 3 4 5; do
+    ALL_DEAD=true
+    while IFS=: read -r pid name; do
+        if kill -0 "$pid" 2>/dev/null; then
+            ALL_DEAD=false
+            break
+        fi
+    done < "$PID_FILE"
+    if $ALL_DEAD; then
+        break
+    fi
+    sleep 1
+done
+
+# SIGKILL any remaining
+while IFS=: read -r pid name; do
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+        warn "  Sent SIGKILL to $name (PID $pid)"
+    fi
+done < "$PID_FILE"
+
+rm -f "$PID_FILE"
+ok "All services stopped. PID file removed."


### PR DESCRIPTION
## Summary

- **Widget calls MCP tools directly** via `window.openai.callTool()` instead of `postMessage` relay through the parent iframe, making the widget self-contained and simplifying the architecture
- **New MCP tools**: `create-checkout-session`, `update-checkout-session`, `track-recommendation-click` — with shared ACP session logic extracted into `acp_sessions.py` so both MCP tools and REST endpoints reuse the same code
- **Recommendation SSE events**: pending/complete event emitters enable the Agent Activity panel to show real-time recommendation progress (previously only promotion events were streamed)
- **Local dev automation**: `install.sh` (prereq validation, dependency install, 8-service launch with health checks) and `stop.sh` (graceful PID-based shutdown) replace the manual multi-terminal setup
- **Documentation restructure**: Docker and local dev guides moved into `deploy/` directory, README streamlined to reference them

## Test plan

- [x] Verify widget loads and can browse products in standalone mode (Vite dev server)
- [x] Verify `callTool` for `get-recommendations` returns products on product detail page
- [x] Verify `callTool` for `create-checkout-session` / `update-checkout-session` works from cart
- [x] Verify checkout flow completes via `callTool("checkout", ...)` with cart sync and attribution
- [x] Verify recommendation SSE events (pending → complete) appear in Agent Activity panel
- [x] Verify `track-recommendation-click` records attribution when clicking recommended products
- [x] Run `./install.sh` on a clean checkout and verify all 8 services start with health checks passing
- [x] Run `./stop.sh` and verify all services are gracefully terminated
- [x] Verify REST endpoints still work (backwards compatibility for deprecated endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)