### PR TITLE
[docs] Clean up agents README and align recommendation config references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Frontend:
 Agent configs:
 - `src/agents/configs/promotion.yml`
 - `src/agents/configs/post-purchase.yml`
-- `src/agents/configs/recommendation-ultrafast.yml`
+- `src/agents/configs/recommendation.yml`
 - `src/agents/configs/search.yml`
 
 ## Runtime Commands (Canonical)
@@ -197,7 +197,7 @@ nat serve --config_file configs/promotion.yml --port 8002
 nat serve --config_file configs/post-purchase.yml --port 8003
 
 # Recommendation agent (port 8004)
-nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+nat serve --config_file configs/recommendation.yml --port 8004
 
 # Search agent (port 8005)
 nat serve --config_file configs/search.yml --port 8005

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -53,7 +53,7 @@ uv pip install -e ".[dev]"
 
 nat serve --config_file configs/promotion.yml --port 8002
 nat serve --config_file configs/post-purchase.yml --port 8003
-nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+nat serve --config_file configs/recommendation.yml --port 8004
 nat serve --config_file configs/search.yml --port 8005
 ```
 

--- a/src/agents/Dockerfile
+++ b/src/agents/Dockerfile
@@ -48,5 +48,5 @@ COPY src/data ./src/data
 # Examples:
 # - nat serve --config_file configs/promotion.yml --port 8002
 # - nat serve --config_file configs/post-purchase.yml --port 8003
-# - nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+# - nat serve --config_file configs/recommendation.yml --port 8004
 # - python scripts/seed_milvus.py (for Milvus seeder)

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -38,11 +38,7 @@ All ACP agents follow a **3-layer hybrid architecture** that combines determinis
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Key Principle
-
-> **The LLM never computes prices, performs calculations, or accesses databases directly.**
-> It selects strategies from pre-approved sets or generates content from structured context.
-> All math, data access, and enforcement are deterministic.
+> **Key Principle:** The LLM never computes prices, performs calculations, or accesses databases directly. It selects strategies from pre-approved sets or generates content from structured context. All math, data access, and enforcement are deterministic.
 
 ## Available Agents
 
@@ -50,47 +46,12 @@ All ACP agents follow a **3-layer hybrid architecture** that combines determinis
 |-------|--------|------|---------|
 | Promotion Agent | `configs/promotion.yml` | 8002 | Strategy arbiter for dynamic pricing |
 | Post-Purchase Agent | `configs/post-purchase.yml` | 8003 | Multilingual shipping message generator |
-| Recommendation Agent (ARAG) | `configs/recommendation-ultrafast.yml` | 8004 | Multi-agent personalized recommendations |
+| Recommendation Agent (ARAG) | `configs/recommendation.yml` | 8004 | Multi-agent personalized recommendations |
 | Search Agent (RAG) | `configs/search.yml` | 8005 | Lightweight semantic product search |
-
-### ARAG Recommendation Agent Architecture
-
-The Recommendation Agent implements an **Agentic Retrieval Augmented Generation (ARAG)** framework based on [SIGIR 2025 research](https://arxiv.org/pdf/2506.21931). This multi-agent approach achieves **42% improvement in NDCG@5** over vanilla RAG.
-
-**Key Design**: All 4 ARAG agents are orchestrated within a **single NAT workflow** using NAT's multi-agent pattern, where specialized agents are defined as `functions` and coordinated by a main `react_agent` workflow.
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│            ARAG MULTI-AGENT ORCHESTRATION (Single YAML)         │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  Recommendation Coordinator (react_agent workflow)       │   │
-│  │  - Orchestrates all specialized agents                   │   │
-│  │  - Uses product_search tool for RAG retrieval            │   │
-│  │  - Delegates to specialist agents as needed              │   │
-│  └─────────────────────┬───────────────────────────────────┘   │
-│                        │                                        │
-│           ┌────────────┼────────────┬───────────┐              │
-│           │            │            │           │              │
-│           ▼            ▼            ▼           ▼              │
-│  ┌────────────┐ ┌────────────┐ ┌────────┐ ┌──────────┐        │
-│  │ product_   │ │ user_      │ │ nli_   │ │ context_ │        │
-│  │ search     │ │ understand │ │ agent  │ │ summary  │        │
-│  │ (RAG tool) │ │ _agent     │ │        │ │ _agent   │        │
-│  └────────────┘ └────────────┘ └────────┘ └──────────┘        │
-│                                                                 │
-│  All agents share: embedders, retrievers, LLM configs          │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-See `docs/features.md` Feature 7 for detailed implementation plan.
 
 ## Installation
 
 ```bash
-# Navigate to the agents directory
 cd src/agents
 
 # Create virtual environment with uv (recommended)
