### PR TITLE
[docs] Add scoped AGENTS guides and privacy guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,20 @@ When debugging:
 3. If not, is documentation outdated or code wrong?
 4. Only then investigate environment/configuration issues.
 
+## Security & Privacy Guardrails (Mandatory)
+
+When creating or editing docs (including `AGENTS.md` files):
+- Never include absolute local filesystem paths (for example: `/Users/<name>/...`, `/home/<name>/...`, `C:\Users\<name>\...`).
+- Never include usernames, home directories, machine-specific temp paths, or other host-identifying data.
+- Prefer repo-relative paths only (for example: `src/merchant/main.py`).
+- Treat any detected local path exposure as a blocking issue and fix before finishing.
+
+Before finalizing documentation changes, run this check and ensure it returns no matches:
+
+```bash
+rg -n -e '/Users/[A-Za-z0-9._-]+/' -e '/home/[A-Za-z0-9._-]+/' -e '\\\\Users\\\\[A-Za-z0-9._-]+\\\\' AGENTS.md src docs
+```
+
 ## Cursor Skills (Mandatory)
 
 Before changing code, read:
@@ -109,6 +123,13 @@ Agentic Commerce Protocol (ACP) reference implementation:
 Core docs:
 - `docs/features.md` for feature status and acceptance criteria
 - `docs/architecture.md` for system design
+
+## Scoped AGENTS (Subfolders)
+
+When working in these components, read the local scoped guide after this root file:
+- `src/merchant/AGENTS.md`
+- `src/apps_sdk/AGENTS.md`
+- `src/agents/AGENTS.md`
 
 ## Quick Map (Where to Look First)
 

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -1,0 +1,82 @@
+---
+description: Scoped fast-start guide for coding agents working in src/agents.
+alwaysApply: false
+---
+
+# AGENTS.md
+
+This file is the local guide for `src/agents/`. Read the root `AGENTS.md` first, then use this for agent-specific work.
+
+## Scope
+
+`src/agents/` contains NAT workflows and custom function registration for:
+- Promotion agent (`configs/promotion.yml`)
+- Post-purchase agent (`configs/post-purchase.yml`)
+- Recommendation agent (`configs/recommendation.yml`, `configs/recommendation-ultrafast.yml`)
+- Search agent (`configs/search.yml`)
+
+## Required Reading (Before Editing)
+
+1. `src/agents/README.md`
+2. `docs/NEMO_AGENT_TOOLKIT_DOCUMENTATION.md`
+3. `docs/features/feature-06-promotion-agent.md`
+4. `docs/features/feature-07-recommendation-agent.md`
+5. `docs/features/feature-08-post-purchase-agent.md`
+
+If changes impact merchant integration, also read:
+- `docs/specs/acp-spec.md`
+- `docs/specs/ucp-spec.md`
+
+## Architecture Contracts (Do Not Break)
+
+1. Preserve the 3-layer hybrid model:
+   - Layer 1 deterministic context in merchant backend
+   - Layer 2 LLM arbitration/generation in NAT
+   - Layer 3 deterministic enforcement in merchant backend
+2. Agent outputs are advisory/content-only. Final pricing, margin checks, and order authority remain deterministic in `src/merchant/`.
+3. Promotion decisions must select from `allowed_actions`.
+4. Recommendation custom components are limited to orchestration/contract guards in `src/agents/register.py`.
+
+## Quick Map
+
+- Configs: `src/agents/configs/*.yml`
+- Custom NAT components: `src/agents/register.py`
+- Eval datasets: `src/agents/data/eval/*.json`
+- Milvus seed helper: `src/agents/scripts/seed_milvus.py`
+- Agent contract test: `tests/agents/test_recommendation_workflow_contract.py`
+
+## Runtime Commands
+
+```bash
+cd src/agents
+uv pip install -e ".[dev]"
+
+nat serve --config_file configs/promotion.yml --port 8002
+nat serve --config_file configs/post-purchase.yml --port 8003
+nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+nat serve --config_file configs/search.yml --port 8005
+```
+
+## Verification (Minimum)
+
+```bash
+cd src/agents
+nat validate --config_file configs/<changed-agent>.yml
+nat run --config_file configs/<changed-agent>.yml --input '<sample-json>'
+
+ruff check .
+ruff format --check .
+pyright
+```
+
+If recommendation orchestration changes, run:
+
+```bash
+uv run pytest tests/agents/test_recommendation_workflow_contract.py -q
+```
+
+## Change Checklist
+
+- Update matching eval dataset when behavior contract changes.
+- Keep prompts/config and integration docs aligned (`src/agents/README.md` and root `AGENTS.md` when needed).
+- Report real command evidence; do not claim agent behavior without a `nat run`/test result.

