### PR TITLE
fix: remove --prerelease=allow to fix Docker NAT agent startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ pnpm dev  # port 3001
 ### NAT agents
 ```bash
 cd src/agents
-uv pip install -e ".[dev]" --prerelease=allow
+uv pip install -e ".[dev]"
 
 # Promotion agent (port 8002)
 nat serve --config_file configs/promotion.yml --port 8002

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+Read `AGENTS.md` for the full agent guide: session workflow, documentation-first rules, code standards, quick map, runtime commands, quality gates, and verification requirements.
+
+## Setup
+
+Trigger: **"setup"** or **"install"** — follow `.cursor/skills/setup/SKILL.md` exactly.

--- a/src/agents/Dockerfile
+++ b/src/agents/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY src/agents/pyproject.toml src/agents/README.md src/agents/register.py ./
 
 # Install dependencies with prerelease support for nvidia-nat
-RUN uv pip install -e ".[dev]" --prerelease=allow --system
+RUN uv pip install -e ".[dev]" --system
 
 # Copy agent configurations
 COPY src/agents/configs ./configs

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -458,7 +458,7 @@ docker compose down -v
    source .venv/bin/activate
    
    # Install dependencies (includes pymilvus)
-   uv pip install -e ".[dev]" --prerelease=allow
+   uv pip install -e ".[dev]"
    
    # Seed the product catalog
    python scripts/seed_milvus.py


### PR DESCRIPTION
## Summary
- Remove `--prerelease=allow` from agents Dockerfile, `src/agents/README.md`, and `AGENTS.md` — this flag caused `uv` to resolve Starlette `1.0.0rc1` in Docker which removed `add_event_handler()` and crashed `nvidia-nat` 1.4.1
- Add `CLAUDE.md` as entry point for Claude Code, referencing `AGENTS.md` and the setup skill

## Test plan
- [x] Rebuilt Docker containers without `--prerelease=allow` — all 4 NAT agents healthy (200)
- [x] Verified Starlette resolves to 0.52.x (stable) instead of 1.0.0rc1
- [x] Core services (merchant, PSP, apps-sdk, UI, nginx) all healthy
- [x] Verify local `./install.sh` still works (no change expected — local never used the flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)