### PR TITLE
[frontend] Fix Apps SDK mode tab activation

### DIFF
--- a/src/ui/components/agent/ModeTabSwitcher.test.tsx
+++ b/src/ui/components/agent/ModeTabSwitcher.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ModeTabSwitcher, type CheckoutMode } from "./ModeTabSwitcher";
+
+describe("ModeTabSwitcher", () => {
+  it("marks the active mode as selected", () => {
+    render(<ModeTabSwitcher activeMode="native" onModeChange={vi.fn()} />);
+
+    expect(screen.getByRole("tab", { name: "Native" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Apps SDK" })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("updates selection immediately when Apps SDK is clicked", () => {
+    const onModeChange = vi.fn();
+    render(<ModeTabSwitcher activeMode="native" onModeChange={onModeChange} />);
+
+    const appsSdkTab = screen.getByRole("tab", { name: "Apps SDK" });
+    fireEvent.click(appsSdkTab);
+
+    expect(appsSdkTab).toHaveAttribute("aria-selected", "true");
+    expect(onModeChange).toHaveBeenCalledWith("apps-sdk");
+  });
+
+  it("updates selection on mouse down before click handling completes", () => {
+    const onModeChange = vi.fn();
+    render(<ModeTabSwitcher activeMode="native" onModeChange={onModeChange} />);
+
+    const appsSdkTab = screen.getByRole("tab", { name: "Apps SDK" });
+    fireEvent.mouseDown(appsSdkTab, { button: 0 });
+
+    expect(appsSdkTab).toHaveAttribute("aria-selected", "true");
+    expect(onModeChange).toHaveBeenCalledWith("apps-sdk");
+  });
+
+  it("does not request the same mode twice during a full mouse click sequence", () => {
+    const onModeChange = vi.fn();
+    render(<ModeTabSwitcher activeMode="native" onModeChange={onModeChange} />);
+
+    const appsSdkTab = screen.getByRole("tab", { name: "Apps SDK" });
+    fireEvent.mouseDown(appsSdkTab, { button: 0 });
+    fireEvent.click(appsSdkTab);
+
+    expect(onModeChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports keyboard activation", () => {
+    const onModeChange = vi.fn();
+    render(<ModeTabSwitcher activeMode="native" onModeChange={onModeChange} />);
+
+    const appsSdkTab = screen.getByRole("tab", { name: "Apps SDK" });
+    fireEvent.keyDown(appsSdkTab, { key: "Enter" });
+
+    expect(appsSdkTab).toHaveAttribute("aria-selected", "true");
+    expect(onModeChange).toHaveBeenCalledWith("apps-sdk");
+  });
+
+  it("syncs selection when the parent mode changes", () => {
+    const Wrapper = ({ mode }: { mode: CheckoutMode }) => (
+      <ModeTabSwitcher activeMode={mode} onModeChange={vi.fn()} />
+    );
+    const { rerender } = render(<Wrapper mode="native" />);
+
+    rerender(<Wrapper mode="apps-sdk" />);
+
+    expect(screen.getByRole("tab", { name: "Apps SDK" })).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/src/ui/components/agent/ModeTabSwitcher.tsx
+++ b/src/ui/components/agent/ModeTabSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * Available checkout modes
@@ -50,30 +50,36 @@ const TABS: TabConfig[] = [
  * - Smooth transition animations
  */
 export function ModeTabSwitcher({ activeMode, onModeChange }: ModeTabSwitcherProps) {
-  const handleTabClick = useCallback(
+  const [selectedMode, setSelectedMode] = useState<CheckoutMode>(activeMode);
+
+  useEffect(() => {
+    setSelectedMode(activeMode);
+  }, [activeMode]);
+
+  const selectMode = useCallback(
     (mode: CheckoutMode) => {
-      if (mode !== activeMode) {
-        onModeChange(mode);
-      }
+      if (mode === selectedMode) return;
+      setSelectedMode(mode);
+      onModeChange(mode);
     },
-    [activeMode, onModeChange]
+    [selectedMode, onModeChange]
   );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent, mode: CheckoutMode) => {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
-        handleTabClick(mode);
+        selectMode(mode);
       }
     },
-    [handleTabClick]
+    [selectMode]
   );
 
   return (
     <div className="mode-tab-switcher" role="tablist" aria-label="Checkout mode">
       <div className="mode-tab-container">
         {TABS.map((tab) => {
-          const isActive = activeMode === tab.mode;
+          const isActive = selectedMode === tab.mode;
           return (
             <button
               key={tab.mode}
@@ -82,7 +88,12 @@ export function ModeTabSwitcher({ activeMode, onModeChange }: ModeTabSwitcherPro
               aria-controls={`panel-${tab.mode}`}
               tabIndex={isActive ? 0 : -1}
               className={`mode-tab ${isActive ? "active" : ""}`}
-              onClick={() => handleTabClick(tab.mode)}
+              onMouseDown={(e) => {
+                if (e.button === 0) {
+                  selectMode(tab.mode);
+                }
+              }}
+              onClick={() => selectMode(tab.mode)}
               onKeyDown={(e) => handleKeyDown(e, tab.mode)}
               title={tab.description}
             >


### PR DESCRIPTION
## Summary
- Fixes the Apps SDK checkout mode tab so selection updates immediately on mouse activation before click handling completes.
- Keeps the switcher synchronized with the parent active mode and adds focused component coverage for click, mouse-down, keyboard, and parent sync behavior.

## Test plan
- `pnpm lint` from `src/ui`
- `pnpm typecheck` from `src/ui`
- `pnpm test:run` from `src/ui` (222 tests passed)
- `pnpm format:check` from `src/ui`
- `pnpm build` from `src/ui`
- Checked failing GitHub Actions job: https://github.com/NVIDIA-AI-Blueprints/Retail-Agentic-Commerce/actions/runs/27980938182/job/82810521807

## Related issue/feature
- Fixes Blueprint QA failure in `Retail Agentic Commerce UI E2E` where the external test clicked the `Apps SDK` tab but `aria-selected` stayed `false`.