### PR TITLE
fix: cached default post-purchase client ignores timeout changes

### DIFF
--- a/src/merchant/services/post_purchase.py
+++ b/src/merchant/services/post_purchase.py
@@ -256,7 +256,11 @@ def get_post_purchase_client(
         PostPurchaseAgentClient instance.
     """
     global _default_client
-    if _default_client is None or _default_client.base_url != base_url:
+    if (
+        _default_client is None
+        or _default_client.base_url != base_url
+        or _default_client.timeout != timeout
+    ):
         _default_client = PostPurchaseAgentClient(base_url, timeout)
     return _default_client
 


### PR DESCRIPTION
This PR addresses the following issue in `src/merchant/services/post_purchase.py`: cached default post-purchase client ignores timeout changes.

## Changes
- `src/merchant/services/post_purchase.py`: cached default post-purchase client ignores timeout changes.

## Details
```diff
--- a/src/merchant/services/post_purchase.py
+++ b/src/merchant/services/post_purchase.py
@@ -1,4 +1,8 @@
-    global _default_client
-    if _default_client is None or _default_client.base_url != base_url:
-        _default_client = PostPurchaseAgentClient(base_url, timeout)
-    return _default_client
+    global _default_client
+    if (
+        _default_client is None
+        or _default_client.base_url != base_url
+        or _default_client.timeout != timeout
+    ):
+        _default_client = PostPurchaseAgentClient(base_url, timeout)
+    return _default_client
```

## Tests
- `tests/merchant/services/test_post_purchase.py`

```diff
--- /dev/null
+++ b/tests/merchant/services/test_post_purchase.py
@@ -0,0 +1,26 @@
+"""Tests for the post-purchase service client caching."""
+
+from src.merchant.services import post_purchase as pp
+
+
+def test_client_recreated_when_timeout_changes():
+    pp._default_client = None
+    client1 = pp.get_post_purchase_client("http://agent:8003", timeout=15.0)
+    client2 = pp.get_post_purchase_client("http://agent:8003", timeout=30.0)
+    assert client1 is not client2
+    assert client1.timeout == 15.0
+    assert client2.timeout == 30.0
+
+
+def test_client_cached_when_config_matches():
+    pp._default_client = None
+    client1 = pp.get_post_purchase_client("http://agent:8003", timeout=15.0)
+    client2 = pp.get_post_purchase_client("http://agent:8003", timeout=15.0)
+    assert client1 is client2
+
+
+def test_client_recreated_when_base_url_changes():
+    pp._default_client = None
+    client1 = pp.get_post_purchase_client("http://agent:8003", timeout=15.0)
+    client2 = pp.get_post_purchase_client("http://agent:8004", timeout=15.0)
+    assert client1 is not client2
+    assert client2.base_url == "http://agent:8004"
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).