### PR TITLE
Add optional AlloyDB search support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 .env
 .venv
 .venv/
+.venv-*/
 env/
 venv/
 ENV/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,31 @@
+# Cloud Build config for the agents image (used for the search agent
+# validation; reusable for promotion/post-purchase/recommendation by changing
+# the deployed config_file at run time).
+#
+# Usage:
+#   gcloud builds submit \
+#       --config cloudbuild.yaml \
+#       --substitutions=_IMAGE=us-central1-docker.pkg.dev/$PROJECT_ID/retail-validation/search-agent:v1 \
+#       .
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - src/agents/Dockerfile
+      - -t
+      - ${_IMAGE}
+      - .
+
+images:
+  - ${_IMAGE}
+
+options:
+  machineType: E2_HIGHCPU_8
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 1800s
+
+substitutions:
+  _IMAGE: ''

--- a/src/agents/Dockerfile
+++ b/src/agents/Dockerfile
@@ -30,7 +30,8 @@ RUN pip install uv
 WORKDIR /app
 
 # Copy agent-specific pyproject.toml, README, and custom component registration
-COPY src/agents/pyproject.toml src/agents/README.md src/agents/register.py ./
+COPY src/agents/pyproject.toml src/agents/README.md \
+     src/agents/register.py src/agents/alloydb_search.py ./
 
 # Install dependencies with prerelease support for nvidia-nat
 RUN uv pip install -e ".[dev]" --system
@@ -38,15 +39,20 @@ RUN uv pip install -e ".[dev]" --system
 # Copy agent configurations
 COPY src/agents/configs ./configs
 
-# Copy scripts (for seeding Milvus, etc.)
+# Copy scripts (for seeding Milvus / AlloyDB, etc.)
 COPY src/agents/scripts ./scripts
 
-# Copy shared data (product catalog for Milvus seeder)
+# Copy shared data (product catalog for the seeders)
 COPY src/data ./src/data
 
-# No default CMD - set via docker-compose command for each agent
+# No default CMD - set via docker-compose command (local) or
+# `gcloud run deploy --command/--args` (Cloud Run).
+# For Cloud Run the agent must bind to $PORT (defaults to 8080).
 # Examples:
 # - nat serve --config_file configs/promotion.yml --port 8002
 # - nat serve --config_file configs/post-purchase.yml --port 8003
+# - nat serve --config_file configs/search.yml --host 0.0.0.0 --port 8005
+# - nat serve --config_file configs/search-alloydb.yml --host 0.0.0.0 --port 8005
 # - nat serve --config_file configs/recommendation.yml --port 8004
-# - python scripts/seed_milvus.py (for Milvus seeder)
+# - python scripts/seed_milvus.py (one-shot Milvus seeder)
+# - python scripts/seed_alloydb.py (one-shot AlloyDB seeder)

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -47,7 +47,8 @@ All ACP agents follow a **3-layer hybrid architecture** that combines determinis
 | Promotion Agent | `configs/promotion.yml` | 8002 | Strategy arbiter for dynamic pricing |
 | Post-Purchase Agent | `configs/post-purchase.yml` | 8003 | Multilingual shipping message generator |
 | Recommendation Agent (ARAG) | `configs/recommendation.yml` | 8004 | Multi-agent personalized recommendations |
-| Search Agent (RAG) | `configs/search.yml` | 8005 | Lightweight semantic product search |
+| Search Agent (RAG) | `configs/search.yml` | 8005 | Lightweight semantic product search with Milvus |
+| Search Agent (AlloyDB) | `configs/search-alloydb.yml` | 8005 | Optional semantic product search with AlloyDB AI |
 
 ## Installation
 
@@ -74,6 +75,9 @@ pip install -e ".[dev]"
 | `NVIDIA_API_KEY` | API key for NVIDIA NIM | Yes | — |
 | `MILVUS_URI` | Milvus vector database URI | For Recommendation + Search | `http://localhost:19530` |
 | `PHOENIX_ENDPOINT` | Phoenix observability endpoint | No | `http://localhost:6006` |