@@ -108,24 +69,68 @@ pip install -e ".[dev]"
 
 ### Environment Variables
 
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `NVIDIA_API_KEY` | API key for NVIDIA NIM | Yes |
-
-### Setting API Key
+| Variable | Description | Required | Default |
+|----------|-------------|----------|---------|
+| `NVIDIA_API_KEY` | API key for NVIDIA NIM | Yes | — |
+| `MILVUS_URI` | Milvus vector database URI | For Recommendation + Search | `http://localhost:19530` |
+| `PHOENIX_ENDPOINT` | Phoenix observability endpoint | No | `http://localhost:6006` |
 
 ```bash
 export NVIDIA_API_KEY=<your_nvidia_api_key>
 ```
 
-## Running Agents
+### Shared Infrastructure (Milvus + Phoenix)
 
-### Promotion Agent
+The Recommendation and Search agents require **Milvus** for vector search. **Phoenix** provides optional LLM observability and tracing.
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| Milvus | 19530 | Vector similarity search for product embeddings |
+| Phoenix | 6006 | LLM observability UI and trace collection |
+| MinIO | 9001 | Object storage for Milvus |
+
+**Starting infrastructure:**
+
+```bash
+# From project root
+docker compose up -d
+
+# Verify services
+curl -s http://localhost:9091/healthz  # Milvus — should return "OK"
+curl -s http://localhost:6006/healthz  # Phoenix — should return "OK"
+```
+
+**Seeding the product catalog:**
+
+```bash
+cd src/agents
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+python scripts/seed_milvus.py
+```
+
+**Stopping infrastructure:**
+
+```bash
+docker compose down      # Stop services
+docker compose down -v   # Stop and remove all data
+```
+
+| UI | URL |
+|----|-----|
+| Phoenix (traces, LLM calls) | http://localhost:6006 |
+| MinIO Console (optional) | http://localhost:9001 |
+
+---
+
+## Promotion Agent
 
 The Promotion Agent selects optimal promotion actions based on pre-computed business signals.
 
+**Workflow Type:** `chat_completion` | **Port:** 8002
+
 ```bash
-# Start as REST endpoint (for ACP integration)
+# Start as REST endpoint
 nat serve --config_file configs/promotion.yml --port 8002
 
 # Test with direct input
@@ -154,14 +159,42 @@ nat run --config_file configs/promotion.yml --input '{
 }
 ```
 
-### Post-Purchase Agent
+### Input Format
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `product_id` | string | Product identifier |
+| `product_name` | string | Human-readable product name |
+| `base_price_cents` | int | Original price in cents (context only) |
+| `stock_count` | int | Current inventory units |
+| `min_margin` | float | Minimum profit margin (0.18 = 18%) |
+| `lowest_competitor_price_cents` | int | Lowest competitor price in cents |
+| `signals.inventory_pressure` | string | `"high"` or `"low"` |
+| `signals.competition_position` | string | `"above_market"`, `"at_market"`, or `"below_market"` |
+| `allowed_actions` | list[string] | Actions filtered by margin constraints |
+
+### Available Actions
+
+| Action | Description | Discount |
+|--------|-------------|----------|
+| `NO_PROMO` | No discount applied | 0% |
+| `DISCOUNT_5_PCT` | 5% discount | 5% |
+| `DISCOUNT_10_PCT` | 10% discount | 10% |
+| `DISCOUNT_15_PCT` | 15% discount | 15% |
+| `FREE_SHIPPING` | Free shipping benefit | 0% (price) |
+
+---
+
+## Post-Purchase Agent
 
 The Post-Purchase Agent generates multilingual shipping update messages based on brand persona and order context.
+
+**Workflow Type:** `chat_completion` | **Port:** 8003
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Order Lifecycle Event                        │
-│         (order_confirmed → shipped → out_for_delivery → delivered)
+│       (order_confirmed → shipped → out_for_delivery → delivered)│
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -192,18 +225,12 @@ The Post-Purchase Agent generates multilingual shipping update messages based on
 │  Layer 3: Validate & Deliver                                    │
 │  - Validate response format                                     │
 │  - Fallback to templates if agent unavailable                   │
-│  - Queue for webhook delivery (Feature 11)                      │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Webhook Delivery (Future)                    │
-│               POST to WEBHOOK_URL with signed payload           │
+│  - Queue for webhook delivery                                   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
 ```bash
-# Start as REST endpoint (for ACP integration)
+# Start as REST endpoint
 nat serve --config_file configs/post-purchase.yml --port 8003
 
 # Test with direct input
@@ -235,47 +262,13 @@ nat run --config_file configs/post-purchase.yml --input '{
 }
 ```
 
