### PR TITLE
[backend] Validate UCP add-to-checkout quantities

### DIFF
--- a/src/merchant/protocols/ucp/services/a2a_transport.py
+++ b/src/merchant/protocols/ucp/services/a2a_transport.py
@@ -290,9 +290,19 @@ async def handle_update(
 
     if action == "add_to_checkout":
         product_id = data.get("product_id") or data.get("id")
-        quantity = data.get("quantity", 1)
         if not product_id:
             raise ValueError("product_id required for add_to_checkout")
+        try:
+            line_item = UCPLineItemInput.model_validate(
+                {
+                    "item": {"id": product_id},
+                    "quantity": data.get("quantity", 1),
+                }
+            )
+        except ValidationError as exc:
+            raise ValueError(f"Invalid add_to_checkout payload: {exc}") from exc
+        product_id = line_item.item.id
+        quantity = line_item.quantity
 
         existing_items = [
             {"id": li.item.id, "quantity": li.item.quantity}
@@ -301,11 +311,11 @@ async def handle_update(
         found = False
         for item in existing_items:
             if item["id"] == product_id:
-                item["quantity"] = int(item["quantity"]) + int(quantity)
+                item["quantity"] = int(item["quantity"]) + quantity
                 found = True
                 break
         if not found:
-            existing_items.append({"id": str(product_id), "quantity": int(quantity)})
+            existing_items.append({"id": product_id, "quantity": quantity})
         update_kwargs: dict[str, Any] = {"items": existing_items}
 
     elif action == "remove_from_checkout":

--- a/tests/merchant/api/test_ucp_a2a.py
+++ b/tests/merchant/api/test_ucp_a2a.py
@@ -364,6 +364,33 @@ class TestCheckoutActions:
         checkout = body["result"]["parts"][0]["data"]["a2a.ucp.checkout"]
         assert len(checkout["line_items"]) == 2
 
+    @pytest.mark.parametrize("quantity", [None, [], {}])
+    @pytest.mark.usefixtures("mock_platform_profile")
+    def test_add_to_checkout_rejects_invalid_quantity(
+        self,
+        auth_client: TestClient,
+        a2a_headers: dict[str, str],
+        quantity: Any,
+    ) -> None:
+        create_req = _make_request(
+            "create_checkout",
+            {"line_items": [{"item": {"id": "prod_1"}, "quantity": 1}]},
+        )
+        create_resp = auth_client.post("/a2a", json=create_req, headers=a2a_headers)
+        ctx = create_resp.json()["result"]["contextId"]
+
+        add_req = _make_request(
+            "add_to_checkout",
+            {"product_id": "prod_1", "quantity": quantity},
+            context_id=ctx,
+        )
+        response = auth_client.post("/a2a", json=add_req, headers=a2a_headers)
+
+        assert response.status_code == 200
+        error = response.json()["error"]
+        assert error["code"] == -32602
+        assert "quantity" in error["message"]
+
     @pytest.mark.usefixtures("mock_platform_profile")
     def test_cancel_checkout(
         self, auth_client: TestClient, a2a_headers: dict[str, str]


### PR DESCRIPTION
## Summary

- validate direct UCP `add_to_checkout` items with the existing `UCPLineItemInput` model
- return JSON-RPC invalid params for malformed quantity types instead of an internal error
- add parameterized regression coverage for `null`, array, and object quantities

## Root cause

The direct `product_id` / `quantity` action path bypassed UCP line-item validation and called `int(quantity)`. Non-scalar JSON values raised `TypeError`, which escaped the executor's invalid-params handling and became JSON-RPC `-32603`.

## Test plan

- `uv run --with pytest --with pytest-asyncio pytest tests/merchant/api/test_ucp_a2a.py -q` — 29 passed
- `uv run --with pytest --with pytest-asyncio pytest tests/ -v --tb=short` — 392 passed
- `uv run --extra dev ruff check src/merchant/ src/payment/ src/apps_sdk/ tests/`
- `uv run --extra dev ruff format --check src/merchant/ src/payment/ src/apps_sdk/ tests/`
- `uv run --extra dev pyright src/merchant/ src/payment/ src/apps_sdk/`

Fixes #120
