### PR TITLE
fix(checkout): verify settled payment before completing checkout

### DIFF
--- a/src/merchant/domain/checkout/service.py
+++ b/src/merchant/domain/checkout/service.py
@@ -47,6 +47,11 @@ from src.merchant.domain.checkout.models import (
     UpdateCheckoutRequest,
 )
 
+# Importing the PSP models also registers their tables on the shared SQLModel
+# metadata, so the merchant engine (same database, see payment/config.py) can
+# read the settled payment state written by the PSP service.
+from src.payment.db.models import PaymentIntent, PaymentIntentStatus, VaultToken
+
 logger = logging.getLogger(__name__)
 
 
@@ -92,6 +97,19 @@ class InvalidStateTransitionError(CheckoutServiceError):
             message=f"Cannot {action} session with status '{current_status}'",
             code="invalid_status_transition",
         )
+
+
+class PaymentVerificationError(CheckoutServiceError):
+    """Raised when a checkout cannot be completed because payment is unverified.
+
+    The order (the paid resource) must only be released once a settled payment
+    is bound to the session and covers the server-computed total. This is raised
+    when that invariant does not hold, so the caller never receives an order
+    without a confirmed transfer (issue #112).
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message=message, code="invalid_payment")
 
 
 # =============================================================================
@@ -511,10 +529,69 @@ async def update_checkout_session_from_data(
     return await update_checkout_session(db, session_id, request)
 
 
+def _session_total_amount(session: CheckoutSession) -> int:
+    """Return the server-computed grand total for a session (minor units).
+
+    Reads the persisted totals, never a caller-supplied amount.
+    """
+    totals: list[dict[str, Any]] = json.loads(session.totals_json)
+    return next((t["amount"] for t in totals if t["type"] == "total"), 0)
+
+
+def verify_payment_for_session(
+    db: Session, session: CheckoutSession, payment_token: str
+) -> None:
+    """Verify a settled payment is bound to the session before releasing it.
+
+    Enforces the issue #112 invariant: an order may only be created when a
+    completed payment intent exists that is (a) reached via the presented vault
+    token, (b) bound to THIS session via the vault token's allowance, (c) covers
+    the server-computed session total, and (d) matches the session currency.
+
+    Args:
+        db: Database session (shared DB also holds the PSP tables).
+        session: The checkout session being completed.
+        payment_token: The vault token presented in ``payment_data.token``.
+
+    Raises:
+        PaymentVerificationError: If no settled, bound, sufficient payment exists.
+    """
+    vault_token = db.exec(
+        select(VaultToken).where(VaultToken.id == payment_token)
+    ).first()
+    if vault_token is None:
+        raise PaymentVerificationError("No payment is associated with this token.")
+
+    # The vault token's allowance must be bound to THIS checkout session.
+    allowance: dict[str, Any] = json.loads(vault_token.allowance_json)
+    if allowance.get("checkout_session_id") != session.id:
+        raise PaymentVerificationError(
+            "Payment token is not bound to this checkout session."
+        )
+
+    # A completed payment intent must exist for this vault token.
+    payment_intent = db.exec(
+        select(PaymentIntent)
+        .where(PaymentIntent.vault_token_id == vault_token.id)
+        .where(PaymentIntent.status == PaymentIntentStatus.COMPLETED)
+    ).first()
+    if payment_intent is None:
+        raise PaymentVerificationError("Payment has not been completed.")
+
+    # The settled amount must cover the server-computed total, same currency.
+    session_total = _session_total_amount(session)
+    if payment_intent.amount < session_total:
+        raise PaymentVerificationError("Payment amount does not cover the order total.")
+    if payment_intent.currency.lower() != session.currency.lower():
+        raise PaymentVerificationError(
+            "Payment currency does not match the order currency."
+        )
+
+
 def complete_checkout_session(
     db: Session,
     session_id: str,
-    payment_data: PaymentDataInput,  # noqa: ARG001  # Reserved for payment validation
+    payment_data: PaymentDataInput,
     buyer: BuyerInput | None = None,
 ) -> CheckoutSessionResponse:
     """Complete a checkout session with payment.
