### PR TITLE
fix: non-UTF-8 agent responses crash with UnicodeDecodeError

### DIFF
--- a/.github/scripts/check_nat_agents.py
+++ b/.github/scripts/check_nat_agents.py
@@ -87,7 +87,7 @@ def call_agent(
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
                 status = response.status
-                raw_response = response.read().decode()
+                raw_response = response.read().decode(errors="replace")
         except urllib.error.HTTPError as error:
             detail = error.read().decode(errors="replace")
             if attempt == 0 and is_retryable_empty_llm_response(error.code, detail):


### PR DESCRIPTION
This PR addresses the following issue in `.github/scripts/check_nat_agents.py`: non-UTF-8 agent responses crash with UnicodeDecodeError.

## Changes
- `.github/scripts/check_nat_agents.py`: non-UTF-8 agent responses crash with UnicodeDecodeError.

## Details
```diff
--- a/.github/scripts/check_nat_agents.py
+++ b/.github/scripts/check_nat_agents.py
@@ -1,5 +1,5 @@
-        try:
-            with urllib.request.urlopen(request, timeout=timeout) as response:
-                status = response.status
-                raw_response = response.read().decode()
-        except urllib.error.HTTPError as error:
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                status = response.status
+                raw_response = response.read().decode(errors="replace")
+        except urllib.error.HTTPError as error:
```

## Tests
- `tests/test_check_nat_agents.py`

```diff
--- /dev/null
+++ tests/test_check_nat_agents.py
@@ -0,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the NAT agent functional checker."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# The script lives under a dot-prefixed directory, so add it to sys.path.
+sys.path.insert(0, ".github/scripts")
+
+from check_nat_agents import call_agent
+
+
+class TestCallAgent(unittest.TestCase):
+    def test_non_utf8_response_is_handled(self):
+        """Invalid bytes in a 200 response must not raise UnicodeDecodeError."""
+        invalid_body = b'{"value": {"text": "bad \xff"}}'
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = invalid_body
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        with patch("urllib.request.urlopen", return_value=response):
+            result = call_agent("promotion", 8002, {"foo": "bar"}, timeout=5)
+
+        self.assertEqual(result, {"text": "bad \uFFFD"})
+
+
+if __name__ == "__main__":
+    unittest.main()
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).