+| `ALLOYDB_HOST` | AlloyDB public/private host | For `search-alloydb.yml` password auth | `localhost` |
+| `ALLOYDB_INSTANCE_URI` | AlloyDB Connector instance URI | For `search-alloydb.yml` IAM auth | — |
+| `ALLOYDB_USE_IAM_AUTH` | Use AlloyDB IAM auth via connector | For Cloud Run AlloyDB search | `false` |
 
 ```bash
 export NVIDIA_API_KEY=<your_nvidia_api_key>
@@ -548,6 +552,18 @@ nat run --config_file configs/search.yml --input '{
   "query": "lightweight summer tee",
   "limit": 3
 }'
+```
+
+### AlloyDB AI Search
+
+AlloyDB AI support is available as an explicit alternate config. The default `configs/search.yml` remains Milvus-backed.
+
+```bash
+# Seed AlloyDB after creating the catalog_vectors.products table and ScaNN index prerequisites
+python scripts/seed_alloydb.py
+
+# Run the AlloyDB-backed search agent
+nat serve --config_file configs/search-alloydb.yml --port 8005
 ```
 
 ---

--- a/src/agents/alloydb_search.py
+++ b/src/agents/alloydb_search.py
@@ -1,0 +1,252 @@
+"""AlloyDB AI vector search NAT function.
+
+Registers a NAT function ``_type: alloydb_search`` that:
+
+1. Accepts a ``query`` string from a tool-calling agent.
+2. Embeds it via hosted NIM (or a NIM-compatible endpoint).
+3. Runs an ANN cosine query against AlloyDB AI (pgvector + ScaNN).
+4. Returns a JSON document with the top-k matches.
+
+This provides an optional AlloyDB-backed search path for
+``configs/search-alloydb.yml`` while leaving the default Milvus-backed
+``configs/search.yml`` unchanged. It calls the embedder endpoint directly
+rather than going through NAT's embedder abstraction, which keeps the
+dependency surface small and matches what ``scripts/seed_alloydb.py`` already
+does.
+
+Connection modes:
+
+* Password auth (``use_iam_auth=False``, default) — direct psycopg connection.
+  Used for local testing against AlloyDB public IP.
+* IAM auth (``use_iam_auth=True``) — google-cloud-alloydb-connector with the
+  Cloud Run service account's identity. Used for Cloud Run deployment.
+
+Required env vars at runtime (resolved via ``${...}`` in YAML or read here):
+
+* ``NVIDIA_API_KEY`` — for hosted NIM embeddings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+from nat.builder.builder import Builder
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+
+class AlloyDBSearchConfig(FunctionBaseConfig, name="alloydb_search"):
+    """Configuration for the AlloyDB AI vector search function."""
+
+    host: str | None = Field(
+        default=None,
+        description=(
+            "AlloyDB instance host (public IP). Required when use_iam_auth=false; "
+            "ignored when use_iam_auth=true (Connector uses alloydb_instance_uri)."
+        ),
+    )
+    port: int = Field(default=5432, description="AlloyDB Postgres port.")
+    database: str = Field(
+        default="catalog_vectors", description="AlloyDB database name."
+    )
+    user: str = Field(default="postgres", description="Database user.")
+    password: str | None = Field(
+        default=None,
+        description="Database password (ignored when use_iam_auth=true).",
+    )
+    sslmode: str = Field(default="require", description="psycopg sslmode.")
+    table: str = Field(default="products", description="Vector-indexed table name.")
+    embedding_column: str = Field(
+        default="embedding", description="Vector column name in the table."
+    )
+    top_k: int = Field(default=10, ge=1, le=100, description="Top-k matches.")
+    topic: str = Field(
+        default="Search product catalog for items matching the user query",
+        description="Tool description shown to the agent LLM.",
+    )
+
+    embedding_base_url: str = Field(
+        default="https://integrate.api.nvidia.com/v1",
+        description="OpenAI-compatible embeddings base URL (NIM).",
+    )
+    embedding_model_name: str = Field(
+        default="nvidia/nv-embedqa-e5-v5",
+        description="Embedding model identifier.",
+    )
+
+    use_iam_auth: bool = Field(
+        default=False,
+        description=(
+            "If true, connect via google-cloud-alloydb-connector with IAM auth. "
+            "Set this for Cloud Run; ``alloydb_instance_uri`` must be provided."
+        ),
+    )
+    alloydb_instance_uri: str | None = Field(
+        default=None,
+        description=(
+            "AlloyDB instance URI in the form "
+            "projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE. "
+            "Required when use_iam_auth=true."
+        ),
+    )
+
+
+def _embed_query(
+    *, base_url: str, model: str, api_key: str, query: str
+) -> list[float]:
+    """Call the OpenAI-compatible embeddings endpoint and return one vector."""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    payload = {
+        "input": [query],
+        "model": model,
+        "input_type": "query",
+        "encoding_format": "float",
+        "truncate": "END",
+    }
+    with httpx.Client(timeout=60.0) as client:
+        resp = client.post(f"{base_url}/embeddings", headers=headers, json=payload)
+        resp.raise_for_status()
+    return resp.json()["data"][0]["embedding"]
+
+
+def _build_password_conn(config: AlloyDBSearchConfig):
+    """Open a psycopg connection using password auth and return it.
+
+    Caller is responsible for closing.
+    """
+    import psycopg
+    from pgvector.psycopg import register_vector
+
+    if not config.host:
+        raise ValueError(
+            "ALLOYDB_HOST (or alloydb_search.host) must be set when "
+            "use_iam_auth=false"
+        )
+    if not config.password:
+        raise ValueError(
+            "ALLOYDB_PASSWORD (or alloydb_search.password) must be set when "
+            "use_iam_auth=false"
+        )
+    conninfo = (
+        f"host={config.host} port={config.port} dbname={config.database} "
+        f"user={config.user} password={config.password} sslmode={config.sslmode}"
+    )
+    conn = psycopg.connect(conninfo)
+    register_vector(conn)
+    return conn
+
+
+def _build_iam_conn(config: AlloyDBSearchConfig):
+    """Open a connection using google-cloud-alloydb-connector + IAM auth."""
+    from google.cloud.alloydb.connector import Connector, IPTypes  # type: ignore[import-not-found]
+    from pgvector.psycopg import register_vector
+
+    if not config.alloydb_instance_uri:
+        raise ValueError("alloydb_instance_uri is required when use_iam_auth=True")
+
+    connector = Connector()
+    conn = connector.connect(
+        config.alloydb_instance_uri,
+        "psycopg",
+        user=config.user,
+        db=config.database,
+        ip_type=IPTypes.PUBLIC,
+        enable_iam_auth=True,
+    )
+    register_vector(conn)
+    return conn
+
+
+def _run_query(
+    *, conn, table: str, embedding_column: str, query_vec: list[float], top_k: int
+) -> list[dict[str, Any]]:
+    sql = (
+        f"SELECT id, sku, name, category, subcategory, "
+        f"price_cents, stock_count, text, attributes_json, "
+        f"1 - ({embedding_column} <=> %s::vector) AS similarity "
+        f"FROM {table} "
+        f"ORDER BY {embedding_column} <=> %s::vector "
+        f"LIMIT %s"
+    )
+    with conn.cursor() as cur:
+        cur.execute(sql, (query_vec, query_vec, top_k))
+        rows = cur.fetchall()
+        cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row, strict=True)) for row in rows]
+
+
+@register_function(
+    config_type=AlloyDBSearchConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN]
+)
+async def alloydb_search_function(config: AlloyDBSearchConfig, builder: Builder):
+    """Yield a search function bound to an AlloyDB AI cosine vector index."""
+
+    _ = builder
+    api_key = os.environ.get("NVIDIA_API_KEY", "")
+
+    async def search_products(query: str) -> str:
+        """Search the product catalog with semantic vector similarity."""
+        if not query or not query.strip():
+            return json.dumps({"results": []})
+
+        query_vec = _embed_query(
+            base_url=config.embedding_base_url,
+            model=config.embedding_model_name,
+            api_key=api_key,
+            query=query.strip(),
+        )
+
+        if config.use_iam_auth:
+            conn = _build_iam_conn(config)
+        else:
+            conn = _build_password_conn(config)
+
+        try:
+            rows = _run_query(
+                conn=conn,
+                table=config.table,
+                embedding_column=config.embedding_column,
+                query_vec=query_vec,
+                top_k=config.top_k,
+            )
+        finally:
+            conn.close()
+
+        results = [
+            {
+                "product_id": str(r.get("id", "")),
+                "product_name": str(r.get("name", "")),
+                "category": str(r.get("category") or ""),
+                "subcategory": str(r.get("subcategory") or ""),
+                "price_cents": int(r["price_cents"])
+                if r.get("price_cents") is not None
+                else None,
+                "stock_count": int(r["stock_count"])
+                if r.get("stock_count") is not None
+                else None,
+                "description": str(r.get("text") or ""),
+                "score": float(r.get("similarity", 0.0)),
+            }
+            for r in rows
+        ]
+
+        logger.info(
+            "alloydb_search: query=%r returned=%d top_score=%.4f",
+            query[:80],
+            len(results),
+            results[0]["score"] if results else 0.0,
+        )
+        return json.dumps({"results": results})
+
+    yield FunctionInfo.from_fn(search_products, description=config.topic)

--- a/src/agents/configs/search-alloydb.yml
+++ b/src/agents/configs/search-alloydb.yml
@@ -1,0 +1,167 @@
+# RAG Search Agent (AlloyDB AI)
+# ============================
+# Purpose: Provide top-k product search results from AlloyDB AI embeddings.
+#
+# Usage:
+#   nat serve --config_file configs/search-alloydb.yml --port 8005
+#   nat run --config_file configs/search-alloydb.yml --input '{"query": "lightweight summer tee", "limit": 3}'
+
+general:
+  use_uvloop: true
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: info
+    tracing:
+      phoenix:
+        _type: phoenix
+        project: "search-agent"
+        endpoint: ${PHOENIX_ENDPOINT:-http://localhost:6006/v1/traces}
+
+# =============================================================================
+# FUNCTIONS - Product search tool backed by AlloyDB AI (pgvector + ScaNN)
+# =============================================================================
+# Connection mode is controlled via env vars; defaults work for local password
+# auth against AlloyDB public IP. For Cloud Run, set ALLOYDB_USE_IAM_AUTH=true
+# and ALLOYDB_INSTANCE_URI to the full
+# projects/.../locations/.../clusters/.../instances/... resource path.
+functions:
+  product_search:
+    _type: alloydb_search
+    host: ${ALLOYDB_HOST:-localhost}
+    port: ${ALLOYDB_PORT:-5432}
+    database: ${ALLOYDB_DATABASE:-catalog_vectors}
+    user: ${ALLOYDB_USER:-postgres}
+    password: ${ALLOYDB_PASSWORD:-}
+    sslmode: ${ALLOYDB_SSLMODE:-require}
+    table: products
+    embedding_column: embedding
+    top_k: 10
+    embedding_base_url: ${NIM_EMBED_BASE_URL:-https://integrate.api.nvidia.com/v1}
+    embedding_model_name: ${NIM_EMBED_MODEL_NAME:-nvidia/nv-embedqa-e5-v5}
+    use_iam_auth: ${ALLOYDB_USE_IAM_AUTH:-false}
+    alloydb_instance_uri: ${ALLOYDB_INSTANCE_URI:-}
+    topic: Search product catalog for items matching the user query
+
+# =============================================================================
+# LLM PROVIDERS
+# Model and endpoint can be configured via environment variables:
+# - NIM_LLM_BASE_URL: Public endpoint (default) or local NIM URL
+# - NIM_LLM_MODEL_NAME: Public model name (default) or local NIM model name
+# =============================================================================
+llms:
+  search_llm:
+    _type: nim
+    base_url: ${NIM_LLM_BASE_URL:-https://integrate.api.nvidia.com/v1}
+    model_name: ${NIM_LLM_MODEL_NAME:-nvidia/nemotron-3-nano-30b-a3b}
+    temperature: 0.2
+    max_tokens: 512
+    chat_template_kwargs:
+      enable_thinking: false
+
+# =============================================================================
+# EVALUATION LLMs - Judge model for eval evaluators, not the main workflow
+# Uses a larger model than the agent for unbiased evaluation scoring
+# =============================================================================
+  nim_eval_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    temperature: 0.0
+    max_tokens: 1024
+  nim_trajectory_eval_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    temperature: 0.0
+    max_tokens: 2048
+
+# =============================================================================
+# MAIN WORKFLOW - Tool-calling agent
+# =============================================================================
+workflow:
+  _type: tool_calling_agent
+  name: rag_search_agent
+  workflow_alias: search_agent
+  llm_name: search_llm
+  tool_names:
+    - product_search
+  verbose: true
+  max_iterations: 2
+  system_prompt: |-
+    You are a product search assistant. You must retrieve products using the product_search tool
+    and return the best results for the user's query. If the search results do not match the query,
+    return an empty results list instead of unrelated items.
+
+    INPUT FORMAT:
+    The input is a JSON object with:
+    - query: string (the search query)
+    - category: string | null (optional category hint)
+    - limit: number (maximum results to return)
+
+    MANDATORY FIRST STEP:
+    You MUST call product_search with a query derived directly from the user's query.
+    If a category is provided, include it in the search query.
+    Do not respond before calling the tool.
+
+    OUTPUT FORMAT (return ONLY this JSON):
+    {
+      "query": "<original query>",
+      "results": [
+        {
+          "product_id": "<exact product_id from search>",
+          "product_name": "<exact product_name from search>",
+          "snippet": "Short relevance note in one sentence",
+          "distance": 0.123
+        }
+      ]
+    }
+
+    RULES:
+    - Use exact product_id and product_name from search results.
+    - Preserve distance/score/similarity from the tool output when available.
+    - Return at most the requested limit.
+    - Do not include products not present in the search results.
+    - Return valid JSON only (no extra text).
+
+# =============================================================================
+# EVALUATION & PROFILING
+# Run with: nat eval --config_file configs/search-alloydb.yml
+# =============================================================================
+eval:
+  general:
+    output_dir: ./.tmp/eval/search_agent_alloydb
+    verbose: true
+    max_concurrency: 2
+    dataset:
+      _type: json
+      file_path: data/eval/search_eval.json
+      id_key: "id"
+      structure:
+        question_key: question
+        answer_key: answer
+    profiler:
+      token_uniqueness_forecast: true
+      workflow_runtime_forecast: true
+      compute_llm_metrics: true
+      csv_exclude_io_text: true
+      prompt_caching_prefixes:
+        enable: true
+        min_frequency: 0.1
+      bottleneck_analysis:
+        enable_nested_stack: true
+      concurrency_spike_analysis:
+        enable: true
+        spike_threshold: 5
+
+  evaluators:
+    accuracy:
+      _type: ragas
+      metric: AnswerAccuracy
+      llm_name: nim_eval_llm
+    relevance:
+      _type: ragas
+      metric: ContextRelevance
+      llm_name: nim_eval_llm
+    trajectory:
+      _type: trajectory
+      llm_name: nim_trajectory_eval_llm

--- a/src/agents/pyproject.toml
+++ b/src/agents/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64", "setuptools-scm>=8"]
 
 [tool.setuptools]
-py-modules = ["register"]
+py-modules = ["register", "alloydb_search"]
 
 [project]
 name = "acp-agents"
@@ -15,6 +15,10 @@ dependencies = [
     # NAT with RAG (Milvus retriever), LangChain, Phoenix, profiler, and Ragas extras
     "nvidia-nat[langchain,phoenix,profiler,rag,ragas]==1.6.0",
     "httpx>=0.27.0",
+    # AlloyDB AI vector search (custom alloydb_search NAT function)
+    "psycopg[binary]>=3.2.3",
+    "pgvector>=0.3.6",
+    "google-cloud-alloydb-connector[psycopg]>=1.4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/agents/register.py
+++ b/src/agents/register.py
@@ -15,13 +15,15 @@
 
 """ARAG custom components.
 