@@ -559,6 +636,10 @@ def complete_checkout_session(
     if not check_ready_for_payment(session):
         logger.warning(f"Session {session_id} not ready for payment")
         raise InvalidStateTransitionError(session.status.value, "complete")
+
+    # Verify a settled payment is bound to this session and covers the total
+    # before releasing the order (issue #112).
+    verify_payment_for_session(db, session, payment_data.token)
 
     # Create order
     order_id = generate_order_id()

--- a/src/merchant/protocols/acp/api/routes/checkout.py
+++ b/src/merchant/protocols/acp/api/routes/checkout.py
@@ -22,6 +22,7 @@ from src.merchant.api.dependencies import verify_api_key
 from src.merchant.db.database import get_session
 from src.merchant.domain.checkout.service import (
     InvalidStateTransitionError,
+    PaymentVerificationError,
     ProductNotFoundError,
     SessionNotFoundError,
     cancel_checkout_session,
@@ -86,6 +87,16 @@ def _handle_service_error(error: Exception) -> HTTPException:
             detail=ErrorResponse(
                 type=ErrorTypeEnum.METHOD_NOT_ALLOWED,
                 code=ErrorResponseCodeEnum.INVALID_STATUS_TRANSITION,
+                message=error.message,
+            ).model_dump(),
+        )
+
+    if isinstance(error, PaymentVerificationError):
+        return HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=ErrorResponse(
+                type=ErrorTypeEnum.INVALID_REQUEST,
+                code=ErrorResponseCodeEnum.INVALID_PAYMENT,
                 message=error.message,
             ).model_dump(),
         )
@@ -300,7 +311,11 @@ def complete_checkout(
             )
 
         return response
-    except (SessionNotFoundError, InvalidStateTransitionError) as e:
+    except (
+        SessionNotFoundError,
+        InvalidStateTransitionError,
+        PaymentVerificationError,
+    ) as e:
         raise _handle_service_error(e) from e
 
 

--- a/tests/merchant/api/test_checkout.py
+++ b/tests/merchant/api/test_checkout.py
@@ -15,8 +15,77 @@
 
 """Tests for the checkout session API endpoints."""
 
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from src.merchant.db import get_engine
+from src.payment.db.models import PaymentIntent, PaymentIntentStatus, VaultToken
+
+
+def _settle_payment(
+    *,
+    checkout_session_id: str,
+    amount: int,
+    currency: str = "usd",
+    status: PaymentIntentStatus = PaymentIntentStatus.COMPLETED,
+) -> str:
+    """Insert a vault token + payment intent into the shared DB.
+
+    Mirrors what the PSP service writes after a successful
+    ``create_and_process_payment_intent`` call. Returns the vault token ID,
+    which is what a client presents as ``payment_data.token``.
+
+    Args:
+        checkout_session_id: Session the vault token's allowance is bound to.
+        amount: Payment intent amount in minor units (cents).
+        currency: ISO 4217 currency code.
+        status: Payment intent status (default COMPLETED).
+
+    Returns:
+        The vault token ID (``vt_...``).
+    """
+    token_id = f"vt_{uuid.uuid4().hex[:12]}"
+    allowance = {
+        "reason": "one_time",
+        "max_amount": amount,
+        "currency": currency,
+        "checkout_session_id": checkout_session_id,
+        "merchant_id": "merchant_001",
+        "expires_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+    }
+    vault_token = VaultToken(
+        id=token_id,
+        idempotency_key=uuid.uuid4().hex,
+        payment_method_json="{}",
+        allowance_json=json.dumps(allowance),
+    )
+    completed_at = (
+        datetime.now(UTC) if status == PaymentIntentStatus.COMPLETED else None
+    )
+    intent = PaymentIntent(
+        id=f"pi_{uuid.uuid4().hex[:12]}",
+        vault_token_id=token_id,
+        amount=amount,
+        currency=currency.lower(),
+        status=status,
+        completed_at=completed_at,
+    )
+    with Session(get_engine()) as db:
+        db.add(vault_token)
+        db.add(intent)
+        db.commit()
+    return token_id
+
+
+def _session_total(auth_client: TestClient, session_id: str) -> int:
+    """Read the server-computed total (minor units) for a session."""
+    data = auth_client.get(f"/checkout_sessions/{session_id}").json()
+    return next(t["amount"] for t in data["totals"] if t["type"] == "total")
 
 
 class TestCreateCheckoutSession:
@@ -558,12 +627,14 @@ class TestUpdateCheckoutSession:
             json={"fulfillment_option_id": fulfillment_option_id},
         )
 
