### PR TITLE
docs: add Node.js download link to README prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This is the recommended path. It does not require local NIM containers.
 
 - Python 3.12+
 - [uv](https://astral.sh/uv) package manager
-- Node.js 18+ and [pnpm](https://pnpm.io/)
+- [Node.js 18+](https://nodejs.org/en/download) and [pnpm](https://pnpm.io/)
 - Docker 24+ and Docker Compose v2
 - NVIDIA API key ([create one](https://build.nvidia.com/settings/api-keys))
 


### PR DESCRIPTION
## Summary
- Added hyperlink to [Node.js download page](https://nodejs.org/en/download) for the Node.js 18+ prerequisite in the Quick Start section

## Test plan
- [x] Verify the link renders correctly in GitHub markdown
- [x] Confirm the URL resolves to the Node.js download page

🤖 Generated with [Claude Code](https://claude.com/claude-code)