### PR TITLE
docker: add healthchecks for NAT agent services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,12 @@ services:
       #                    NIM_LLM_MODEL_NAME=nvidia/nemotron-3-nano
       - NIM_LLM_BASE_URL=${NIM_LLM_BASE_URL:-https://integrate.api.nvidia.com/v1}
       - NIM_LLM_MODEL_NAME=${NIM_LLM_MODEL_NAME:-nvidia/nemotron-3-nano-30b-a3b}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 5
     networks:
       - acp-network
       - acp-infra-network
@@ -167,6 +173,12 @@ services:
       # NIM Configuration
       - NIM_LLM_BASE_URL=${NIM_LLM_BASE_URL:-https://integrate.api.nvidia.com/v1}
       - NIM_LLM_MODEL_NAME=${NIM_LLM_MODEL_NAME:-nvidia/nemotron-3-nano-30b-a3b}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 5
     depends_on:
       promotion-agent:
         condition: service_started
@@ -191,6 +203,12 @@ services:
       - NIM_LLM_MODEL_NAME=${NIM_LLM_MODEL_NAME:-nvidia/nemotron-3-nano-30b-a3b}
       - NIM_EMBED_BASE_URL=${NIM_EMBED_BASE_URL:-https://integrate.api.nvidia.com/v1}
       - NIM_EMBED_MODEL_NAME=${NIM_EMBED_MODEL_NAME:-nvidia/nv-embedqa-e5-v5}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8004/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 5
     depends_on:
       promotion-agent:
         condition: service_started
@@ -215,6 +233,12 @@ services:
       - NIM_LLM_MODEL_NAME=${NIM_LLM_MODEL_NAME:-nvidia/nemotron-3-nano-30b-a3b}
       - NIM_EMBED_BASE_URL=${NIM_EMBED_BASE_URL:-https://integrate.api.nvidia.com/v1}
       - NIM_EMBED_MODEL_NAME=${NIM_EMBED_MODEL_NAME:-nvidia/nv-embedqa-e5-v5}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8005/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 5
     depends_on:
       promotion-agent:
         condition: service_started


### PR DESCRIPTION
## Problem

The four NAT agents (`promotion-agent`, `post-purchase-agent`, `recommendation-agent`, `search-agent`) all expose a `/health` HTTP endpoint when running via `nat serve`, but none had a `healthcheck:` block in `docker-compose.yml` and the shared `src/agents/Dockerfile` contains no `HEALTHCHECK` instruction.

Without a healthcheck, Docker Compose cannot detect a silent crash or a failed initialisation. `docker compose ps` will show an agent as `running` even when it is not ready to serve requests, making failures invisible to operators.

## Solution

Add a `healthcheck:` block to each of the four NAT agent services in `docker-compose.yml`, using the existing `/health` endpoint:

```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:<PORT>/health"]
  interval: 30s
  timeout: 10s
  start_period: 60s
  retries: 5
```

The `start_period` of 60 seconds accounts for the time agents need to connect to Phoenix telemetry and, for the recommendation and search agents, to Milvus. The retry count of 5 gives extra headroom compared to the 3 retries used in the main-service Dockerfiles.

The `depends_on` conditions (`service_started`) are intentionally left unchanged — they exist as a Docker Compose build-sentinel pattern to ensure the shared `nat-agents:latest` image is built before dependent services start, not as a readiness gate.

## Testing

```bash
docker compose -f docker-compose.infra.yml -f docker-compose.yml up -d
docker compose ps   # all four agents now show a health status
```