-        # Complete the session
+        # Complete the session (settle a payment that covers the total first)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
         auth_client.post(
             f"/checkout_sessions/{session_id}/complete",
             json={
                 "payment_data": {
-                    "token": "tok_test",
+                    "token": token,
                     "provider": "stripe",
                 }
             },
@@ -612,10 +683,12 @@ class TestCompleteCheckoutSession:
     def test_complete_ready_session_returns_200(self, auth_client: TestClient) -> None:
         """Happy path: Completing a ready session returns 200."""
         session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
 
         response = auth_client.post(
             f"/checkout_sessions/{session_id}/complete",
-            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+            json={"payment_data": {"token": token, "provider": "stripe"}},
         )
 
         assert response.status_code == 200
@@ -625,10 +698,12 @@ class TestCompleteCheckoutSession:
     ) -> None:
         """Happy path: Completed session has status 'completed'."""
         session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
 
         response = auth_client.post(
             f"/checkout_sessions/{session_id}/complete",
-            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+            json={"payment_data": {"token": token, "provider": "stripe"}},
         )
         data = response.json()
 
@@ -637,10 +712,12 @@ class TestCompleteCheckoutSession:
     def test_complete_session_creates_order(self, auth_client: TestClient) -> None:
         """Happy path: Completed session includes order object."""
         session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
 
         response = auth_client.post(
             f"/checkout_sessions/{session_id}/complete",
-            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+            json={"payment_data": {"token": token, "provider": "stripe"}},
         )
         data = response.json()
 
@@ -654,6 +731,8 @@ class TestCompleteCheckoutSession:
     ) -> None:
         """Happy path: Complete checkout can update buyer with last_name."""
         session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
 
         response = auth_client.post(
             f"/checkout_sessions/{session_id}/complete",
@@ -663,7 +742,7 @@ class TestCompleteCheckoutSession:
                     "last_name": "User",
                     "email": "complete.user@example.com",
                 },
-                "payment_data": {"token": "tok_test", "provider": "stripe"},
+                "payment_data": {"token": token, "provider": "stripe"},
             },
         )
         data = response.json()
@@ -707,11 +786,13 @@ class TestCompleteCheckoutSession:
     ) -> None:
         """Failure case: Completing an already completed session returns 405."""
         session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
 
         # Complete once
         auth_client.post(
             f"/checkout_sessions/{session_id}/complete",
-            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+            json={"payment_data": {"token": token, "provider": "stripe"}},
         )
 
         # Try to complete again
@@ -721,6 +802,147 @@ class TestCompleteCheckoutSession:
         )
 
         assert response.status_code == 405