-## Agent Configuration Reference
-
-### Promotion Agent (`configs/promotion.yml`)
-
-**Workflow Type:** `chat_completion`
-
-**Input Format:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `product_id` | string | Product identifier |
-| `product_name` | string | Human-readable product name |
-| `base_price_cents` | int | Original price in cents (context only) |
-| `stock_count` | int | Current inventory units |
-| `min_margin` | float | Minimum profit margin (0.18 = 18%) |
-| `lowest_competitor_price_cents` | int | Lowest competitor price in cents |
-| `signals.inventory_pressure` | string | "high" or "low" |
-| `signals.competition_position` | string | "above_market", "at_market", or "below_market" |
-| `allowed_actions` | list[string] | Actions filtered by margin constraints |
-
-**Available Actions:**
-
-| Action | Description | Discount |
-|--------|-------------|----------|
-| `NO_PROMO` | No discount applied | 0% |
-| `DISCOUNT_5_PCT` | 5% discount | 5% |
-| `DISCOUNT_10_PCT` | 10% discount | 10% |
-| `DISCOUNT_15_PCT` | 15% discount | 15% |
-| `FREE_SHIPPING` | Free shipping benefit | 0% (price) |
-
-### Post-Purchase Agent (`configs/post-purchase.yml`)
-
-**Workflow Type:** `chat_completion`
-
-**Input Format:**
+### Input Format
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `brand_persona.company_name` | string | Retailer's name |
-| `brand_persona.tone` | string | "friendly", "professional", "casual", "urgent" |
-| `brand_persona.preferred_language` | string | "en", "es", "fr" |
+| `brand_persona.tone` | string | `"friendly"`, `"professional"`, `"casual"`, `"urgent"` |
+| `brand_persona.preferred_language` | string | `"en"`, `"es"`, `"fr"` |
 | `order.order_id` | string | Order identifier |
 | `order.customer_name` | string | Customer's first name |
 | `order.product_name` | string | Name of purchased product |
@@ -283,7 +276,7 @@ nat run --config_file configs/post-purchase.yml --input '{
 | `order.estimated_delivery` | string | ISO date format (optional) |
 | `status` | string | Shipping status |
 
-**Supported Tones:**
+### Supported Tones
 
 | Tone | Description |
 |------|-------------|
@@ -292,7 +285,7 @@ nat run --config_file configs/post-purchase.yml --input '{
 | `casual` | Relaxed, informal, may use emojis |
 | `urgent` | Direct, action-oriented, time-sensitive |
 
-**Shipping Statuses:**
+### Shipping Statuses
 
 | Status | Description |
 |--------|-------------|
@@ -301,11 +294,27 @@ nat run --config_file configs/post-purchase.yml --input '{
 | `out_for_delivery` | Package arriving today |
 | `delivered` | Package delivered |
 
-### Recommendation Agent (`configs/recommendation-ultrafast.yml`)
+---
 
-**Workflow Type:** `react_agent` (multi-agent orchestration)
+## Recommendation Agent (ARAG)
 