--- a/src/apps_sdk/AGENTS.md
+++ b/src/apps_sdk/AGENTS.md
@@ -1,0 +1,96 @@
+---
+description: Scoped fast-start guide for coding agents working in src/apps_sdk.
+alwaysApply: false
+---
+
+# AGENTS.md
+
+This file is the local guide for `src/apps_sdk/`. Read the root `AGENTS.md` first, then use this for Apps SDK work.
+
+## Scope
+
+`src/apps_sdk/` owns:
+- FastAPI + FastMCP server (`main.py`)
+- MCP tool contracts (`schemas.py`, `tools/`)
+- Widget serving endpoints (`widget_endpoints.py`)
+- Widget UI (`web/`, React + Vite + `window.openai` bridge)
+- Protocol Inspector event stream endpoints (`events.py`, `rest_endpoints.py`)
+
+## Required Reading (Before Editing)
+
+1. `docs/specs/apps-sdk-spec.md`
+2. `src/apps_sdk/README.md`
+3. `docs/features/feature-16-apps-sdk.md`
+4. `docs/architecture.md` (Apps SDK integration sections)
+
+If checkout behavior changes, also read:
+- `docs/specs/acp-spec.md`
+
+## Architecture Contracts (Do Not Break)
+
+1. Widget entrypoint remains MCP-driven:
+   - `search-products` exposes `openai/outputTemplate` for widget discovery.
+2. Tool schema and handler parity is mandatory:
+   - `schemas.py` models
+   - tool registration in `list_mcp_tools()`
+   - dispatch map + `_handle_call_tool()` logic in `main.py`
+3. Widget state/interaction must flow via `window.openai` APIs (`callTool`, `toolOutput`, `setWidgetState`).
+4. Product truth source is merchant/search services, not duplicated hardcoded catalogs in tools.
+5. Keep Apps SDK mode ACP-only (UCP mode belongs to merchant native flow).
+
+## Quick Map
+
+- Server entrypoint: `src/apps_sdk/main.py`
+- Tool schemas: `src/apps_sdk/schemas.py`
+- MCP tools: `src/apps_sdk/tools/*.py`
+- Widget routes/static files: `src/apps_sdk/widget_endpoints.py`
+- Widget app: `src/apps_sdk/web/src/*`
+- Apps SDK tests: `tests/apps_sdk/*`
+
+## Runtime Commands
+
+```bash
+# MCP server
+uvicorn src.apps_sdk.main:app --reload --port 2091
+
+# Widget dev/build
+cd src/apps_sdk/web
+pnpm install
+pnpm dev
+pnpm build
+```
+
+## Verification (Minimum)
+
+Backend:
+
+```bash
+uv run ruff check src/apps_sdk tests/apps_sdk
+uv run ruff format --check src/apps_sdk tests/apps_sdk
+uv run pyright src/apps_sdk
+uv run pytest tests/apps_sdk -v
+```
+
+Widget:
+
+```bash
+cd src/apps_sdk/web
+pnpm lint
+pnpm typecheck
+pnpm test:run
+pnpm build
+```
+
+Runtime checks for behavior changes:
+
+```bash
+curl http://localhost:2091/health
+curl http://localhost:2091/widget/merchant-app.html | head -5
+```
+
+## Change Checklist
+
+- If adding/changing a tool, update schema, registration, handler, and tests together.
+- Keep `_meta` fields aligned with widget lifecycle expectations.
+- If widget interaction changes, verify both simulated bridge mode and MCP-served mode.
+- Report status codes/test outputs for runtime claims.