+
+
+class TestCompleteCheckoutPaymentVerification:
+    """Payment verification gate for POST /checkout_sessions/{id}/complete.
+
+    Regression suite for issue #112: an order must only be created when a
+    settled payment intent is bound to the session, covers the server-computed
+    total, and matches the session currency.
+    """
+
+    def _create_ready_session(self, auth_client: TestClient) -> str:
+        """Helper to create a session ready for payment."""
+        create_response = auth_client.post(
+            "/checkout_sessions",
+            json={
+                "items": [{"id": "prod_1", "quantity": 1}],
+                "buyer": {"first_name": "Ready", "email": "ready@example.com"},
+                "fulfillment_address": {
+                    "name": "Ready User",
+                    "line_one": "100 Ready St",
+                    "city": "Ready City",
+                    "state": "RD",
+                    "country": "US",
+                    "postal_code": "00000",
+                },
+            },
+        )
+        session_id = create_response.json()["id"]
+        fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
+        auth_client.post(
+            f"/checkout_sessions/{session_id}",
+            json={"fulfillment_option_id": fulfillment_option_id},
+        )
+        return session_id
+
+    def test_complete_without_settled_payment_returns_402(
+        self, auth_client: TestClient
+    ) -> None:
+        """A token with no settled payment intent must not create an order."""
+        session_id = self._create_ready_session(auth_client)
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": "tok_unsettled", "provider": "stripe"}},
+        )
+
+        assert response.status_code == 402
+        assert response.json()["detail"]["code"] == "invalid_payment"
+
+    def test_complete_with_underpaying_intent_returns_402(
+        self, auth_client: TestClient
+    ) -> None:
+        """A settled intent below the server total must not create an order."""
+        session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total - 1)
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": token, "provider": "stripe"}},
+        )
+
+        assert response.status_code == 402
+        assert response.json()["detail"]["code"] == "invalid_payment"
+
+    def test_complete_with_intent_for_other_session_returns_402(
+        self, auth_client: TestClient
+    ) -> None:
+        """A settled intent bound to another session must not be reusable."""
+        session_id = self._create_ready_session(auth_client)
+        other_session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        # Settle a payment for a DIFFERENT session, then present its token here.
+        token = _settle_payment(
+            checkout_session_id=other_session_id, amount=total + 1000
+        )
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": token, "provider": "stripe"}},
+        )
+
+        assert response.status_code == 402
+        assert response.json()["detail"]["code"] == "invalid_payment"
+
+    def test_complete_with_wrong_currency_intent_returns_402(
+        self, auth_client: TestClient
+    ) -> None:
+        """A settled intent in a different currency must not create an order."""
+        session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(
+            checkout_session_id=session_id, amount=total, currency="eur"
+        )
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": token, "provider": "stripe"}},
+        )
+
+        assert response.status_code == 402
+        assert response.json()["detail"]["code"] == "invalid_payment"
+
+    def test_complete_with_pending_intent_returns_402(
+        self, auth_client: TestClient
+    ) -> None:
+        """A pending (not completed) intent must not create an order."""
+        session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(
+            checkout_session_id=session_id,
+            amount=total,
+            status=PaymentIntentStatus.PENDING,
+        )
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": token, "provider": "stripe"}},
+        )
+
+        assert response.status_code == 402
+        assert response.json()["detail"]["code"] == "invalid_payment"
+
+    def test_complete_with_settled_payment_creates_order(
+        self, auth_client: TestClient
+    ) -> None:
+        """A settled intent that covers the total in the right currency succeeds."""
+        session_id = self._create_ready_session(auth_client)
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
+
+        response = auth_client.post(
+            f"/checkout_sessions/{session_id}/complete",
+            json={"payment_data": {"token": token, "provider": "stripe"}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "completed"
+        assert data["order"] is not None
+        assert data["order"]["id"].startswith("order_")
 
 
 class TestCancelCheckoutSession:
@@ -816,14 +1038,16 @@ class TestCancelCheckoutSession:
         session_id = create_response.json()["id"]
         fulfillment_option_id = create_response.json()["fulfillment_options"][0]["id"]
 
-        # Make it ready and complete
+        # Make it ready and complete (settle a payment that covers the total)
         auth_client.post(
             f"/checkout_sessions/{session_id}",
             json={"fulfillment_option_id": fulfillment_option_id},
         )
+        total = _session_total(auth_client, session_id)
+        token = _settle_payment(checkout_session_id=session_id, amount=total)
         auth_client.post(
             f"/checkout_sessions/{session_id}/complete",
-            json={"payment_data": {"token": "tok_test", "provider": "stripe"}},
+            json={"payment_data": {"token": token, "provider": "stripe"}},
         )
 
         response = auth_client.post(f"/checkout_sessions/{session_id}/cancel")

--- a/tests/merchant/api/test_ucp_a2a.py
+++ b/tests/merchant/api/test_ucp_a2a.py
@@ -17,22 +17,73 @@
 
 from __future__ import annotations
 
+import json
 import uuid
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlmodel import Session
 
 from src.merchant.config import get_settings
-from src.merchant.db.database import reset_engine
+from src.merchant.db.database import get_engine, reset_engine
 from src.merchant.protocols.ucp.services.a2a_transport import (
     A2A_UCP_EXTENSION_URL,
     clear_context_sessions,
+    get_checkout_id_for_context,
 )
 from src.merchant.protocols.ucp.services.agent_executor import clear_idempotency_cache
 from src.merchant.protocols.ucp.services.negotiation import clear_profile_cache
 from src.merchant.services.idempotency import reset_idempotency_store
+from src.payment.db.models import PaymentIntent, PaymentIntentStatus, VaultToken
+
+
+def _settle_ucp_payment(context_id: str, token: str) -> None:
+    """Settle a payment bound to a UCP checkout session for the given token.
+
+    Looks up the checkout session behind the A2A context, reads its
+    server-computed total, and writes a vault token + completed payment intent
+    (what the PSP service would persist) so the completion gate passes.
+    """
+    session_id = get_checkout_id_for_context(context_id)
+    assert session_id is not None
+    with Session(get_engine()) as db:
+        from src.merchant.db.models import CheckoutSession
+
+        session = db.get(CheckoutSession, session_id)
+        assert session is not None
+        totals = json.loads(session.totals_json)
+        total = next(t["amount"] for t in totals if t["type"] == "total")
+        allowance = {
+            "reason": "one_time",
+            "max_amount": total,
+            "currency": session.currency.lower(),
+            "checkout_session_id": session_id,
+            "merchant_id": "merchant_001",
+            "expires_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+        }
+        db.add(
+            VaultToken(
+                id=token,
+                idempotency_key=uuid.uuid4().hex,
+                payment_method_json="{}",
+                allowance_json=json.dumps(allowance),
+            )
+        )
+        db.add(
+            PaymentIntent(
+                id=f"pi_{uuid.uuid4().hex[:12]}",
+                vault_token_id=token,
+                amount=total,
+                currency=session.currency.lower(),
+                status=PaymentIntentStatus.COMPLETED,
+                completed_at=datetime.now(UTC),
+            )
+        )
+        db.commit()
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -437,6 +488,7 @@ class TestCheckoutActions:
         )
         create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
         ctx = create_resp.json()["result"]["contextId"]
+        _settle_ucp_payment(ctx, "vt_test_123")
 
         complete_req = _make_request(
             "complete_checkout",
@@ -521,6 +573,7 @@ class TestCheckoutActions:
         )
         create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
         ctx = create_resp.json()["result"]["contextId"]
+        _settle_ucp_payment(ctx, "vt_test_456")
 
         complete_req = _make_request(
             "complete_checkout",


### PR DESCRIPTION
## Summary

`complete_checkout_session` created an order after only a **readiness** check (line items, buyer, and fulfillment present) and **ignored `payment_data` entirely** — the parameter was annotated `# noqa: ARG001 # Reserved for payment validation`. A client could complete a checkout with an arbitrary token and receive a confirmed order with **no settled payment**, releasing the paid resource before any confirmed transfer.

Fixes #112.

## The invariant this enforces

An order is now created only when a settled payment is bound to the session. Before releasing the order, `verify_payment_for_session` requires a `PaymentIntent` that is:

1. **Settled** — `status == COMPLETED`;
2. **Reached via the presented vault token** — looked up from `payment_data.token`;
3. **Bound to *this* session** — the vault token's `allowance.checkout_session_id` matches the session being completed (a payment settled for another session cannot be replayed here);
4. **Sufficient** — `amount >= ` the **server-computed** session total (read from `totals_json`, never a caller-supplied amount — this addresses the issue's "PSP allowance is client supplied and not bound to merchant total" point);
5. **Same currency** as the session.

If any clause fails, the merchant returns **`402 Payment Required`** with code `invalid_payment` and **no order is created**.

## How the merchant sees the payment

The PSP and merchant **share the same database** (see `src/payment/config.py` — "Database (shared with merchant service)"). Importing the PSP models into the checkout service also registers their tables on the shared `SQLModel` metadata, so the merchant reads the settled `payment_intent` / `vault_token` state in-process — no cross-service HTTP call. This is a **verify-only** gate: it confirms a completed payment exists; it does not itself initiate payment (that remains the PSP's `create_and_process_payment_intent`).

## Ordering / backwards-compatibility

The payment check runs **after** the existing readiness check, so prior behaviour is preserved: not-found → `404`, not-ready → `405`, already-completed → `405`. The new failure mode is `402` for a ready session lacking a verified payment. Callers that previously completed a checkout without settling a payment will now correctly receive `402` instead of a free order — an intended behaviour change.

## Tests

- New `TestCompleteCheckoutPaymentVerification` covers the bypass and every binding clause: no settled payment, underpayment, payment bound to another session, currency mismatch, pending (not completed) intent → all `402`; and the happy path (settled, sufficient, matching) → `200` + order.
- Existing happy-path completion tests (ACP and UCP) updated to mint a real settled payment first.
- Full suite green (395 passed), `ruff check`, `ruff format --check`, and `pyright` (strict) all clean — verified on Linux/Python 3.12.

DCO: commit is signed off.
