### PR TITLE
[apps-sdk] Preserve promotion signals in agent activity events

### DIFF
--- a/src/apps_sdk/events.py
+++ b/src/apps_sdk/events.py
@@ -61,6 +61,7 @@ def emit_agent_activity_event(
     reasoning: str,
     stock_count: int = 0,
     base_price: int = 0,
+    signals: dict[str, str] | None = None,
 ) -> None:
     """Emit a promotion agent activity event to all SSE subscribers."""
     event = {
@@ -76,6 +77,8 @@ def emit_agent_activity_event(
         "basePrice": base_price,
         "timestamp": datetime.now().isoformat(),
     }
+    if signals is not None:
+        event["signals"] = signals
     checkout_events.append(event)
 
     for queue in event_subscribers:

--- a/src/apps_sdk/events.py
+++ b/src/apps_sdk/events.py
@@ -64,7 +64,7 @@ def emit_agent_activity_event(
     signals: dict[str, str] | None = None,
 ) -> None:
     """Emit a promotion agent activity event to all SSE subscribers."""
-    event = {
+    event: dict[str, Any] = {
         "id": f"agent_{datetime.now().timestamp()}",
         "agentType": agent_type,
         "productId": product_id,

--- a/src/apps_sdk/tools/acp_sessions.py
+++ b/src/apps_sdk/tools/acp_sessions.py
@@ -116,6 +116,7 @@ async def create_acp_session(
                         reasoning=promotion.get("reasoning", ""),
                         stock_count=stock_count,
                         base_price=line_item.get("base_amount", 0),
+                        signals=promotion.get("signals"),
                     )
 
             return data

--- a/tests/apps_sdk/test_acp_sessions.py
+++ b/tests/apps_sdk/test_acp_sessions.py
@@ -1,0 +1,99 @@
+"""Tests for shared ACP session helpers used by Apps SDK."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.apps_sdk.tools.acp_sessions import create_acp_session
+
+
+@pytest.fixture(autouse=True)
+def mock_checkout_http_client() -> None:
+    """Override global checkout HTTP mock for this module."""
+    # tests/apps_sdk/conftest.py patches AsyncClient.__aenter__ to always raise.
+    # These tests need to exercise real request/response handling paths.
+    return None
+
+
+class _MockResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = ""
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_create_acp_session_emits_promotion_signals() -> None:
+    """Forwards promotion signals to SSE so price position is deterministic."""
+    merchant_response = {
+        "id": "cs_test_123",
+        "line_items": [
+            {
+                "id": "li_1",
+                "item": {"id": "prod_16", "quantity": 1},
+                "name": "Leather Loafers",
+                "base_amount": 8500,
+                "discount": 850,
+                "promotion": {
+                    "action": "DISCOUNT_10_PCT",
+                    "reason_codes": [
+                        "HIGH_INVENTORY",
+                        "CLEARANCE",
+                        "DEMAND_DECELERATING",
+                    ],
+                    "reasoning": "Test reasoning",
+                    "stock_count": 25,
+                    "signals": {
+                        "inventory_pressure": "low",
+                        "competition_position": "above_market",
+                        "seasonal_urgency": "off_season",
+                        "product_lifecycle": "clearance",
+                        "demand_velocity": "decelerating",
+                    },
+                },
+            }
+        ],
+        "totals": [],
+    }
+
+    class _MockAsyncClient:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _MockAsyncClient:
+            return self
+
+        async def __aexit__(
+            self,
+            _exc_type: type[BaseException] | None,
+            _exc: BaseException | None,
+            _tb: Any,
+        ) -> None:
+            return None
+
+        async def post(self, *_args: Any, **_kwargs: Any) -> _MockResponse:
+            return _MockResponse(201, merchant_response)
+
+    with (
+        patch("src.apps_sdk.tools.acp_sessions.httpx.AsyncClient", _MockAsyncClient),
+        patch(
+            "src.apps_sdk.tools.acp_sessions.emit_agent_activity_event"
+        ) as emit_agent,
+    ):
+        result = await create_acp_session(items=[{"id": "prod_16", "quantity": 1}])
+
+    assert result["id"] == "cs_test_123"
+    emit_agent.assert_called_once()
+    assert emit_agent.call_args.kwargs["signals"] == {
+        "inventory_pressure": "low",
+        "competition_position": "above_market",
+        "seasonal_urgency": "off_season",
+        "product_lifecycle": "clearance",
+        "demand_velocity": "decelerating",
+    }

--- a/tests/apps_sdk/test_acp_sessions.py
+++ b/tests/apps_sdk/test_acp_sessions.py
@@ -64,7 +64,8 @@ async def test_create_acp_session_emits_promotion_signals() -> None:
 
     class _MockAsyncClient:
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
-            pass
+            self._args = _args
+            self._kwargs = _kwargs
 
         async def __aenter__(self) -> _MockAsyncClient:
             return self

--- a/tests/apps_sdk/test_events.py
+++ b/tests/apps_sdk/test_events.py
@@ -1,0 +1,26 @@
+"""Tests for Apps SDK SSE event emitters."""
+
+from src.apps_sdk.events import checkout_events, emit_agent_activity_event
+
+
+def test_emit_agent_activity_event_includes_signals() -> None:
+    """Promotion activity payload includes signals when provided."""
+    checkout_events.clear()
+
+    emit_agent_activity_event(
+        agent_type="promotion",
+        product_id="prod_16",
+        product_name="Leather Loafers",
+        action="DISCOUNT_10_PCT",
+        discount_amount=850,
+        reason_codes=["CLEARANCE"],
+        reasoning="Test reasoning",
+        stock_count=25,
+        base_price=8500,
+        signals={"competition_position": "above_market"},
+    )
+
+    assert len(checkout_events) == 1
+    latest_event = checkout_events[-1]
+    assert latest_event["agentType"] == "promotion"
+    assert latest_event["signals"] == {"competition_position": "above_market"}


### PR DESCRIPTION
## Summary
- Forward promotion signals from Merchant API checkout line items into Apps SDK SSE promotion activity events.
- Extend emit_agent_activity_event to include optional signal payload for UI consumers.
- Add regression test to verify create_acp_session emits promotion signals.

## Test plan
- PYTHONDONTWRITEBYTECODE=1 uv run --with ruff ruff check src/apps_sdk/events.py src/apps_sdk/tools/acp_sessions.py tests/apps_sdk/test_acp_sessions.py
- PYTHONDONTWRITEBYTECODE=1 uv run --with ruff ruff format --check src/apps_sdk/events.py src/apps_sdk/tools/acp_sessions.py tests/apps_sdk/test_acp_sessions.py
- PYTHONDONTWRITEBYTECODE=1 uv run --with pytest --with pytest-asyncio python -m pytest tests/apps_sdk/test_acp_sessions.py -q -p no:cacheprovider
- PYTHONDONTWRITEBYTECODE=1 uv run --with pytest python -m pytest tests/merchant/services/test_promotion.py::TestComputeCompetitionPosition tests/merchant/services/test_promotion.py::TestComputePromotionContext -q -p no:cacheprovider

## Related
- N/A