-The Recommendation Agent uses an ARAG (Agentic RAG) architecture with 4 specialized sub-agents orchestrated by a coordinator workflow.
+The Recommendation Agent implements an **Agentic Retrieval Augmented Generation (ARAG)** framework based on [SIGIR 2025 research](https://arxiv.org/pdf/2506.21931). This multi-agent approach achieves significant improvement over vanilla RAG for personalized recommendations.
+
+**Workflow Type:** `sequential_executor` (multi-agent orchestration) | **Port:** 8004
+
+### Why ARAG?
+
+Traditional RAG retrieves documents based on embedding similarity alone. ARAG introduces **multi-agent reasoning** into the retrieval pipeline:
+
+| Approach | NDCG@5 | Hit@5 | Improvement |
+|----------|--------|-------|-------------|
+| Recency-based | 0.309 | 0.395 | — |
+| Vanilla RAG | 0.299 | 0.379 | — |
+| **ARAG** | **0.439** | **0.535** | **+42%** |
+
+### Multi-Agent Pipeline
+
+All ARAG agents are orchestrated within a **single NAT workflow** (`configs/recommendation.yml`) using NAT's multi-agent pattern. Specialized agents are defined as `functions` and executed by a `sequential_executor` with parallel fan-out for UUA and NLI via a custom `parallel_executor` component.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -330,10 +339,10 @@ The Recommendation Agent uses an ARAG (Agentic RAG) architecture with 4 speciali
 │  Layer 2: ARAG Multi-Agent Pipeline                             │
 │                                                                  │
 │  ┌────────────────────────────────────────────────────────────┐ │
-│  │       Recommendation Coordinator (react_agent workflow)    │ │
+│  │      Sequential Executor (sequential_executor workflow)   │ │
 │  │  - Receives cart items + session context                   │ │
-│  │  - Orchestrates specialized agents via tool calls          │ │
-│  │  - Aggregates results into final response                  │ │
+│  │  - Orchestrates specialized agents in sequence             │ │
+│  │  - Parallel fan-out for UUA + NLI via parallel_executor    │ │
 │  └──────────────────────────┬─────────────────────────────────┘ │
 │                             │                                    │
 │            ┌────────────────┼────────────────┐                   │
@@ -365,8 +374,9 @@ The Recommendation Agent uses an ARAG (Agentic RAG) architecture with 4 speciali
 │  └────────────────────────────────────────────────────────────┘ │
 │                             │                                    │
 │  ┌──────────────────────────┴─────────────────────────────────┐ │
-│  │       Recommendation Coordinator (aggregates results)      │ │
-│  │  - Formats recommendations array with rankings             │ │
+│  │       Output Contract Guard (deterministic)                │ │
+│  │  - Validates and normalizes recommendation payload         │ │
+│  │  - Enforces max recommendations and required fields        │ │
 │  │  - Includes pipeline_trace for observability               │ │
 │  └────────────────────────────────────────────────────────────┘ │
 │                                                                  │
@@ -389,86 +399,31 @@ The Recommendation Agent uses an ARAG (Agentic RAG) architecture with 4 speciali
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Infrastructure (Docker Compose):**
+### Pipeline Steps
 
-The Recommendation Agent requires Milvus for vector search and Phoenix for observability. Both are defined in `docker-compose.yml` at the project root.
+| Step | Component | Type | Purpose |
+|------|-----------|------|---------|
+| 1 | `rag_retriever` | Custom (`register.py`) | Adapts input into retriever query, normalizes candidates |
+| 2a | `user_understanding_agent` | chat_completion | Infers buyer preferences from cart/context |
+| 2b | `nli_agent` | chat_completion | Scores semantic alignment with user intent |
+| — | `parallel_analysis` | Custom (`register.py`) | Runs UUA + NLI in parallel via `asyncio.gather` |
+| 3 | `context_summary_agent` | chat_completion | Synthesizes UUA + NLI signals into focused context |
+| 4 | `item_ranker_agent` | chat_completion | Produces final ranked recommendations |
+| 5 | `output_contract_guard` | Custom (`register.py`) | Validates and normalizes output schema |
 
-| Service | Port | Purpose |
-|---------|------|---------|
-| Milvus | 19530 | Vector similarity search for product embeddings |
-| Phoenix | 6006 | LLM observability UI and trace collection |
-| MinIO | 9001 | Object storage for Milvus (console optional) |
+Underlying retrieval:
 
-### Search Agent (`configs/search.yml`)
+| Component | Type | Purpose |
+|-----------|------|---------|
+| `product_search` | nat_retriever | Vector search for candidate products in Milvus |
 
-**Workflow Type:** `tool_calling_agent`
+### Running
 
-Lightweight RAG search agent that performs semantic product search against the
-Milvus `product_catalog` collection and returns top-k matches for a query.
-
-```bash
-# Start as REST endpoint
-nat serve --config_file configs/search.yml --port 8005
-
-# Test with direct input
-nat run --config_file configs/search.yml --input '{
-  "query": "lightweight summer tee",
-  "limit": 3
-}'
-```
-
-**Requires:** Milvus running and seeded (same setup as Recommendation Agent).
+**Requires:** Milvus running and seeded (see [Shared Infrastructure](#shared-infrastructure-milvus--phoenix)).
 
 ```bash
-# Start infrastructure
-docker compose up -d
-
-# Stop infrastructure
-docker compose down
-
-# Stop and remove all data
-docker compose down -v
-```
-
-| Health Check | Command |
-|--------------|---------|
-| Milvus | `curl -s http://localhost:9091/healthz` |
-| Phoenix | `curl -s http://localhost:6006/healthz` |
-
-| UI | URL |
-|----|-----|
-| Phoenix (traces, LLM calls) | http://localhost:6006 |
-| MinIO Console (optional) | http://localhost:9001 |
-
-**Prerequisites:**
-
-1. **Start Infrastructure (Milvus + Phoenix):**
-   ```bash
-   # From project root
-   docker compose up -d
-   
-   # Verify services are running
-   curl -s http://localhost:9091/healthz  # Milvus - Should return "OK"
-   curl -s http://localhost:6006/healthz  # Phoenix - Should return "OK"
-   ```
-
-2. **Seed Product Catalog with Embeddings:**
-   ```bash
-   cd src/agents
-   source .venv/bin/activate
-   
-   # Install dependencies (includes pymilvus)
-   uv pip install -e ".[dev]"
-   
-   # Seed the product catalog
-   python scripts/seed_milvus.py
-   ```
-
-**Running the Agent:**
-
-```bash
-# Start as REST endpoint
-nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
+# Start as REST endpoint (single command runs entire ARAG pipeline)
+nat serve --config_file configs/recommendation.yml --port 8004
 
 # Test with curl
 curl -X POST http://localhost:8004/generate \
@@ -477,6 +432,15 @@ curl -X POST http://localhost:8004/generate \
     "input_message": "{\"cart_items\": [{\"product_id\": \"prod_1\", \"name\": \"Classic Tee\", \"category\": \"tops\", \"price\": 2500}], \"session_context\": {}}"
   }'
 ```
+
+### Config Variants
+
+| Config | Workflow | Latency (H100) | Trade-off |
+|--------|----------|-----------------|-----------|
+| `recommendation.yml` | `sequential_executor` with parallel fan-out | ~4.8 s | Multi-agent pipeline with dedicated LLM agents per step; higher quality outputs |
+| `recommendation-ultrafast.yml` | `tool_calling_agent` | <3 s | Single LLM call with ARAG methodology embedded in prompt; faster, less modular |
+
+`recommendation.yml` is the default. Use `recommendation-ultrafast.yml` when latency is the primary concern and slightly lower output quality is acceptable.
 
 **Example Output:**
 ```json
@@ -504,31 +468,101 @@ curl -X POST http://localhost:8004/generate \
 }
 ```
 
-**Sub-Agents:**
+### Architecture Benefits
 
-| Agent | Type | Purpose |
-|-------|------|---------|
-| `product_search` | RAG retriever | Vector search for candidate products |
-| `user_understanding_agent` | chat_completion | Infers buyer preferences from cart/context |
-| `nli_alignment_agent` | chat_completion | Scores semantic alignment with user intent |
-| `context_summary_agent` | chat_completion | Synthesizes signals into focused context |
-| `item_ranker_agent` | chat_completion | Produces final ranked recommendations |
+Using NAT's multi-agent orchestration provides:
 
-**Environment Variables:**
+1. **Single Deployment** — one `nat serve` command runs the entire ARAG pipeline
+2. **Shared Resources** — embedders, retrievers, and LLMs defined once, used by all agents
+3. **Flexible LLM Assignment** — different models for different tasks (fast for scoring, reasoning for ranking)
+4. **Built-in Tracing** — Phoenix integration for debugging the multi-agent workflow
+5. **Tool Composition** — coordinator can call specialized agents as tools
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `NVIDIA_API_KEY` | NVIDIA NIM API key | Required |
-| `MILVUS_URI` | Milvus vector database URI | `http://localhost:19530` |
+### Observability with Phoenix
+
+The Recommendation Agent includes built-in observability using [Arize Phoenix](https://docs.arize.com/phoenix/), providing distributed tracing and LLM call visualization for debugging the multi-agent pipeline.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    ARAG Agent Pipeline                           │
+│  (Coordinator → UUA → NLI → CSA → IRA)                          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ OTLP traces (port 6006)
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Phoenix (Docker Container)                    │
+├─────────────────────────────────────────────────────────────────┤
+│  - Trace visualization for multi-agent workflow                  │
+│  - LLM call details (prompts, completions, tokens)              │
+│  - Latency breakdown per agent                                   │
+│  - Token usage and cost tracking                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Phoenix tracing is configured in `configs/recommendation.yml`:
+
+```yaml
+general:
+  telemetry:
+    tracing:
+      phoenix:
+        _type: phoenix
+        project: "arag-recommendations"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006/v1/traces}
+```
+
+To enable Phoenix tracing, install the Phoenix telemetry package:
+
+```bash
+pip install "nvidia-nat[phoenix]"
+```
+
+Open http://localhost:6006 to view traces, spans, latency breakdowns, and errors.
+
+### Research Reference
+
+> **ARAG: Agentic Retrieval Augmented Generation for Personalized Recommendation**
+> Maragheh et al., SIGIR 2025
+> https://arxiv.org/pdf/2506.21931
+>
+> Key insight: Integrating agentic reasoning into RAG enables better understanding of user intent
+> and semantic alignment, leading to significantly improved recommendation quality.
+
+---
+
+## Search Agent
+
+Lightweight RAG search agent that performs semantic product search against the Milvus `product_catalog` collection and returns top-k matches for a query.
+
+**Workflow Type:** `tool_calling_agent` | **Port:** 8005
+
+**Requires:** Milvus running and seeded (see [Shared Infrastructure](#shared-infrastructure-milvus--phoenix)).
+
+```bash
+# Start as REST endpoint
+nat serve --config_file configs/search.yml --port 8005
+
+# Test with direct input
+nat run --config_file configs/search.yml --input '{
+  "query": "lightweight summer tee",
+  "limit": 3
+}'
+```
+
+---
 
 ## Backend Integration
 
 Each agent has a corresponding service module in `src/merchant/services/`:
 
-| Agent | Service Module |
-|-------|----------------|
-| Promotion | `src/merchant/services/promotion.py` |
-| Post-Purchase | `src/merchant/services/post_purchase.py` |
+| Agent | Service Module | Integration |
+|-------|----------------|-------------|
+| Promotion | `src/merchant/services/promotion.py` | Direct REST call from checkout flow |
+| Post-Purchase | `src/merchant/services/post_purchase.py` | Direct REST call from order lifecycle |
+| Recommendation | `src/merchant/services/recommendation_attribution.py` | Attribution tracking; agent called via Apps SDK MCP |
+| Search | — | Agent called via Apps SDK MCP |
+| All agents | `src/merchant/services/agent_outcomes.py` | Invocation outcome recording and aggregation |
 
 These service modules provide:
 - **Enums** for actions, statuses, and options
@@ -612,12 +646,12 @@ To add a new NAT agent:
 src/agents/
 ├── pyproject.toml           # Shared dependencies for all agents
 ├── README.md                # This file
-├── register.py              # Custom NAT component registration
+├── register.py              # Custom NAT component registration (ARAG)
 ├── configs/
 │   ├── promotion.yml        # Promotion strategy arbiter (port 8002)
 │   ├── post-purchase.yml    # Multilingual shipping messages (port 8003)
-│   ├── recommendation.yml   # ARAG multi-agent recommendations (full version)
-│   ├── recommendation-ultrafast.yml  # ARAG recommendations optimized for speed (port 8004)
+│   ├── recommendation.yml   # ARAG multi-agent recommendations (port 8004)
+│   ├── recommendation-ultrafast.yml  # ARAG single-prompt variant (optional, speed-optimized)
 │   └── search.yml           # RAG product search agent (port 8005)
 ├── data/
 │   └── eval/                # Evaluation datasets (JSON)
@@ -634,23 +668,15 @@ src/agents/
 ### Code Quality
 
 ```bash
-# Linting
 ruff check .
-
-# Formatting
 ruff format .
-
-# Type checking
 pyright
 ```
 
 ### Testing Agent Configs
 
 ```bash
-# Validate config
 nat validate --config_file configs/promotion.yml
-
-# Run with verbose output
 nat run --config_file configs/promotion.yml --input '...' --verbose
 ```
 
@@ -664,15 +690,14 @@ Each agent config includes an `eval` section for automated quality evaluation an
 cd src/agents
 source .venv/bin/activate
 
-# Run eval for a specific agent
 nat eval --config_file configs/promotion.yml
 nat eval --config_file configs/post-purchase.yml
 nat eval --config_file configs/search.yml
-nat eval --config_file configs/recommendation-ultrafast.yml
 nat eval --config_file configs/recommendation.yml
+nat eval --config_file configs/recommendation-ultrafast.yml  # optional variant
 ```
 
-### Environment Variables
+### Private NIM Environment Variables
 
 When using a private NIM endpoint, set these before running evals:
 
@@ -717,16 +742,16 @@ All agents include profiler settings that generate performance metrics:
 
 ```yaml
 profiler:
-  token_uniqueness_forecast: true     # Token reuse analysis across queries
-  workflow_runtime_forecast: true      # Expected workflow latency estimates
-  compute_llm_metrics: true            # Inference timing, token counts, cost
-  csv_exclude_io_text: true            # Keep CSV output compact
-  prompt_caching_prefixes:             # Identify cacheable prompt prefixes
+  token_uniqueness_forecast: true
+  workflow_runtime_forecast: true
+  compute_llm_metrics: true
+  csv_exclude_io_text: true
+  prompt_caching_prefixes:
     enable: true
     min_frequency: 0.1
-  bottleneck_analysis:                 # Call hierarchy bottleneck detection
-    enable_nested_stack: true          # (search + recommendation agents)
-  concurrency_spike_analysis:          # Concurrent operation spike detection
+  bottleneck_analysis:
+    enable_nested_stack: true
+  concurrency_spike_analysis:
     enable: true
     spike_threshold: 5
 ```
@@ -759,17 +784,16 @@ Results from eval runs on the full 10-sample datasets:
 | Search | relevance | 1.00 | 3.00s | 1.97s |
 | | accuracy | 0.70 | | |
 | | trajectory | 0.40 | | |
+| Recommendation | accuracy | 0.80 | 5.08s | 1.46s |
+| | trajectory | 0.90 | | |
 | Recommendation (Ultrafast) | accuracy | 0.70 | 2.74s | 2.12s |
 | | trajectory | 0.85 | | |
-| Recommendation (Sequential) | accuracy | 0.80 | 5.08s | 1.46s |
-| | trajectory | 0.90 | | |
 
 ### Adding Evals to a New Agent
 
 When creating a new agent config, add an `eval` section at the bottom:
 
 ```yaml
-# 1. Add eval LLM(s) to the llms section
 llms:
   # ... your workflow LLMs ...
   nim_eval_llm:
@@ -781,7 +805,6 @@ llms:
     chat_template_kwargs:
       enable_thinking: false
 
-# 2. Add eval section
 eval:
   general:
     output_dir: ./.tmp/eval/<agent_name>
@@ -810,7 +833,6 @@ eval:
 
 ### API Key Issues
 
-Verify your API key is set:
 ```bash
 echo $NVIDIA_API_KEY
 ```
@@ -830,223 +852,14 @@ If the agent returns non-JSON output, check:
 
 Ensure the agent server is running:
 ```bash
-# Check if server is running
 curl http://localhost:8002/health
-
-# Start server if not running
 nat serve --config_file configs/promotion.yml --port 8002
 ```
 
-## ARAG Recommendation Agent (Planned - Feature 7)
-
-### Overview
-
-The Recommendation Agent uses an **Agentic Retrieval Augmented Generation (ARAG)** architecture, a research-backed approach from [Walmart Global Tech (SIGIR 2025)](https://arxiv.org/pdf/2506.21931) that significantly outperforms traditional RAG for personalized recommendations.
-
-### Why ARAG?
-
-Traditional RAG retrieves documents based on embedding similarity alone. ARAG introduces **multi-agent reasoning** into the retrieval pipeline:
-
-| Approach | NDCG@5 | Hit@5 | Improvement |
-|----------|--------|-------|-------------|
-| Recency-based | 0.309 | 0.395 | - |
-| Vanilla RAG | 0.299 | 0.379 | - |
-| **ARAG** | **0.439** | **0.535** | **+42%** |
-
-### Agent Responsibilities
-
-| Agent | Responsibility | Input | Output |
-|-------|----------------|-------|--------|
-| **User Understanding (UUA)** | Infer buyer preferences | Cart items, session context | Preference summary JSON |
-| **NLI Agent** | Score semantic alignment | Candidate products, user intent | Alignment scores (0-1) |
-| **Context Summary (CSA)** | Synthesize signals | UUA output, NLI scores | Focused context JSON |
-| **Item Ranker (IRA)** | Final ranking | User summary, context | Ranked recommendations |
-
-### Complete NAT Configuration (`configs/recommendation-ultrafast.yml`)
-
-All ARAG agents are orchestrated in a **single YAML file** using NAT's multi-agent pattern.
-
-### Running the ARAG Agent
-
-```bash
-# Start as REST endpoint (single command for all agents)
-nat serve --config_file configs/recommendation-ultrafast.yml --port 8004
-
-# Test with direct input
-nat run --config_file configs/recommendation-ultrafast.yml --input '{
-  "cart_items": [
-    {"product_id": "prod_1", "name": "Classic Tee", "category": "tops", "price": 2500}
-  ],
-  "session_context": {
-    "browse_history": ["casual wear", "summer clothes"],
-    "price_range_viewed": [2000, 4000]
-  }
-}'
-```
-
-### Example Output
-
-```json
-{
-  "recommendations": [
-    {
-      "product_id": "prod_5",
-      "product_name": "Khaki Shorts",
-      "rank": 1,
-      "reasoning": "Perfect casual pairing with Classic Tee for a complete summer outfit"
-    },
-    {
-      "product_id": "prod_8",
-      "product_name": "Canvas Sneakers",
-      "rank": 2,
-      "reasoning": "Complements casual style, within user's price range"
-    }
-  ],
-  "user_intent": "Shopping for casual summer basics, price-conscious",
-  "pipeline_trace": {
-    "candidates_found": 20,
-    "after_nli_filter": 8,
-    "final_ranked": 2
-  }
-}
-```
-
-### Environment Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `NVIDIA_API_KEY` | API key for NVIDIA NIM | Required |
-| `MILVUS_URI` | Milvus vector database URI | `http://localhost:19530` |
-| `PHOENIX_ENDPOINT` | Phoenix observability endpoint | `http://localhost:6006` |
-
-### Architecture Benefits
-
-Using NAT's multi-agent orchestration provides:
-
-1. **Single Deployment**: One `nat serve` command runs the entire ARAG pipeline
-2. **Shared Resources**: Embedders, retrievers, and LLMs defined once, used by all agents
-3. **Flexible LLM Assignment**: Different models for different tasks (fast for scoring, reasoning for ranking)
-4. **Built-in Tracing**: Phoenix integration for debugging the multi-agent workflow
-5. **Tool Composition**: Coordinator can call specialized agents as tools
-
-### Observability with Phoenix
-
-The Recommendation Agent includes built-in observability using [Arize Phoenix](https://docs.arize.com/phoenix/), providing distributed tracing and LLM call visualization for debugging the multi-agent pipeline.
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    ARAG Agent Pipeline                           │
-│  (Coordinator → UUA → NLI → CSA → IRA)                          │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              │ OTLP traces (port 6006)
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Phoenix (Docker Container)                    │
-├─────────────────────────────────────────────────────────────────┤
-│  - Trace visualization for multi-agent workflow                  │
-│  - LLM call details (prompts, completions, tokens)              │
-│  - Latency breakdown per agent                                   │
-│  - Token usage and cost tracking                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Starting Phoenix:**
-
-```bash
-# Start Phoenix alongside Milvus (from project root)
-docker compose up -d
-
-# Verify Phoenix is running
-curl -s http://localhost:6006/healthz  # Should return "OK"
-```
-
-**Accessing the Phoenix UI:**
-
-Open http://localhost:6006 in your browser to view:
-- **Traces**: End-to-end request traces showing all agent calls
-- **Spans**: Individual LLM calls with prompts, completions, and token counts
-- **Latency**: Time breakdown for each step in the pipeline
-- **Errors**: Failed calls and error details
-
-**Configuration:**
-
-Phoenix tracing is configured in `configs/recommendation-ultrafast.yml`:
-
-```yaml
-general:
-  telemetry:
-    tracing:
-      phoenix:
-        _type: phoenix
-        project_name: "arag-recommendations"
-        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006}
-```
-
-**Installation:**
-
-To enable Phoenix tracing, install the Phoenix telemetry package:
-
-```bash
-pip install "nvidia-nat[phoenix]"
-```
-
-**Troubleshooting Phoenix:**
+### Phoenix Tracing Issues
 
 | Issue | Solution |
 |-------|----------|
 | No traces appearing | Verify Phoenix is running: `curl http://localhost:6006/healthz` |
 | Connection refused | Check `PHOENIX_ENDPOINT` env var matches your Phoenix URL |
 | Traces missing spans | Ensure `nvidia-nat[phoenix]` is installed |
-
-### Service Integration
-
-The recommendation service calls the ARAG agent as a single endpoint:
-
-```python
-# src/merchant/services/recommendation.py (planned)
-async def get_recommendations(
-    cart_items: list[dict], 
-    session_context: dict | None = None
-) -> list[Recommendation]:
-    """
-    Call ARAG Recommendation Agent for cross-sell suggestions.
-    
-    Layer 1 (Deterministic): Validate cart items exist in catalog
-    Layer 2 (ARAG Agent): Multi-agent recommendation pipeline  
-    Layer 3 (Deterministic): Validate recommendations are in-stock
-    """
-    # Layer 1: Validate inputs
-    validated_items = validate_cart_items(cart_items)
-    
-    # Layer 2: Call ARAG agent (single REST call)
-    response = await httpx.post(
-        f"{settings.recommendation_agent_url}/generate",
-        json={
-            "input": json.dumps({
-                "cart_items": validated_items,
-                "session_context": session_context or {}
-            })
-        },
-        timeout=15.0  # Higher timeout for multi-agent pipeline
-    )
-    
-    result = response.json()
-    
-    # Layer 3: Validate and filter recommendations
-    recommendations = validate_recommendations(
-        result.get("recommendations", []),
-        exclude_ids=[item["product_id"] for item in cart_items]
-    )
-    
-    return recommendations
-```
-
-### Research Reference
-
-> **ARAG: Agentic Retrieval Augmented Generation for Personalized Recommendation**
-> Maragheh et al., SIGIR 2025
-> https://arxiv.org/pdf/2506.21931
->
-> Key insight: Integrating agentic reasoning into RAG enables better understanding of user intent
-> and semantic alignment, leading to significantly improved recommendation quality.


### PR DESCRIPTION
## Summary

- **Removed duplicate ARAG section** (~210 lines) that was incorrectly labeled "(Planned - Feature 7)" when the feature is fully implemented; consolidated unique content (Why ARAG metrics, Architecture Benefits, Phoenix observability, Research Reference) into the existing Recommendation Agent section
- **Updated primary recommendation config** from `recommendation-ultrafast.yml` to `recommendation.yml` across README, root AGENTS.md, scoped AGENTS.md, and Dockerfile — `recommendation.yml` uses the multi-agent `sequential_executor` pipeline (~4.8s on H100, higher quality), while `recommendation-ultrafast.yml` is documented as an optional speed-optimized variant (<3s, single LLM call)
- **Improved document structure**: fixed interleaved Recommendation/Search sections, added shared infrastructure section for Milvus + Phoenix, updated Backend Integration table to reflect actual service modules, removed stale "(planned)" labels

## Test plan

- [x] Verify all `nat serve` commands in the README use correct config file names
- [x] Confirm `docker-compose.yml` already references `recommendation.yml` (no change needed there)
- [x] Review rendered markdown for broken links and table formatting


Made with [Cursor](https://cursor.com)