### PR TITLE
Add deployment verification script and troubleshooting guide

### DIFF
--- a/deploy/TROUBLESHOOTING.md
+++ b/deploy/TROUBLESHOOTING.md
@@ -1,0 +1,52 @@
+# Troubleshooting
+
+Common issues when bringing up the stack for the first time, and how to
+resolve them. Run `./scripts/check_stack.sh` first — it will point you at
+the specific service that's failing.
+
+## Setup and environment
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `NVIDIA_API_KEY` errors, or 401/403 responses from agents/LLM calls | Key missing, unset, or still the placeholder from `env.example` | `cp env.example .env`, then set `NVIDIA_API_KEY=nvapi-...` with a key from [build.nvidia.com](https://build.nvidia.com/settings/api-keys) |
+| `docker network create acp-infra-network` fails with "already exists" | Harmless — a leftover network from a previous run | Ignore; existing docs already guard this with `\|\| true` |
+| Services can't reach each other in Docker mode | Containers on different Docker networks, or infra stack not started before the app stack | Start infra **and** app together: `docker compose -f docker-compose.infra.yml -f docker-compose.yml up --build -d` |
+| `install.sh` exits early / partial services | A prerequisite (Python 3.12+, `uv`, Node 20.9+, `pnpm`, Docker) is missing or too old | Re-check versions against [Prerequisites in local-development.md](local-development.md#prerequisites); `install.sh` checks these but stops on the first missing tool |
+
+## Ports and connectivity
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `curl: (7) Failed to connect` on a service port | Port already in use by another process, or that service didn't start | `lsof -i :<port>` (or `docker compose ps`) to see what's bound; check `logs/<service>.log` (local) or `docker compose logs -f <service>` (Docker) |
+| Health check passes for Merchant/PSP/Apps SDK but agents fail | In full Docker deployment, agent ports (8002–8005) are **internal-only** and not published to `localhost` | Check agent health from inside the merchant container (see `deploy/docker-deployment.md#agent-health-troubleshooting`), not via `curl localhost:800x` |
+| UI loads but shows no products / empty state | Backend services started before their data/vector store finished initializing | Give Milvus/MinIO a few extra seconds after `docker compose up`, then re-run `check_stack.sh` |
+
+## Local NIM / GPU deployment
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Agents time out or return errors only in local-NIM mode | `NIM_LLM_BASE_URL` / `NIM_EMBED_BASE_URL` point at containers that aren't running yet, or GPU memory is exhausted | Confirm you actually need local NIMs — the default deployment uses NVIDIA's hosted API and needs no GPU at all. If you do need local NIMs, follow `deploy/1_Deploy_Agentic_Commerce.ipynb` fully before switching these env vars |
+| "insufficient GPU memory" on NIM container startup | Hardware below the documented minimum (1× A100/H100 80GB per model, 2 GPUs total) | See Hardware Requirements in the root `README.md`; use the hosted-API path instead if you don't have this hardware |
+
+## Resetting
+
+If you're stuck and want a clean slate:
+
+```bash
+docker compose -f docker-compose.infra.yml -f docker-compose.yml down -v
+docker network rm acp-infra-network 2>/dev/null || true
+docker network create acp-infra-network
+docker compose -f docker-compose.infra.yml -f docker-compose.yml up --build -d
+```
+
+For local dev mode:
+
+```bash
+./stop.sh
+rm -rf logs/*.log
+./install.sh
+```
+
+Still stuck? Open a pull request describing the failure (issue creation is
+currently disabled on this repo) with the output of `./scripts/check_stack.sh`
+attached.

--- a/scripts/check_stack.sh
+++ b/scripts/check_stack.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# check_stack.sh — Verify a local Retail-Agentic-Commerce deployment.
+#
+# Detects whether the stack is running via Docker Compose (nginx-fronted)
+# or via local development (`install.sh`, services on host ports) and
+# runs the health checks documented in deploy/docker-deployment.md and
+# deploy/local-development.md, printing a single pass/fail summary.
+#
+# Usage:
+#   ./scripts/check_stack.sh
+#
+# Exit code is non-zero if any required check fails.
+
+set -uo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() { printf "  ${GREEN}PASS${NC}  %s\n" "$1"; PASS=$((PASS+1)); }
+fail() { printf "  ${RED}FAIL${NC}  %s\n" "$1"; FAIL=$((FAIL+1)); }
+warn() { printf "  ${YELLOW}WARN${NC}  %s\n" "$1"; WARN=$((WARN+1)); }
+section() { printf "\n\033[1m%s\033[0m\n" "$1"; }
+
+http_ok() {
+  # http_ok <url> — returns 0 if the URL responds with a 2xx/3xx status
+  local url="$1"
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 4 "$url" 2>/dev/null)
+  [[ "$code" =~ ^(2|3)[0-9]{2}$ ]]
+}
+
+# ---------------------------------------------------------------------------
+section "1. Prerequisites"
+# ---------------------------------------------------------------------------
+
+for bin in docker curl; do
+  if command -v "$bin" >/dev/null 2>&1; then
+    pass "$bin is installed"
+  else
+    fail "$bin is not installed or not on PATH"
+  fi
+done
+
+if docker compose version >/dev/null 2>&1; then
+  pass "Docker Compose v2 is available"
+else
+  fail "Docker Compose v2 not found (try: docker compose version)"
+fi
+
+for bin in uv node pnpm; do
+  if command -v "$bin" >/dev/null 2>&1; then
+    pass "$bin is installed"
+  else
+    warn "$bin not found on PATH (only required for local-dev mode)"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+section "2. Environment configuration"
+# ---------------------------------------------------------------------------
+
+if [[ -f .env ]]; then
+  pass ".env file found"
+  if grep -qE '^NVIDIA_API_KEY=nvapi-.+' .env; then
+    pass "NVIDIA_API_KEY looks set in .env"
+  else
+    fail "NVIDIA_API_KEY missing or still a placeholder in .env"
+  fi
+else
+  fail ".env file not found (copy env.example to .env and set NVIDIA_API_KEY)"
+fi
+
+if docker network inspect acp-infra-network >/dev/null 2>&1; then
+  pass "Docker network 'acp-infra-network' exists"
+else
+  warn "Docker network 'acp-infra-network' not found (create with: docker network create acp-infra-network)"
+fi
+
+# ---------------------------------------------------------------------------
+section "3. Detecting deployment mode"
+# ---------------------------------------------------------------------------
+
+MODE="unknown"
+if docker compose -f docker-compose.infra.yml -f docker-compose.yml ps --status running 2>/dev/null | grep -q .; then
+  MODE="docker"
+  pass "Docker Compose stack has running containers -> checking in DOCKER mode"
+elif http_ok "http://localhost:8000/docs"; then
+  MODE="local"
+  pass "Merchant API reachable on host port 8000 -> checking in LOCAL DEV mode"
+else
+  fail "Could not detect a running stack (neither Docker containers nor host-port services responded)"
+  echo -e "\nNo services detected. Start the stack first:"
+  echo "  Docker:    docker compose -f docker-compose.infra.yml -f docker-compose.yml up --build -d"
+  echo "  Local dev: ./install.sh"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+section "4. Core service health"
+# ---------------------------------------------------------------------------
+
+if [[ "$MODE" == "docker" ]]; then
+  http_ok "http://localhost/api/health"       && pass "Merchant API  (http://localhost/api/health)"       || fail "Merchant API  (http://localhost/api/health)"
+  http_ok "http://localhost/psp/health"       && pass "PSP service  (http://localhost/psp/health)"        || fail "PSP service  (http://localhost/psp/health)"
+  http_ok "http://localhost/apps-sdk/health"  && pass "Apps SDK MCP (http://localhost/apps-sdk/health)"   || fail "Apps SDK MCP (http://localhost/apps-sdk/health)"
+  http_ok "http://localhost/"                 && pass "Demo UI      (http://localhost/)"                 || fail "Demo UI      (http://localhost/)"
+else
+  http_ok "http://localhost:8000/docs"  && pass "Merchant API  (http://localhost:8000/docs)"  || fail "Merchant API  (http://localhost:8000/docs)"
+  http_ok "http://localhost:8001/docs"  && pass "PSP service  (http://localhost:8001/docs)"   || fail "PSP service  (http://localhost:8001/docs)"
+  http_ok "http://localhost:2091/docs"  && pass "Apps SDK MCP (http://localhost:2091/docs)"   || fail "Apps SDK MCP (http://localhost:2091/docs)"
+  http_ok "http://localhost:3000/"      && pass "Demo UI      (http://localhost:3000/)"       || fail "Demo UI      (http://localhost:3000/)"
+fi
+
+# ---------------------------------------------------------------------------
+section "5. NAT agent health"
+# ---------------------------------------------------------------------------
+
+if [[ "$MODE" == "docker" ]]; then
+  # Agents are internal-only in full Docker deployment; check from inside
+  # the merchant container, as documented in deploy/docker-deployment.md.
+  AGENT_OUT=$(docker compose -f docker-compose.infra.yml -f docker-compose.yml exec -T merchant \
+    python -c "
+import urllib.request as u
+for name, host in [('promotion','promotion-agent:8002'),('post-purchase','post-purchase-agent:8003'),('recommendation','recommendation-agent:8004'),('search','search-agent:8005')]:
+    try:
+        code = u.urlopen(f'http://{host}/health', timeout=5).status
+        print(f'{name}:{code}')
+    except Exception as e:
+        print(f'{name}:ERROR:{e}')
+" 2>/dev/null)
+
+  for agent in promotion post-purchase recommendation search; do
+    line=$(echo "$AGENT_OUT" | grep "^${agent}:")
+    if echo "$line" | grep -q ':200$'; then
+      pass "${agent} agent (internal, via merchant container)"
+    else
+      fail "${agent} agent (internal, via merchant container) -> ${line:-no response}"
+    fi
+  done
+else
+  http_ok "http://localhost:8002/health" && pass "promotion agent      (http://localhost:8002/health)" || fail "promotion agent      (http://localhost:8002/health)"
+  http_ok "http://localhost:8003/health" && pass "post-purchase agent  (http://localhost:8003/health)" || fail "post-purchase agent  (http://localhost:8003/health)"
+  http_ok "http://localhost:8004/health" && pass "recommendation agent (http://localhost:8004/health)" || fail "recommendation agent (http://localhost:8004/health)"
+  http_ok "http://localhost:8005/health" && pass "search agent         (http://localhost:8005/health)" || fail "search agent         (http://localhost:8005/health)"
+fi
+
+# ---------------------------------------------------------------------------
+section "6. Infrastructure (best-effort)"
+# ---------------------------------------------------------------------------
+
+http_ok "http://localhost:6006" && pass "Phoenix traces (http://localhost:6006)" || warn "Phoenix traces (http://localhost:6006) not reachable"
+http_ok "http://localhost:9001" && pass "MinIO console  (http://localhost:9001)" || warn "MinIO console  (http://localhost:9001) not reachable"
+
+# ---------------------------------------------------------------------------
+section "Summary"
+# ---------------------------------------------------------------------------
+
+echo -e "  ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}, ${YELLOW}${WARN} warnings${NC} (mode: ${MODE})\n"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "See deploy/TROUBLESHOOTING.md for fixes to common failures."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Add deployment verification script and troubleshooting guide

Adds scripts/check_stack.sh, which detects Docker vs. local-dev
mode and runs the health checks already documented in
deploy/docker-deployment.md and deploy/local-development.md,
printing a single pass/fail summary instead of requiring several
manual curl commands.

Adds deploy/TROUBLESHOOTING.md, a matrix of common first-run
failures (missing NVIDIA_API_KEY, port conflicts, stale Docker
network/volumes, internal-only agent ports in Docker mode,
local-NIM/GPU issues) and their fixes.

No protocol, agent, or payment logic touched.