--- a/src/merchant/AGENTS.md
+++ b/src/merchant/AGENTS.md
@@ -1,0 +1,93 @@
+---
+description: Scoped fast-start guide for coding agents working in src/merchant.
+alwaysApply: false
+---
+
+# AGENTS.md
+
+This file is the local guide for `src/merchant/`. Read the root `AGENTS.md` first, then use this for backend protocol work.
+
+## Scope
+
+`src/merchant/` is the core commerce backend:
+- ACP checkout REST implementation
+- UCP discovery + A2A checkout transport
+- Shared checkout domain logic and persistence
+- Agent integrations (promotion, post-purchase, metrics/attribution)
+
+## Required Reading (Before Editing)
+
+1. `docs/specs/acp-spec.md`
+2. `docs/specs/ucp-spec.md`
+3. `docs/features/feature-17-ucp-integration.md`
+4. `docs/architecture.md`
+
+If post-purchase/webhook behavior changes:
+- `docs/features/feature-11-webhook-integration.md`
+
+## Architecture Contracts (Do Not Break)
+
+1. Keep protocol adapters thin:
+   - ACP routes in `protocols/acp/`
+   - UCP transport/discovery in `protocols/ucp/`
+   - Shared business logic in `domain/checkout/` and `services/`
+2. No ACP↔UCP cross-imports inside protocol packages (guarded by architecture test).
+3. UCP checkout transport is A2A (`POST /a2a`) with discovery at `/.well-known/ucp`.
+4. Preserve protocol status vocabularies:
+   - ACP: `not_ready_for_payment`, `ready_for_payment`, `authentication_required`, `in_progress`, `completed`, `canceled`
+   - UCP: `incomplete`, `requires_escalation`, `ready_for_complete`, `complete_in_progress`, `completed`, `canceled`
+5. API auth/idempotency headers and middleware behavior must stay consistent with spec.
+
+## Quick Map
+
+- App wiring: `src/merchant/main.py`
+- Shared API routes: `src/merchant/api/routes/`
+- ACP checkout routes/schemas: `src/merchant/protocols/acp/api/routes/`, `src/merchant/protocols/acp/api/schemas/`
+- UCP discovery/schemas/services: `src/merchant/protocols/ucp/api/`, `src/merchant/protocols/ucp/services/`
+- Shared checkout service: `src/merchant/domain/checkout/service.py`
+- DB models: `src/merchant/db/models.py`
+- Agent service integrations: `src/merchant/services/`
+
+## Runtime Commands
+
+```bash
+# Merchant API
+uvicorn src.merchant.main:app --reload --port 8000
+
+# Health
+curl http://localhost:8000/health
+```
+
+## Verification (Minimum)
+
+Static + tests:
+
+```bash
+uv run ruff check src/merchant tests/merchant
+uv run ruff format --check src/merchant tests/merchant
+uv run pyright src/merchant
+uv run pytest tests/merchant -v
+```
+
+Targeted protocol tests when relevant:
+
+```bash
+uv run pytest tests/merchant/api/test_checkout.py -q
+uv run pytest tests/merchant/api/test_ucp_discovery.py tests/merchant/api/test_ucp_a2a.py tests/merchant/api/test_ucp_negotiation.py -q
+uv run pytest tests/merchant/architecture/test_protocol_import_boundaries.py -q
+```
+
+Runtime evidence for endpoint changes:
+
+```bash
+curl -s -w "\nHTTP_CODE:%{http_code}" -X POST http://localhost:8000/<endpoint> \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '<payload>'
+```
+
+## Change Checklist
+
+- Update schemas, route handlers, and transformation logic together.
+- Keep docs in sync when contracts or transport behavior change.
+- If protocol behavior changes, include both happy-path and failure-path verification evidence.


### PR DESCRIPTION
## Summary
- add scoped AGENTS.md guides for src/agents, src/apps_sdk, and src/merchant
- add root AGENTS.md links to scoped guides for faster component onboarding
- add mandatory security/privacy guardrails to prevent leaking local machine paths in docs

## Test plan
- rg -n -e '/Users/[A-Za-z0-9._-]+/' -e '/home/[A-Za-z0-9._-]+/' -e '\\Users\\[A-Za-z0-9._-]+\\' AGENTS.md src docs
- manual review of updated AGENTS.md files for repo-relative paths only

## Notes
- docs-only change; no runtime behavior modified