### PR TITLE
search: recalibrate relevance cutoffs for nemotron-3-embed-1b embedder

### DIFF
--- a/env.example
+++ b/env.example
@@ -87,10 +87,12 @@ RECOMMENDATION_AGENT_TIMEOUT=15.0
 
 # Search Agent Configuration
 SEARCH_AGENT_URL=http://localhost:8005
-# Maximum L2 distance allowed in Milvus range search
-SEARCH_DISTANCE_CUTOFF=1.4
-# Minimum similarity threshold for search results (0.0-1.0)
-SEARCH_MIN_SIMILARITY=0.35
+# Maximum L2 distance allowed for a search result. Calibrated for
+# nvidia/nemotron-3-embed-1b (genuine matches ~1.05-1.63). Re-derive if the
+# embedder changes.
+SEARCH_DISTANCE_CUTOFF=2.0
+# Minimum similarity, 0.0-1.0. Kept consistent with the cutoff: 1/(1+2.0)≈0.33.
+SEARCH_MIN_SIMILARITY=0.33
 
 # Phoenix Observability (for Recommendation Agent tracing)
 # Start Phoenix: docker compose up -d

--- a/src/apps_sdk/config.py
+++ b/src/apps_sdk/config.py
@@ -46,13 +46,12 @@ class AppsSdkSettings(BaseSettings):
     recommendation_agent_url: str = "http://localhost:8004"
     search_agent_url: str = "http://localhost:8005"
 
-    # Search tuning
-    # Minimum similarity score required to keep a search result.
-    # Similarity is computed from the vector distance returned by Milvus.
-    search_min_similarity: float = 0.35
-    # Maximum distance allowed from vector search results.
-    # Lower values are stricter; set to 0 to disable distance filtering.
-    search_distance_cutoff: float = 1.4
+    # Search tuning — calibrated for embedder nemotron-3-embed-1b.
+    # Genuine matches sit at distance ~1.05-1.63, so cutoff = 2.0.
+    # Minimum similarity, kept consistent: 1/(1+2.0) ≈ 0.33.
+    search_min_similarity: float = 0.33
+    # Max distance to keep a result (0 = off).
+    search_distance_cutoff: float = 2.0
 
     # API keys for calling merchant and PSP services
     merchant_api_key: str = "merchant-api-key-12345"


### PR DESCRIPTION
## TL;DR
This branch swapped the embedder but didn't re-calibrate the search filter thresholds. The old cutoffs are now **too strict** on the new model, so the filter drops valid matches → the widget returns 0 products → tests fail.

## What happened
- The branch swaps the embedder: `nv-embedqa-e5-v5` (1024-d) → `nemotron-3-embed-1b` (2048-d).
- Changing the embedder **changes the L2 distance scale** — the same match now lands at a different distance range.
- But `search_distance_cutoff=1.4` / `search_min_similarity=0.35` were calibrated for the **old** model and were never updated.
- Measured on the new model, genuine in-catalog matches sit at distance **~1.05–1.63**. The `1.4` cutoff falls right in the middle of that range, so it drops most real matches (e.g. a `"tee"` search returns 0 products), while `"classic tee"` happens to score lower and still gets through.

## Evidence (probed directly against the new embedder)
- In-catalog matches: distance min **1.045**, max **1.626**.
- Out-of-catalog queries (`laptop`, `banana`, `dress`, ...): the search agent returns **empty** already — the RAG agent filters irrelevant queries on its own, so the app doesn't need to gate them.

→ The cutoff only needs to sit **above** the max real-match distance. Set to **2.0** (~1.2× of 1.63, leaving headroom for run-to-run / cross-deploy drift). `min_similarity=0.33` = `1/(1+2.0)` to stay consistent.