-Only three components require custom Python code:
+Custom Python components registered with NAT:
 
 1. **rag_retriever** — retrieval adapter that builds query context and normalizes
    retriever documents to ARAG candidate items.
 2. **text_function_adapter** — typed adapter that lets NAT ``chat_completion``
    steps participate in string-based control-flow chains.
 3. **output_contract_guard** — deterministic schema guard for final output.
+4. **alloydb_search** — AlloyDB AI vector search function (registered via the
+   ``alloydb_search`` module imported below).
 
 All recommendation semantics (NLI scoring, context synthesis, ranking) are
 performed by LLM agents declared in ``configs/recommendation.yml``.
@@ -38,6 +40,8 @@ from nat.cli.register_workflow import register_function
 from nat.data_models.component_ref import FunctionRef
 from nat.data_models.function import FunctionBaseConfig
 from pydantic import Field
+
+import alloydb_search  # noqa: F401  -- registers the alloydb_search function
 
 logger = logging.getLogger(__name__)
 

--- a/src/agents/scripts/seed_alloydb.py
+++ b/src/agents/scripts/seed_alloydb.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Seed AlloyDB AI (pgvector + ScaNN) with Product Catalog Embeddings.
+
+Mirrors the behavior of `seed_milvus.py` but targets AlloyDB:
+- Connects via psycopg (Postgres) + pgvector adapter.
+- Generates 1024-dim embeddings via hosted NIM (nv-embedqa-e5-v5).
+- TRUNCATEs and re-inserts all products (idempotent).
+- Creates the ScaNN index AFTER data is loaded (AlloyDB requirement).
+- Verifies with a vector similarity query.
+
+Local validation usage:
+    cd Retail-Agentic-Commerce/src/agents
+    source .venv/bin/activate    # or your venv
+    pip install "psycopg[binary]" pgvector httpx
+
+    export NVIDIA_API_KEY=nvapi-...
+    export ALLOYDB_HOST=<public_ip>
+    export ALLOYDB_PASSWORD=$(cat ../../../.alloydb_password)
+    python scripts/seed_alloydb.py
+
+Environment Variables:
+    NVIDIA_API_KEY        - Required for hosted NIM embeddings
+    ALLOYDB_HOST          - AlloyDB instance public IP
+    ALLOYDB_PORT          - Default: 5432
+    ALLOYDB_DATABASE      - Default: catalog_vectors
+    ALLOYDB_USER          - Default: postgres
+    ALLOYDB_PASSWORD      - Postgres password for ALLOYDB_USER
+    ALLOYDB_SSLMODE       - Default: require
+    NIM_EMBED_BASE_URL    - Default: https://integrate.api.nvidia.com/v1
+    NIM_EMBED_MODEL_NAME  - Default: nvidia/nv-embedqa-e5-v5
+    SCANN_NUM_LEAVES      - Default: 50
+    BATCH_SIZE            - Embedding batch size, default: 32
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import psycopg
+from pgvector.psycopg import register_vector
+
+try:
+    sys.path.insert(0, "/app")
+    from src.data.product_catalog import PRODUCTS
+except ImportError:
+    project_root = Path(__file__).parent.parent.parent.parent
+    sys.path.insert(0, str(project_root))
+    from src.data.product_catalog import PRODUCTS
+
+NVIDIA_API_KEY = os.environ.get("NVIDIA_API_KEY", "")
+NIM_EMBED_BASE_URL = os.environ.get(
+    "NIM_EMBED_BASE_URL", "https://integrate.api.nvidia.com/v1"
+)
+EMBEDDING_MODEL = os.environ.get("NIM_EMBED_MODEL_NAME", "nvidia/nv-embedqa-e5-v5")
+EMBED_API_URL = f"{NIM_EMBED_BASE_URL}/embeddings"
+EMBEDDING_DIM = 1024
+
+ALLOYDB_HOST = os.environ.get("ALLOYDB_HOST", "")
+ALLOYDB_PORT = os.environ.get("ALLOYDB_PORT", "5432")
+ALLOYDB_DATABASE = os.environ.get("ALLOYDB_DATABASE", "catalog_vectors")
+ALLOYDB_USER = os.environ.get("ALLOYDB_USER", "postgres")
+ALLOYDB_PASSWORD = os.environ.get("ALLOYDB_PASSWORD", "")
+ALLOYDB_SSLMODE = os.environ.get("ALLOYDB_SSLMODE", "require")
+
+SCANN_NUM_LEAVES = int(os.environ.get("SCANN_NUM_LEAVES", "50"))
+BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "32"))
+
+
+def conninfo() -> str:
+    return (
+        f"host={ALLOYDB_HOST} port={ALLOYDB_PORT} dbname={ALLOYDB_DATABASE} "
+        f"user={ALLOYDB_USER} password={ALLOYDB_PASSWORD} sslmode={ALLOYDB_SSLMODE}"
+    )
+
+
+def embed_batch(texts: list[str]) -> list[list[float]]:
+    headers = {"Content-Type": "application/json"}
+    if NVIDIA_API_KEY:
+        headers["Authorization"] = f"Bearer {NVIDIA_API_KEY}"
+    payload = {
+        "input": texts,
+        "model": EMBEDDING_MODEL,
+        "input_type": "passage",
+        "encoding_format": "float",
+        "truncate": "END",
+    }
+    with httpx.Client(timeout=120.0) as client:
+        resp = client.post(EMBED_API_URL, headers=headers, json=payload)
+        resp.raise_for_status()
+    data = resp.json()["data"]
+    return [item["embedding"] for item in data]
+
+
+def get_embeddings(texts: list[str]) -> list[list[float]]:
+    out: list[list[float]] = []
+    for i in range(0, len(texts), BATCH_SIZE):
+        chunk = texts[i : i + BATCH_SIZE]
+        print(
+            f"  Embedding batch {i // BATCH_SIZE + 1}: "
+            f"{len(chunk)} texts (offset {i})"
+        )
+        out.extend(embed_batch(chunk))
+    return out
+
+
+def build_rows() -> tuple[list[str], list[tuple]]:
+    embedding_texts = []
+    for p in PRODUCTS:
+        attrs = ", ".join(p["attributes"])
+        embedding_texts.append(
+            f"{p['name']}. {p['description']} "
+            f"Category: {p['category']}. Attributes: {attrs}"
+        )
+
+    embeddings = get_embeddings(embedding_texts)
+    print(
+        f"  Generated {len(embeddings)} embeddings "
+        f"(dim={len(embeddings[0]) if embeddings else 0})"
+    )
+
+    rows: list[tuple] = []
+    for p, vec in zip(PRODUCTS, embeddings, strict=True):
+        rows.append(
+            (
+                p["id"],
+                p["sku"],
+                p["name"],
+                p.get("category"),
+                p.get("subcategory"),
+                p.get("price_cents"),
+                p.get("stock_count"),
+                p["description"],
+                json.dumps(p.get("attributes", [])),
+                vec,
+            )
+        )
+    return embedding_texts, rows
+
+
+def seed():
+    print("=" * 60)
+    print("ALLOYDB PRODUCT CATALOG SEEDER")
+    print("=" * 60)
+    print(f"  Host:     {ALLOYDB_HOST}:{ALLOYDB_PORT}")
+    print(f"  Database: {ALLOYDB_DATABASE}")
+    print(f"  User:     {ALLOYDB_USER}")
+    print(f"  Embed:    {EMBEDDING_MODEL} via {NIM_EMBED_BASE_URL}")
+    print(f"  Products: {len(PRODUCTS)}")
+
+    if not NVIDIA_API_KEY:
+        print("\nERROR: NVIDIA_API_KEY is required")
+        sys.exit(1)
+    if not ALLOYDB_HOST or not ALLOYDB_PASSWORD:
+        print("\nERROR: ALLOYDB_HOST and ALLOYDB_PASSWORD are required")
+        sys.exit(1)
+
+    print("\n1. Generating embeddings via hosted NIM...")
+    _, rows = build_rows()
+
+    print("\n2. Connecting to AlloyDB...")
+    with psycopg.connect(conninfo()) as conn:
+        register_vector(conn)
+        with conn.cursor() as cur:
+            print("\n3. TRUNCATEing products table (idempotent re-seed)...")
+            cur.execute("TRUNCATE TABLE products")
+
+            print("\n4. Dropping existing ScaNN index if present...")
+            cur.execute("DROP INDEX IF EXISTS products_embedding_scann")
+
+            print(f"\n5. INSERTing {len(rows)} products...")
+            cur.executemany(
+                """
+                INSERT INTO products (
+                    id, sku, name, category, subcategory,
+                    price_cents, stock_count, text, attributes_json, embedding
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+                """,
+                rows,
+            )
+
+            print(
+                f"\n6. Creating ScaNN index "
+                f"(num_leaves={SCANN_NUM_LEAVES}, cosine)..."
+            )
+            cur.execute(
+                f"""
+                CREATE INDEX products_embedding_scann
+                    ON products
+                    USING scann (embedding cosine)
+                    WITH (num_leaves = {SCANN_NUM_LEAVES})
+                """
+            )
+
+            print("\n7. ANALYZE products...")
+            cur.execute("ANALYZE products")
+
+        conn.commit()
+
+        print("\n8. Verifying with a sample vector query...")
+        test_query = "casual pants to wear with a t-shirt"
+        query_vec = embed_batch([test_query])[0]
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, name, category,
+                       1 - (embedding <=> %s::vector) AS similarity
+                FROM products
+                ORDER BY embedding <=> %s::vector
+                LIMIT 5
+                """,
+                (query_vec, query_vec),
+            )
+            rows = cur.fetchall()
+
+        print(f"\n   Test query: '{test_query}'")
+        print("   Top 5 results:")
+        for i, (pid, name, cat, sim) in enumerate(rows, start=1):
+            print(f"     {i}. [{pid}] {name} ({cat}) sim={sim:.4f}")
+
+    print("\n" + "=" * 60)
+    print(f"SUCCESS: Seeded {len(PRODUCTS)} products into AlloyDB")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        seed()
+    except Exception as exc:
+        print(f"\nERROR: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary

This PR adds optional AlloyDB AI vector search support for the Search Agent without changing the default Milvus-backed behavior.

- Adds a new NAT function (`alloydb_search`) that embeds queries via NIM and runs cosine vector search against AlloyDB (pgvector + ScaNN).
- Adds a dedicated config (`configs/search-alloydb.yml`) for AlloyDB deployments; the default `configs/search.yml` remains Milvus-backed and is unchanged.
- Adds an AlloyDB seeder (`scripts/seed_alloydb.py`) mirroring the existing Milvus seeder.
- Registers the new function in `register.py` and adds required dependencies (`psycopg`, `pgvector`, `google-cloud-alloydb-connector`).
- Updates the agents Docker image and adds `cloudbuild.yaml` for native amd64 Cloud Build image builds.

## Why

The blueprint currently supports Milvus for local/docker-compose workflows. This change adds an opt-in AlloyDB path for GCP deployments (for example Cloud Run + AlloyDB AI) while preserving existing Milvus defaults for adopters who do not use AlloyDB.

## Usage

**Default (unchanged):**
```bash
nat serve --config_file configs/search.yml --port 8005
```

**AlloyDB (opt-in):**
```bash
python scripts/seed_alloydb.py
nat serve --config_file configs/search-alloydb.yml --port 8005
```

For Cloud Run, pass `--config_file=configs/search-alloydb.yml` and set AlloyDB env vars (`ALLOYDB_USE_IAM_AUTH`, `ALLOYDB_INSTANCE_URI`, etc.).

## Test plan

- [ ] Confirm `configs/search.yml` still uses `milvus_retriever` + `nat_retriever` (default behavior unchanged)
- [ ] Run Search Agent locally with `configs/search.yml` against seeded Milvus
- [ ] Seed AlloyDB with `scripts/seed_alloydb.py` and run Search Agent with `configs/search-alloydb.yml`
- [ ] Verify Cloud Run deploy with `configs/search-alloydb.yml` and AlloyDB IAM auth (optional GCP validation)
- [ ] Confirm recommendation agent and other configs still use Milvus unchanged